### PR TITLE
improve: _search Elasticsearch requests can now handle larger specified number of fields

### DIFF
--- a/src/searchShim.js
+++ b/src/searchShim.js
@@ -43,18 +43,23 @@ export default async function searchShim(index, type, op, query, statsInfo) {
     delete options.type;
   }
 
+  /* Since _source might contain a large number of fields,
+   * insert into HTTP request body, NOT as a URL parameter.
+   * Otherwise, a 300-field search request can result in a ~11000-character
+   * URL, which might not be transmittable.
+   */
   if(query._source) {
     var source_object = false;
     if(query._source.exclude) {
-      options._sourceExclude = query._source.exclude;
+      options.body["_sourceExclude"] = query._source.exclude;
       source_object = true;
     }
     if(query._source.include) {
-      options._sourceInclude = query._source.include;
+      options.body["_sourceInclude"] = query._source.include;
       source_object = true;
     }
 
-    if(!source_object) { options._source = query._source; }
+    if(!source_object) { options.body["_source"] = query._source; }
   }
 
   if(query.sort) {


### PR DESCRIPTION
(Particularly affects logic using searchShim.js)

As it turns out, requesting 300 fields can result in a >10,000-character URL which, understandably, is met with ECONNRESET.
Moving the potentially large '_source' array from URL parameters to the HTTP request body shrinks the URL back down to transmittable length.

Previously, the way these ES requests were built leads to response errors to requests for around 80–110 fields.

Reported by @mgaynor1 