### PR TITLE
Fix: 500 error due to include/exclude keywords and regenerate mocks

### DIFF
--- a/__tests__/mock/search-0e39ef458483b9551407c45705f12588.json
+++ b/__tests__/mock/search-0e39ef458483b9551407c45705f12588.json
@@ -1,0 +1,4066 @@
+{
+  "timed_out": false,
+  "_shards": {
+    "total": 48,
+    "successful": 48,
+    "failed": 0
+  },
+  "hits": {
+    "total": 114017,
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a04854e2-2a22-433a-8e9a-8bbd14e8105b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lat": 41.76527,
+            "lon": -72.19861
+          },
+          "family": "sapindaceae",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.2463768115942029,
+          "stateprovince": "connecticut",
+          "institutioncode": "uconn",
+          "municipality": "mansfield",
+          "county": "tolland county",
+          "phylum": "tracheophyta",
+          "catalognumber": "conn00070249",
+          "startdayofyear": 50,
+          "taxonrank": "species",
+          "specificepithet": "saccharinum",
+          "continent": "north america",
+          "uuid": "a04854e2-2a22-433a-8e9a-8bbd14e8105b",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "jody foley",
+          "commonnames": [
+            "Silver Maple"
+          ],
+          "mediarecords": [
+            "b51105ab-33eb-457a-bafc-43a57d77643d"
+          ],
+          "datemodified": "2014-09-09T02:54:49.495000+00:00",
+          "datecollected": "1999-02-19T00:00:00+00:00",
+          "etag": "2d2c88d7840bafc1ab38d4d76878a5d6193a6bc1",
+          "recordnumber": "40",
+          "hasImage": true,
+          "kingdom": "plantae",
+          "highertaxon": "plantae; dicotyledonae; sapindales; aceraceae",
+          "commonname": "silver maple",
+          "taxonid": "3189837",
+          "scientificname": "acer saccharinum l.",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "flag_dwc_family_replaced": true,
+            "dwc:specificEpithet": "saccharinum",
+            "idigbio:dateModified": "2014-09-09T02:54:49.495000",
+            "dwc:countryCode": "US",
+            "dwc:county": "Tolland County",
+            "dwc:recordedBy": "Jody Foley",
+            "idigbio:uuid": "a04854e2-2a22-433a-8e9a-8bbd14e8105b",
+            "dwc:locationAccordingTo": "seconds added from gazetteer",
+            "dwc:order": "Sapindales",
+            "flag_gbif_reference_added": true,
+            "idigbio:isocountrycode": "usa",
+            "flag_dwc_scientificnameauthorship_added": true,
+            "dwc:locality": "Mansfield Center, Wolfrock section of Nipmuck Trail, Crane Hill Road.",
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00070249"
+            ],
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00070249",
+            "dwc:scientificName": "Acer saccharinum L.",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189837",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero argentato"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable argenté"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable blanc"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:source": "korean peninsula flora",
+                "dwc:vernacularname": "은단풍"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "plaine blanche"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "plaine de france"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "river maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "silber-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "silber-ahorn",
+                "coreid": "3189837",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "silberahorn"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "silverlönn"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "silver maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "silver maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "silver maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "silver maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "soft maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "soft maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "white maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "white maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "witte esdoorn"
+              }
+            ],
+            "flag_dwc_kingdom_replaced": true,
+            "flag_gbif_genericname_added": true,
+            "flag_dwc_parentnameusageid_added": true,
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dwc:stateProvince": "Connecticut",
+            "flag_dwc_taxonomicstatus_added": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:eventDate": "1999-02-19",
+            "dwc:country": "united states",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "gnu free documentation license",
+                "dcterms:title": "blattoberseite",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_saccharinum_002.jpg",
+                "coreid": "3189837",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/0/08/acer_saccharinum_002.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "de: silber-ahorn (acer saccharinum) im neuen botanischen garten marburg, hessen, deutschland en: silver maple (acer saccharinum) in the new botanical garden marburg, hesse, germany",
+                "dcterms:creator": "willow",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:silber-ahorn_(acer_saccharinum).jpg",
+                "coreid": "3189837",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/6/64/silber-ahorn_%28acer_saccharinum%29.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "gnu free documentation license",
+                "dcterms:title": "silber-ahorn (acer saccharinum)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_saccharinum_001.jpg",
+                "coreid": "3189837",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/d/db/acer_saccharinum_001.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "de: silber-ahorn (acer saccharinum) im neuen botanischen garten marburg, hessen, deutschland en: silver maple (acer saccharinum) in the new botanical garden marburg, hesse, germany",
+                "dcterms:creator": "willow",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "2d2c88d7840bafc1ab38d4d76878a5d6193a6bc1",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "41°45' 55\" N",
+            "gbif:reference": [
+              {
+                "coreid": "3189837",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "l. (1753) in: sp. pl. 1055"
+              }
+            ],
+            "dwc:kingdom": "plantae",
+            "dwc:decimalLatitude": "41.76527",
+            "dwc:occurrenceRemarks": "Tree 35 ft. tall by 19 in. wide, south of Wolf Rock, on east side of trail.",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "sapindaceae",
+            "flag_dwc_continent_added": true,
+            "flag_dwc_country_replaced": true,
+            "dwc:class": "magnoliopsida",
+            "dwc:municipality": "Mansfield",
+            "flag_dwc_taxonid_added": true,
+            "dwc:previousIdentifications": "Acer saccharinum L.",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "b51105ab-33eb-457a-bafc-43a57d77643d"
+              ]
+            },
+            "flag_dwc_class_added": true,
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:vernacularName": "Silver Maple",
+            "gbif:canonicalname": "acer saccharinum",
+            "dwc:scientificnameauthorship": "l.",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_phylum_added": true,
+            "gbif:genericname": "acer",
+            "dwc:georeferenceSources": "no date. Topozone. TopoZone.com © Maps a la carte, Inc. - All rights reserved.",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "UConn",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:reproductiveCondition": "winter / dormant condition",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Sapindales; Aceraceae",
+            "dwc:catalogNumber": "CONN00070249",
+            "dwc:taxonid": "3189837",
+            "dwc:taxonrank": "species",
+            "dwc:higherGeography": "USA; Connecticut; Tolland County; Mansfield",
+            "dwc:month": "2",
+            "dwc:decimalLongitude": "-72.19861",
+            "dwc:verbatimLongitude": "72°11' 55\" W",
+            "dwc:verbatimEventDate": "19-Feb-99",
+            "dwc:phylum": "tracheophyta",
+            "dwc:recordNumber": "40",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "flag_dwc_multimedia_added": true,
+            "flag_dwc_datasetid_replaced": true,
+            "dcterms:modified": "2012-04-05T00:00-0500",
+            "dwc:coordinateUncertaintyInMeters": "20000",
+            "dwc:day": "19",
+            "dwc:datasetID": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dwc:year": "1999"
+          },
+          "hasMedia": true,
+          "coordinateuncertainty": 20000,
+          "data": {
+            "dwc:specificEpithet": "saccharinum",
+            "dwc:countryCode": "US",
+            "dwc:county": "Tolland County",
+            "dwc:recordedBy": "Jody Foley",
+            "dwc:georeferenceSources": "no date. Topozone. TopoZone.com © Maps a la carte, Inc. - All rights reserved.",
+            "dwc:order": "Sapindales",
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00070249",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1999-02-19",
+            "dwc:country": "USA",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "41°45' 55\" N",
+            "dwc:kingdom": "Dicotyledonae",
+            "dwc:decimalLatitude": "41.76527",
+            "dwc:occurrenceRemarks": "Tree 35 ft. tall by 19 in. wide, south of Wolf Rock, on east side of trail.",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Aceraceae",
+            "dwc:coordinateUncertaintyInMeters": "20000",
+            "dwc:municipality": "Mansfield",
+            "dwc:previousIdentifications": "Acer saccharinum L.",
+            "dwc:vernacularName": "Silver Maple",
+            "dwc:locationAccordingTo": "seconds added from gazetteer",
+            "dwc:locality": "Mansfield Center, Wolfrock section of Nipmuck Trail, Crane Hill Road.",
+            "dwc:institutionCode": "UConn",
+            "dwc:reproductiveCondition": "winter / dormant condition",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Sapindales; Aceraceae",
+            "dwc:catalogNumber": "CONN00070249",
+            "dwc:higherGeography": "USA; Connecticut; Tolland County; Mansfield",
+            "dwc:month": "2",
+            "dwc:decimalLongitude": "-72.19861",
+            "dwc:verbatimLongitude": "72°11' 55\" W",
+            "dwc:verbatimEventDate": "19-Feb-99",
+            "dwc:recordNumber": "40",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "dcterms:modified": "2012-04-05T00:00-0500",
+            "dwc:scientificName": "Acer saccharinum L.",
+            "dwc:day": "19",
+            "dwc:datasetID": "62967",
+            "dwc:year": "1999"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:catalog:uconn:conn:conn00070249",
+          "country": "united states",
+          "locality": "mansfield center, wolfrock section of nipmuck trail, crane hill road.",
+          "collectioncode": "conn",
+          "canonicalname": "acer saccharinum",
+          "eventdate": "1999-02-19",
+          "flags": [
+            "geopoint_datum_missing",
+            "dwc_taxonrank_added",
+            "dwc_family_replaced",
+            "gbif_reference_added",
+            "dwc_scientificnameauthorship_added",
+            "dwc_kingdom_replaced",
+            "gbif_genericname_added",
+            "dwc_parentnameusageid_added",
+            "dwc_taxonomicstatus_added",
+            "dwc_continent_added",
+            "dwc_country_replaced",
+            "dwc_taxonid_added",
+            "dwc_class_added",
+            "idigbio_isocountrycode_added",
+            "gbif_canonicalname_added",
+            "dwc_phylum_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_multimedia_added",
+            "dwc_datasetid_replaced"
+          ],
+          "verbatimeventdate": "19-feb-99",
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00070249"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9a8fb7bd-de66-499f-a229-366f76d4c08d",
+        "_score": 1,
+        "_source": {
+          "family": "sapindaceae",
+          "recordset": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "dqs": 0.2318840579710145,
+          "stateprovince": "connecticut",
+          "municipality": "cheshire",
+          "county": "new haven county",
+          "phylum": "tracheophyta",
+          "catalognumber": "cbs.026036",
+          "startdayofyear": 269,
+          "taxonrank": "species",
+          "specificepithet": "spicatum",
+          "continent": "north america",
+          "uuid": "9a8fb7bd-de66-499f-a229-366f76d4c08d",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "arthur edmond blewitt",
+          "institutioncode": "yale peabody museum of natural history",
+          "mediarecords": [
+            "f0caf08c-a500-4327-9012-e839d62017ea"
+          ],
+          "datemodified": "2016-03-21T21:43:25.444854+00:00",
+          "datecollected": "1907-09-26T00:00:00+00:00",
+          "etag": "41d85c320a71e032c1fb6eddca3af7ca1daa97fe",
+          "recordnumber": "4290",
+          "hasImage": true,
+          "kingdom": "plantae",
+          "collectionid": "http://grbio.org/cool/x0m9-a3bs",
+          "taxonid": "3189848",
+          "scientificname": "acer spicatum",
+          "indexData": {
+            "dwc:startDayOfYear": "269",
+            "flag_dwc_taxonrank_added": true,
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "creative commons attribution share alike 3.0 unported",
+                "dcterms:title": "blätter",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_spicatum_jpg1l.jpg",
+                "coreid": "3189848",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/e/e3/acer_spicatum_jpg1l.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "français : feuilles d’érable à épis ou plaine bâtarde – acer spicatum année de plantation : 1998 position exacte : arboretum robert lenoir (s28 - 2968) - rendeux (belgique). english: hornbeam maple acer spicatum leaves planting date : 1998 precise location : arboretum robert lenoir (s28 - 2968) rendeux (belgium). walon: fouyes di bastaurde plane acer carpinifolium annéye do plantis' : 1998 place rècta : arboretum robert lenoir (s28 - 2968) - rindeu (bèljike).",
+                "dcterms:creator": "jean-pol grandmont",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "creative commons attribution share alike 3.0 unported",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_spicatum_jpg1l.jpg",
+                "coreid": "3189848",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/e/e3/acer_spicatum_jpg1l.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "français : feuilles d’érable à épis ou plaine bâtarde – acer spicatum année de plantation : 1998 position exacte : arboretum robert lenoir (s28 - 2968) - rendeux (belgique). english: hornbeam maple acer spicatum leaves planting date : 1998 precise location : arboretum robert lenoir (s28 - 2968) rendeux (belgium). walon: fouyes di bastaurde plane acer carpinifolium annéye do plantis' : 1998 place rècta : arboretum robert lenoir (s28 - 2968) - rindeu (bèljike).",
+                "dcterms:creator": "jean-pol grandmont",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "dwc:specificEpithet": "spicatum",
+            "idigbio:dateModified": "2016-03-21T21:43:25.444854",
+            "dwc:county": "New Haven County",
+            "dwc:recordedBy": "Arthur Edmond Blewitt",
+            "idigbio:uuid": "9a8fb7bd-de66-499f-a229-366f76d4c08d",
+            "flag_dwc_multimedia_added": true,
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110498",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "lam.",
+            "idigbio:recordIds": [
+              "urn:uuid:6c916224-a076-40d4-bb04-7670f7e7cfa2",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\urn:uuid:9fc10d21-7148-4590-b1bd-259bf1e2548b",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\110498"
+            ],
+            "dwc:occurrenceID": "urn:uuid:9fc10d21-7148-4590-b1bd-259bf1e2548b",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1907-09-26",
+            "flag_dwc_scientificnameauthorship_replaced": true,
+            "dwc:collectionID": "http://grbio.org/cool/x0m9-a3bs",
+            "dwc:country": "united states",
+            "idigbio:recordId": "urn:uuid:6c916224-a076-40d4-bb04-7670f7e7cfa2",
+            "idigbio:etag": "41d85c320a71e032c1fb6eddca3af7ca1daa97fe",
+            "dwc:collectionCode": "CBS",
+            "id": "110498",
+            "dwc:kingdom": "Plantae",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_phylum_replaced": true,
+            "dwc:municipality": "Cheshire",
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "usa",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "f0caf08c-a500-4327-9012-e839d62017ea"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "gbif:canonicalname": "acer spicatum",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "acer",
+            "dwc:locality": "The Notch",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "CBS.026036",
+            "dwc:taxonid": "3189848",
+            "dwc:taxonrank": "species",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189848",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "axlönn"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable à épis"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable bâtard"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "moose maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "moose maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "moose maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "mountain maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "mountain maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "mountain maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "mountain maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "plaine bâtarde"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "plaine bleue"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "vermont-ahorn"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "white maple"
+              }
+            ],
+            "dwc:month": "9",
+            "flag_dwc_class_replaced": true,
+            "gbif:reference": [
+              {
+                "coreid": "3189848",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "lam. (1786) in: encyc. 2: 381"
+              }
+            ],
+            "flag_dwc_continent_added": true,
+            "dwc:recordNumber": "4290",
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dcterms:modified": "2011-07-23 00:00:00",
+            "dwc:scientificName": "Acer spicatum",
+            "dwc:day": "26",
+            "dwc:year": "1907"
+          },
+          "hasMedia": true,
+          "data": {
+            "dwc:startDayOfYear": "269",
+            "dwc:specificEpithet": "spicatum",
+            "dwc:county": "New Haven County",
+            "dwc:recordedBy": "Arthur Edmond Blewitt",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110498",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:occurrenceID": "urn:uuid:9fc10d21-7148-4590-b1bd-259bf1e2548b",
+            "dwc:scientificNameAuthorship": "Lam.",
+            "id": "110498",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1907-09-26",
+            "dwc:collectionID": "http://grbio.org/cool/x0m9-a3bs",
+            "dwc:country": "USA",
+            "idigbio:recordId": "urn:uuid:6c916224-a076-40d4-bb04-7670f7e7cfa2",
+            "dwc:collectionCode": "CBS",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:kingdom": "Plantae",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:municipality": "Cheshire",
+            "dwc:phylum": "Charophyta",
+            "dwc:locality": "The Notch",
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "dwc:class": "Equisetopsida",
+            "dwc:catalogNumber": "CBS.026036",
+            "dwc:month": "9",
+            "dwc:recordNumber": "4290",
+            "dcterms:modified": "2011-07-23 00:00:00",
+            "dwc:scientificName": "Acer spicatum",
+            "dwc:day": "26",
+            "dwc:year": "1907"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:9fc10d21-7148-4590-b1bd-259bf1e2548b",
+          "country": "united states",
+          "locality": "the notch",
+          "collectioncode": "cbs",
+          "canonicalname": "acer spicatum",
+          "eventdate": "1907-09-26",
+          "flags": [
+            "dwc_taxonrank_added",
+            "dwc_multimedia_added",
+            "gbif_reference_added",
+            "gbif_canonicalname_added",
+            "dwc_country_replaced",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_scientificnameauthorship_replaced",
+            "dwc_parentnameusageid_added",
+            "dwc_phylum_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_class_replaced",
+            "dwc_continent_added"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "urn:uuid:6c916224-a076-40d4-bb04-7670f7e7cfa2",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\urn:uuid:9fc10d21-7148-4590-b1bd-259bf1e2548b",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\110498"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e81e2a6e-36f8-44e1-a80a-dbabcf7c1a41",
+        "_score": 1,
+        "_source": {
+          "family": "sapindaceae",
+          "recordset": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+          "dqs": 0.13043478260869565,
+          "stateprovince": "75 paris",
+          "phylum": "tracheophyta",
+          "catalognumber": "p00047742",
+          "taxonrank": "species",
+          "specificepithet": "pseudoplatanus",
+          "verbatimlocality": "terrasse du collège henry iv",
+          "datemodified": "2021-04-19T22:06:14.550973+00:00",
+          "uuid": "e81e2a6e-36f8-44e1-a80a-dbabcf7c1a41",
+          "countrycode": "fra",
+          "basisofrecord": "preservedspecimen",
+          "collector": "crevoisier, e.",
+          "institutioncode": "mnhn",
+          "mediarecords": [
+            "39c5f12d-5933-4def-97d6-3019f6bf54d4",
+            "42747526-ebb3-4959-ae2b-7607c00281b1"
+          ],
+          "continent": "europe",
+          "etag": "68040292ab2202cd6418889587e8cf35fa856f82",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "taxonid": "3189870",
+          "scientificname": "acer pseudoplatanus l.",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "idigbio:dateModified": "2021-04-19T22:06:14.550973",
+            "dwc:countryCode": "fr",
+            "dwc:kingdom": "plantae",
+            "dwc:recordedBy": "Crevoisier, E.",
+            "idigbio:uuid": "e81e2a6e-36f8-44e1-a80a-dbabcf7c1a41",
+            "flag_dwc_multimedia_added": true,
+            "gbif:canonicalname": "acer pseudoplatanus",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "L.",
+            "idigbio:recordIds": [
+              "616857b7-f952-44ef-9b6f-576dc1e65b51\\http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742"
+            ],
+            "dwc:occurrenceID": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+            "flag_dwc_specificepithet_added": true,
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "id": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+            "dwc:stateProvince": "75 Paris",
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dwc:country": "France",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "gnu free documentation license",
+                "dcterms:title": "a. pseudoplatanus in the bergpark wilhelmshöhe, kassel",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pseudoplatanus_005.jpg",
+                "coreid": "3189870",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/c/cd/acer_pseudoplatanus_005.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "deutsch: bergahorn (acer pseudoplatanus) im schlosspark wilhelmshöhe, kassel, hessen, deutschland english: sycamore maple (acer pseudoplatanus) in the schlosspark wilhelmshöhe, kassel, hesse, germany",
+                "dcterms:creator": "willow",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "public domain mark 1.0",
+                "dcterms:title": "berg-ahorn (acer pseudoplatanus)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pseudoplatanusaa.jpg",
+                "coreid": "3189870",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/f/fb/acer_pseudoplatanusaa.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "amsterdam, johannes allart, 1802 [-1808]",
+                "dcterms:creator": "user:mpf",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "68040292ab2202cd6418889587e8cf35fa856f82",
+            "dwc:collectionCode": "P",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "europe",
+            "dwc:family": "Sapindaceae",
+            "flag_dwc_continent_added": true,
+            "flag_dwc_parentnameusageid_added": true,
+            "dwc:specificepithet": "pseudoplatanus",
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "fra",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "39c5f12d-5933-4def-97d6-3019f6bf54d4",
+                "42747526-ebb3-4959-ae2b-7607c00281b1"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:order": "sapindales",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_phylum_added": true,
+            "gbif:genericname": "acer",
+            "dwc:locality": "Paris",
+            "dwc:fieldNotes": "Dicotylédone - acérinée - acer / fleurs en panicules racémiformes pendantes . feuilles blanches en dessous.",
+            "dwc:institutionCode": "MNHN",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "P00047742",
+            "dwc:taxonid": "3189870",
+            "gbif:Identifier": [
+              {
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+                "dcterms:identifier": "E6046C4ADB0D4075BF7D0D7AF082DCF0",
+                "dcterms:subject": "e-recolnat"
+              }
+            ],
+            "dwc:taxonrank": "species",
+            "dwc:Identification": [
+              {
+                "dwc:taxonID": "SONNERAT|13980",
+                "dwc:identificationVerificationStatus": "1",
+                "dwc:specificEpithet": "pseudoplatanus",
+                "dwc:scientificNameAuthorship": "L.",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+                "dwc:identificationID": "SONNERAT|66764",
+                "dwc:genus": "Acer",
+                "dwc:scientificName": "Acer pseudoplatanus L.",
+                "dwc:higherClassification": "Acer;Sapindaceae",
+                "dwc:family": "Sapindaceae"
+              },
+              {
+                "dwc:taxonID": "SONNERAT|13980",
+                "dwc:identificationRemarks": "operation de numerisation 2010-2012",
+                "dwc:specificEpithet": "pseudoplatanus",
+                "dwc:identificationID": "SONNERAT|7170284",
+                "dwc:identificationVerificationStatus": "0",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+                "dwc:scientificNameAuthorship": "L.",
+                "dwc:genus": "Acer",
+                "dwc:scientificName": "Acer pseudoplatanus L.",
+                "dwc:higherClassification": "Acer;Sapindaceae",
+                "dwc:family": "Sapindaceae"
+              }
+            ],
+            "dwc:month": "5",
+            "flag_dwc_order_added": true,
+            "dwc:verbatimLocality": "terrasse du collège Henry IV",
+            "gbif:reference": [
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "l. (1753) in: sp. pl.: 1054"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "dwc:phylum": "tracheophyta",
+            "dwc:preparations": "hb",
+            "flag_dwc_class_added": true,
+            "dcterms:modified": "2015-09-15 16:03:36.0",
+            "dwc:scientificName": "Acer pseudoplatanus L.",
+            "dwc:day": "20",
+            "flag_dwc_kingdom_added": true,
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189870",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero montano"
+              },
+              {
+                "dwc:countrycode": "dk",
+                "dwc:country": "denmark",
+                "dwc:vernacularname": "ahorn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "da"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "bergahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "bergahorn",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "berg-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "berg-ahorn",
+                "coreid": "3189870",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "bergahorn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "berg-ahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "érable sycomore",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable sycomore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "fr",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "érable sycomore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "false planetree"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "gewone esdoorn",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "gewone esdoorn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "great maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen lo&zcaron;noplatanovyj"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "platanlønn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nb"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "platanlønn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "scottish maple"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "sycamore",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sycamore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sycamore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "tysklönn"
+              },
+              {
+                "dwc:countrycode": "se",
+                "dwc:country": "sweden",
+                "dwc:vernacularname": "tysklönn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "vuorivaahtera",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "fi"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "vuorivaahtera",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              }
+            ]
+          },
+          "data": {
+            "dwc:countryCode": "fr",
+            "dwc:recordedBy": "Crevoisier, E.",
+            "dwc:scientificNameAuthorship": "L.",
+            "dwc:occurrenceID": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+            "id": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+            "dwc:stateProvince": "75 Paris",
+            "dwc:country": "France",
+            "dwc:collectionCode": "P",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:preparations": "hb",
+            "dwc:locality": "Paris",
+            "dwc:fieldNotes": "Dicotylédone - acérinée - acer / fleurs en panicules racémiformes pendantes . feuilles blanches en dessous.",
+            "dwc:institutionCode": "MNHN",
+            "dwc:catalogNumber": "P00047742",
+            "gbif:Identifier": [
+              {
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+                "dcterms:identifier": "E6046C4ADB0D4075BF7D0D7AF082DCF0",
+                "dcterms:subject": "e-recolnat"
+              }
+            ],
+            "dwc:Identification": [
+              {
+                "dwc:taxonID": "SONNERAT|13980",
+                "dwc:identificationVerificationStatus": "1",
+                "dwc:specificEpithet": "pseudoplatanus",
+                "dwc:scientificNameAuthorship": "L.",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+                "dwc:identificationID": "SONNERAT|66764",
+                "dwc:genus": "Acer",
+                "dwc:scientificName": "Acer pseudoplatanus L.",
+                "dwc:higherClassification": "Acer;Sapindaceae",
+                "dwc:family": "Sapindaceae"
+              },
+              {
+                "dwc:taxonID": "SONNERAT|13980",
+                "dwc:identificationRemarks": "operation de numerisation 2010-2012",
+                "dwc:specificEpithet": "pseudoplatanus",
+                "dwc:scientificNameAuthorship": "L.",
+                "dwc:identificationVerificationStatus": "0",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+                "dwc:identificationID": "SONNERAT|7170284",
+                "dwc:genus": "Acer",
+                "dwc:scientificName": "Acer pseudoplatanus L.",
+                "dwc:higherClassification": "Acer;Sapindaceae",
+                "dwc:family": "Sapindaceae"
+              }
+            ],
+            "dwc:month": "5",
+            "dwc:verbatimLocality": "terrasse du collège Henry IV",
+            "dwc:family": "Sapindaceae",
+            "dcterms:modified": "2015-09-15 16:03:36.0",
+            "dwc:scientificName": "Acer pseudoplatanus L.",
+            "dwc:day": "20"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+          "country": "france",
+          "locality": "paris",
+          "collectioncode": "p",
+          "canonicalname": "acer pseudoplatanus",
+          "flags": [
+            "dwc_taxonrank_added",
+            "dwc_multimedia_added",
+            "gbif_reference_added",
+            "dwc_specificepithet_added",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "gbif_vernacularname_added",
+            "dwc_continent_added",
+            "dwc_parentnameusageid_added",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "gbif_canonicalname_added",
+            "dwc_phylum_added",
+            "gbif_taxon_corrected",
+            "dwc_order_added",
+            "dwc_class_added",
+            "dwc_kingdom_added"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "616857b7-f952-44ef-9b6f-576dc1e65b51\\http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "de605db9-65a3-4fd0-950b-82a88c6d2828",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lat": 41.56444,
+            "lon": -72.79527
+          },
+          "family": "sapindaceae",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.2463768115942029,
+          "stateprovince": "connecticut",
+          "institutioncode": "uconn",
+          "municipality": "meriden",
+          "county": "new haven county",
+          "phylum": "tracheophyta",
+          "catalognumber": "conn00078635",
+          "startdayofyear": 138,
+          "taxonrank": "species",
+          "specificepithet": "pensylvanicum",
+          "continent": "north america",
+          "uuid": "de605db9-65a3-4fd0-950b-82a88c6d2828",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "g.s. torrey",
+          "commonnames": [
+            "Moosewood; Snake-Bark Maple; Striped Maple"
+          ],
+          "mediarecords": [
+            "8ad43dd0-da79-4834-bcb6-442793fbbaa2"
+          ],
+          "datemodified": "2014-09-09T02:58:24.436000+00:00",
+          "datecollected": "1958-05-18T00:00:00+00:00",
+          "etag": "f5d5c7a1a14fc111ff24aeecb39c9ec51e4d431d",
+          "recordnumber": "5528",
+          "hasImage": true,
+          "kingdom": "plantae",
+          "highertaxon": "plantae; dicotyledonae; sapindales; aceraceae",
+          "commonname": "moosewood; snake-bark maple; striped maple",
+          "taxonid": "3189836",
+          "scientificname": "acer pensylvanicum l.",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "flag_dwc_family_replaced": true,
+            "dwc:specificEpithet": "pensylvanicum",
+            "idigbio:dateModified": "2014-09-09T02:58:24.436000",
+            "dwc:countryCode": "US",
+            "dwc:county": "New Haven County",
+            "dwc:recordedBy": "G.S. Torrey",
+            "idigbio:uuid": "de605db9-65a3-4fd0-950b-82a88c6d2828",
+            "dwc:georeferenceSources": "no date. Topozone. TopoZone.com © Maps a la carte, Inc. - All rights reserved.",
+            "dwc:order": "Sapindales",
+            "flag_gbif_reference_added": true,
+            "idigbio:isocountrycode": "usa",
+            "flag_dwc_scientificnameauthorship_added": true,
+            "dwc:locality": "Trap ridge woods, Cathole Pass, Meriden, CT.",
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00078635"
+            ],
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00078635",
+            "dwc:scientificName": "Acer pensylvanicum L.",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189836",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "amerikansk strimlönn"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "bois barré"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "bois d'orignal"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable bois-barré"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable de pennsylvanie"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "goosefoot"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "moose maple"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "moosewood"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "moosewood"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "moosewood"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "pennsylvanischer ahorn"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "snakebark maple"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "snakebark maple"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "streifen-ahorn"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "streifenahorn"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "striped maple"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "striped maple"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "striped maple"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "striped maple"
+              }
+            ],
+            "flag_dwc_kingdom_replaced": true,
+            "flag_gbif_genericname_added": true,
+            "flag_dwc_parentnameusageid_added": true,
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dwc:stateProvince": "Connecticut",
+            "flag_dwc_taxonomicstatus_added": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:eventDate": "1958-05-18",
+            "dwc:country": "united states",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "public domain",
+                "dcterms:title": "striped maple leaves, cranberry wilderness, west virginia",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:moosewood_leaves.jpg",
+                "coreid": "3189836",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/7/72/moosewood_leaves.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "english: photo taken july, 2005, cranberry wilderness, west virginia",
+                "dcterms:creator": "original uploader was jaknouse at en.wikipedia",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "creative commons attribution share alike 3.0 migrated",
+                "dcterms:title": "streifen-ahorn (acer pensylvanicum)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pensylvanicum3.jpg",
+                "coreid": "3189836",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/7/74/acer_pensylvanicum3.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "f5d5c7a1a14fc111ff24aeecb39c9ec51e4d431d",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "41°32' 112\" N",
+            "gbif:reference": [
+              {
+                "coreid": "3189836",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "l. (1753) in: sp. pl. 1055"
+              }
+            ],
+            "dwc:kingdom": "plantae",
+            "dwc:decimalLatitude": "41.56444",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "sapindaceae",
+            "flag_dwc_continent_added": true,
+            "flag_dwc_country_replaced": true,
+            "dwc:class": "magnoliopsida",
+            "dwc:municipality": "Meriden",
+            "flag_dwc_taxonid_added": true,
+            "dwc:previousIdentifications": "Acer pensylvanicum L.",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "8ad43dd0-da79-4834-bcb6-442793fbbaa2"
+              ]
+            },
+            "flag_dwc_class_added": true,
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:vernacularName": "Moosewood; Snake-Bark Maple; Striped Maple",
+            "gbif:canonicalname": "acer pensylvanicum",
+            "dwc:scientificnameauthorship": "l.",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_phylum_added": true,
+            "gbif:genericname": "acer",
+            "dwc:locationAccordingTo": "seconds added from gazetteer",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "UConn",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:reproductiveCondition": "flowering",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Sapindales; Aceraceae",
+            "dwc:catalogNumber": "CONN00078635",
+            "dwc:taxonid": "3189836",
+            "dwc:taxonrank": "species",
+            "dwc:higherGeography": "USA; Connecticut; New Haven County; Meriden",
+            "dwc:month": "5",
+            "dwc:decimalLongitude": "-72.79527",
+            "dwc:verbatimLongitude": "72°47' 43\" W",
+            "dwc:verbatimEventDate": "18-May-58",
+            "dwc:phylum": "tracheophyta",
+            "dwc:recordNumber": "5528",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "flag_dwc_multimedia_added": true,
+            "flag_dwc_datasetid_replaced": true,
+            "dcterms:modified": "2009-05-21T00:00-0500",
+            "dwc:coordinateUncertaintyInMeters": "20000",
+            "dwc:day": "18",
+            "dwc:datasetID": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dwc:year": "1958"
+          },
+          "hasMedia": true,
+          "coordinateuncertainty": 20000,
+          "data": {
+            "dwc:specificEpithet": "pensylvanicum",
+            "dwc:countryCode": "US",
+            "dwc:county": "New Haven County",
+            "dwc:recordedBy": "G.S. Torrey",
+            "dwc:georeferenceSources": "no date. Topozone. TopoZone.com © Maps a la carte, Inc. - All rights reserved.",
+            "dwc:order": "Sapindales",
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00078635",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1958-05-18",
+            "dwc:country": "USA",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "41°32' 112\" N",
+            "dwc:kingdom": "Dicotyledonae",
+            "dwc:decimalLatitude": "41.56444",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Aceraceae",
+            "dwc:coordinateUncertaintyInMeters": "20000",
+            "dwc:municipality": "Meriden",
+            "dwc:previousIdentifications": "Acer pensylvanicum L.",
+            "dwc:vernacularName": "Moosewood; Snake-Bark Maple; Striped Maple",
+            "dwc:locationAccordingTo": "seconds added from gazetteer",
+            "dwc:locality": "Trap ridge woods, Cathole Pass, Meriden, CT.",
+            "dwc:institutionCode": "UConn",
+            "dwc:reproductiveCondition": "flowering",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Sapindales; Aceraceae",
+            "dwc:catalogNumber": "CONN00078635",
+            "dwc:higherGeography": "USA; Connecticut; New Haven County; Meriden",
+            "dwc:month": "5",
+            "dwc:decimalLongitude": "-72.79527",
+            "dwc:verbatimLongitude": "72°47' 43\" W",
+            "dwc:verbatimEventDate": "18-May-58",
+            "dwc:recordNumber": "5528",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "dcterms:modified": "2009-05-21T00:00-0500",
+            "dwc:scientificName": "Acer pensylvanicum L.",
+            "dwc:day": "18",
+            "dwc:datasetID": "68670",
+            "dwc:year": "1958"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:catalog:uconn:conn:conn00078635",
+          "country": "united states",
+          "locality": "trap ridge woods, cathole pass, meriden, ct.",
+          "collectioncode": "conn",
+          "canonicalname": "acer pensylvanicum",
+          "eventdate": "1958-05-18",
+          "flags": [
+            "geopoint_datum_missing",
+            "dwc_taxonrank_added",
+            "dwc_family_replaced",
+            "gbif_reference_added",
+            "dwc_scientificnameauthorship_added",
+            "dwc_kingdom_replaced",
+            "gbif_genericname_added",
+            "dwc_parentnameusageid_added",
+            "dwc_taxonomicstatus_added",
+            "dwc_continent_added",
+            "dwc_country_replaced",
+            "dwc_taxonid_added",
+            "dwc_class_added",
+            "idigbio_isocountrycode_added",
+            "gbif_canonicalname_added",
+            "dwc_phylum_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_multimedia_added",
+            "dwc_datasetid_replaced"
+          ],
+          "verbatimeventdate": "18-may-58",
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00078635"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "df6e800e-e2e1-4fcf-9940-fb738b70e7ed",
+        "_score": 1,
+        "_source": {
+          "family": "sapindaceae",
+          "recordset": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "stateprovince": "massachusetts",
+          "phylum": "tracheophyta",
+          "catalognumber": "yu.076227",
+          "startdayofyear": 134,
+          "taxonrank": "species",
+          "specificepithet": "saccharum",
+          "continent": "north america",
+          "uuid": "df6e800e-e2e1-4fcf-9940-fb738b70e7ed",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "c. w. swan",
+          "institutioncode": "yale peabody museum of natural history",
+          "mediarecords": [
+            "ef158cc6-2f94-48e5-92be-e608631f990f"
+          ],
+          "datemodified": "2016-01-27T21:25:22.884015+00:00",
+          "datecollected": "1883-05-14T00:00:00+00:00",
+          "etag": "40afcc8743e5335c309c3e97915d13e0c8ec57eb",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "collectionid": "urn:lsid:biocol.org:col:14791",
+          "taxonid": "3189859",
+          "scientificname": "acer saccharum",
+          "indexData": {
+            "dwc:startDayOfYear": "134",
+            "flag_dwc_taxonrank_added": true,
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:title": "zucker-ahorn (acer saccharum)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_saccharum_jpg01.jpg",
+                "coreid": "3189859",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/0/04/acer_saccharum_jpg01.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "français : meise (belgique), jardin national botanique de belgique - acer saccharum - Érable à sucre. english: meise (belgium), national garden of belgium - plant palace - acer saccharum - sugarmaple. nederlands: meise (belgië), nationale plantentuin van belgië - plantenpaleis – acer saccharum - suikeresdoorn. walon: meise (bèljike), djârdin national di bèljike - acer saccharum - aube a suke.",
+                "dcterms:creator": "jean-pol grandmont",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:title": "sugar maple in morton arboretum",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_saccharum.jpg",
+                "coreid": "3189859",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/2/26/acer_saccharum.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "sugar maple tree, acer saccharum. specimen at morton arboretum, lisle, illinois. accession 258-78-1.",
+                "dcterms:creator": "bruce marlin",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "dwc:specificEpithet": "saccharum",
+            "idigbio:dateModified": "2016-01-27T21:25:22.884015",
+            "dwc:kingdom": "Plantae",
+            "dwc:recordedBy": "C. W. Swan",
+            "idigbio:uuid": "df6e800e-e2e1-4fcf-9940-fb738b70e7ed",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807945",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "marshall",
+            "idigbio:recordIds": [
+              "urn:uuid:3e7dd858-0ee0-44c4-98c4-72a95a275b0c",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\urn:uuid:6504d3db-a170-45ef-af81-c01de16d6f85",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\807945"
+            ],
+            "dwc:occurrenceID": "urn:uuid:6504d3db-a170-45ef-af81-c01de16d6f85",
+            "flag_gbif_canonicalname_added": true,
+            "id": "807945",
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "symbiota:recordEnteredBy": "Bob Swerling",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+            "dwc:stateProvince": "Massachusetts",
+            "dwc:eventDate": "1883-05-14",
+            "flag_dwc_scientificnameauthorship_replaced": true,
+            "dwc:collectionID": "urn:lsid:biocol.org:col:14791",
+            "dwc:country": "united states",
+            "idigbio:recordId": "urn:uuid:3e7dd858-0ee0-44c4-98c4-72a95a275b0c",
+            "idigbio:etag": "40afcc8743e5335c309c3e97915d13e0c8ec57eb",
+            "dwc:collectionCode": "YU",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_phylum_replaced": true,
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "usa",
+            "gbif:reference": [
+              {
+                "coreid": "3189834",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "idigbio:siblings": {
+              "mediarecord": [
+                "ef158cc6-2f94-48e5-92be-e608631f990f"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "gbif:canonicalname": "acer saccharum",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "acer",
+            "flag_dwc_multimedia_added": true,
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "YU.076227",
+            "dwc:taxonid": "3189859",
+            "dwc:taxonrank": "species",
+            "dwc:Identification": [
+              {
+                "coreid": "807945",
+                "dwc:identificationRemarks": "0",
+                "idigbio:recordId": "urn:uuid:f82d1222-8a7b-4349-9b71-189e31334b13",
+                "dwc:scientificName": "Acer saccharum Marsh.",
+                "dwc:scientificNameAuthorship": "Marsh."
+              }
+            ],
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189859",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable à sucre"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable franc"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable franche"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "hard maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:source": "korean peninsula flora",
+                "dwc:vernacularname": "설탕단풍"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "rock maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "sugar maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "sugar maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "en",
+                "dcterms:source": "english wikipedia - species pages",
+                "dwc:vernacularname": "sugar maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sugar maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sugar maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "zucker-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "zucker-ahorn",
+                "coreid": "3189859",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              }
+            ],
+            "dwc:month": "5",
+            "flag_dwc_class_replaced": true,
+            "dwc:verbatimEventDate": "5-14-83",
+            "flag_dwc_continent_added": true,
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dcterms:modified": "2015-06-17 13:01:45",
+            "dwc:scientificName": "Acer saccharum",
+            "dwc:day": "14",
+            "dwc:year": "1883"
+          },
+          "data": {
+            "dwc:startDayOfYear": "134",
+            "dwc:specificEpithet": "saccharum",
+            "dwc:kingdom": "Plantae",
+            "dwc:recordedBy": "C. W. Swan",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807945",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:occurrenceID": "urn:uuid:6504d3db-a170-45ef-af81-c01de16d6f85",
+            "dwc:scientificNameAuthorship": "Marsh.",
+            "id": "807945",
+            "symbiota:recordEnteredBy": "Bob Swerling",
+            "dwc:stateProvince": "Massachusetts",
+            "dwc:eventDate": "1883-05-14",
+            "dwc:collectionID": "urn:lsid:biocol.org:col:14791",
+            "dwc:country": "United States of America",
+            "idigbio:recordId": "urn:uuid:3e7dd858-0ee0-44c4-98c4-72a95a275b0c",
+            "dwc:collectionCode": "YU",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:phylum": "Charophyta",
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "dwc:class": "Equisetopsida",
+            "dwc:catalogNumber": "YU.076227",
+            "dwc:Identification": [
+              {
+                "coreid": "807945",
+                "dwc:identificationRemarks": "0",
+                "idigbio:recordId": "urn:uuid:f82d1222-8a7b-4349-9b71-189e31334b13",
+                "dwc:scientificName": "Acer saccharum Marsh.",
+                "dwc:scientificNameAuthorship": "Marsh."
+              }
+            ],
+            "dwc:month": "5",
+            "dwc:verbatimEventDate": "5-14-83",
+            "dcterms:modified": "2015-06-17 13:01:45",
+            "dwc:scientificName": "Acer saccharum",
+            "dwc:day": "14",
+            "dwc:year": "1883"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:6504d3db-a170-45ef-af81-c01de16d6f85",
+          "country": "united states",
+          "dqs": 0.18840579710144928,
+          "collectioncode": "yu",
+          "canonicalname": "acer saccharum",
+          "eventdate": "1883-05-14",
+          "flags": [
+            "dwc_taxonrank_added",
+            "gbif_reference_added",
+            "gbif_canonicalname_added",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_scientificnameauthorship_replaced",
+            "dwc_parentnameusageid_added",
+            "dwc_phylum_replaced",
+            "dwc_country_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "dwc_multimedia_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_class_replaced",
+            "dwc_continent_added"
+          ],
+          "verbatimeventdate": "5-14-83",
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "urn:uuid:3e7dd858-0ee0-44c4-98c4-72a95a275b0c",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\urn:uuid:6504d3db-a170-45ef-af81-c01de16d6f85",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\807945"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e0690554-8c60-494b-85f0-d07553b9e59e",
+        "_score": 1,
+        "_source": {
+          "family": "sapindaceae",
+          "recordset": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "dqs": 0.2463768115942029,
+          "stateprovince": "connecticut",
+          "municipality": "wethersfield",
+          "county": "hartford county",
+          "phylum": "tracheophyta",
+          "catalognumber": "cbs.025833",
+          "startdayofyear": 145,
+          "taxonrank": "species",
+          "specificepithet": "pseudoplatanus",
+          "continent": "north america",
+          "uuid": "e0690554-8c60-494b-85f0-d07553b9e59e",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "hugh s. clark",
+          "institutioncode": "yale peabody museum of natural history",
+          "mediarecords": [
+            "c9f1880b-39de-4aaf-95d1-2365f9cae04d"
+          ],
+          "datemodified": "2016-03-21T21:43:25.444854+00:00",
+          "datecollected": "1901-05-25T00:00:00+00:00",
+          "etag": "10b5d8c49419e7524281708a71780f39e898f68c",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "collectionid": "http://grbio.org/cool/x0m9-a3bs",
+          "taxonid": "3189870",
+          "scientificname": "acer pseudoplatanus",
+          "indexData": {
+            "dwc:startDayOfYear": "145",
+            "flag_dwc_taxonrank_added": true,
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "gnu free documentation license",
+                "dcterms:title": "a. pseudoplatanus in the bergpark wilhelmshöhe, kassel",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pseudoplatanus_005.jpg",
+                "coreid": "3189870",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/c/cd/acer_pseudoplatanus_005.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "deutsch: bergahorn (acer pseudoplatanus) im schlosspark wilhelmshöhe, kassel, hessen, deutschland english: sycamore maple (acer pseudoplatanus) in the schlosspark wilhelmshöhe, kassel, hesse, germany",
+                "dcterms:creator": "willow",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "public domain mark 1.0",
+                "dcterms:title": "berg-ahorn (acer pseudoplatanus)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pseudoplatanusaa.jpg",
+                "coreid": "3189870",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/f/fb/acer_pseudoplatanusaa.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "amsterdam, johannes allart, 1802 [-1808]",
+                "dcterms:creator": "user:mpf",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "dwc:specificEpithet": "pseudoplatanus",
+            "idigbio:dateModified": "2016-03-21T21:43:25.444854",
+            "dwc:county": "Hartford County",
+            "dwc:recordedBy": "Hugh S. Clark",
+            "idigbio:uuid": "e0690554-8c60-494b-85f0-d07553b9e59e",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110335",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "L.",
+            "idigbio:recordIds": [
+              "urn:uuid:c183a846-5fe6-4901-8e6a-79147feead7d",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\urn:uuid:bc642633-9440-430f-a6e4-b2c21fc10237",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\110335"
+            ],
+            "dwc:occurrenceID": "urn:uuid:bc642633-9440-430f-a6e4-b2c21fc10237",
+            "flag_gbif_canonicalname_added": true,
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189870",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero montano"
+              },
+              {
+                "dwc:countrycode": "dk",
+                "dwc:country": "denmark",
+                "dwc:vernacularname": "ahorn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "da"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "bergahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "bergahorn",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "berg-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "berg-ahorn",
+                "coreid": "3189870",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "bergahorn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "berg-ahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "érable sycomore",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable sycomore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "fr",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "érable sycomore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "false planetree"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "gewone esdoorn",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "gewone esdoorn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "great maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen lo&zcaron;noplatanovyj"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "platanlønn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nb"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "platanlønn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "scottish maple"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "sycamore",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sycamore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sycamore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "tysklönn"
+              },
+              {
+                "dwc:countrycode": "se",
+                "dwc:country": "sweden",
+                "dwc:vernacularname": "tysklönn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "vuorivaahtera",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "fi"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "vuorivaahtera",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              }
+            ],
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1901-05-25",
+            "dwc:collectionID": "http://grbio.org/cool/x0m9-a3bs",
+            "dwc:country": "united states",
+            "idigbio:recordId": "urn:uuid:c183a846-5fe6-4901-8e6a-79147feead7d",
+            "idigbio:etag": "10b5d8c49419e7524281708a71780f39e898f68c",
+            "dwc:collectionCode": "CBS",
+            "id": "110335",
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "41.7012",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_phylum_replaced": true,
+            "dwc:municipality": "Wethersfield",
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "usa",
+            "dwc:geodeticDatum": "WGS84",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "c9f1880b-39de-4aaf-95d1-2365f9cae04d"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "gbif:canonicalname": "acer pseudoplatanus",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "acer",
+            "flag_dwc_multimedia_added": true,
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "CBS.025833",
+            "dwc:taxonid": "3189870",
+            "dwc:taxonrank": "species",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:decimalLongitude": "-72.6704",
+            "dwc:scientificName": "Acer pseudoplatanus",
+            "dwc:month": "5",
+            "flag_dwc_class_replaced": true,
+            "gbif:reference": [
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "l. (1753) in: sp. pl.: 1054"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "flag_dwc_continent_added": true,
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dcterms:modified": "2011-07-20 00:00:00",
+            "dwc:coordinateUncertaintyInMeters": "4657",
+            "dwc:day": "25",
+            "dwc:year": "1901"
+          },
+          "coordinateuncertainty": 4657,
+          "data": {
+            "dwc:startDayOfYear": "145",
+            "dwc:specificEpithet": "pseudoplatanus",
+            "dwc:county": "Hartford County",
+            "dwc:recordedBy": "Hugh S. Clark",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110335",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:occurrenceID": "urn:uuid:bc642633-9440-430f-a6e4-b2c21fc10237",
+            "dwc:scientificNameAuthorship": "L.",
+            "id": "110335",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1901-05-25",
+            "dwc:collectionID": "http://grbio.org/cool/x0m9-a3bs",
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "dwc:country": "USA",
+            "idigbio:recordId": "urn:uuid:c183a846-5fe6-4901-8e6a-79147feead7d",
+            "dwc:collectionCode": "CBS",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "41.7012",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:municipality": "Wethersfield",
+            "dwc:phylum": "Charophyta",
+            "dwc:geodeticDatum": "WGS84",
+            "dwc:class": "Equisetopsida",
+            "dwc:catalogNumber": "CBS.025833",
+            "dwc:month": "5",
+            "dwc:decimalLongitude": "-72.6704",
+            "dwc:coordinateUncertaintyInMeters": "4657",
+            "dcterms:modified": "2011-07-20 00:00:00",
+            "dwc:scientificName": "Acer pseudoplatanus",
+            "dwc:day": "25",
+            "dwc:year": "1901"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:bc642633-9440-430f-a6e4-b2c21fc10237",
+          "country": "united states",
+          "geopoint": {
+            "lat": 41.7012,
+            "lon": -72.6704
+          },
+          "collectioncode": "cbs",
+          "canonicalname": "acer pseudoplatanus",
+          "eventdate": "1901-05-25",
+          "flags": [
+            "dwc_taxonrank_added",
+            "gbif_reference_added",
+            "gbif_canonicalname_added",
+            "dwc_country_replaced",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_parentnameusageid_added",
+            "dwc_phylum_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "dwc_multimedia_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_class_replaced",
+            "dwc_continent_added"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "urn:uuid:c183a846-5fe6-4901-8e6a-79147feead7d",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\urn:uuid:bc642633-9440-430f-a6e4-b2c21fc10237",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\110335"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7a9fda29-5231-456c-8d59-bef531e36e8e",
+        "_score": 1,
+        "_source": {
+          "family": "sapindaceae",
+          "recordset": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "stateprovince": "massachusetts",
+          "municipality": "milton",
+          "county": "norfolk",
+          "phylum": "tracheophyta",
+          "catalognumber": "yu.076200",
+          "startdayofyear": 127,
+          "taxonrank": "species",
+          "specificepithet": "platanoides",
+          "continent": "north america",
+          "uuid": "7a9fda29-5231-456c-8d59-bef531e36e8e",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "c. w. swan",
+          "institutioncode": "yale peabody museum of natural history",
+          "mediarecords": [
+            "8e25027c-64e7-445c-aaae-e80df0c67e72"
+          ],
+          "datemodified": "2016-01-27T21:25:22.884015+00:00",
+          "datecollected": "1883-05-07T00:00:00+00:00",
+          "etag": "1f631099cc371c214fff4041e849dddb1c5078f7",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "collectionid": "urn:lsid:biocol.org:col:14791",
+          "taxonid": "3189846",
+          "scientificname": "acer platanoides",
+          "indexData": {
+            "dwc:startDayOfYear": "127",
+            "flag_dwc_taxonrank_added": true,
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:title": "spitz-ahorn (acer platanoides)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:spitz-ahorn_(acer_platanoides)_1.jpg",
+                "coreid": "3189846",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/0/0e/spitz-ahorn_%28acer_platanoides%29_1.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:title": "norway maple leaves",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:spitz-ahorn(mbo).jpg",
+                "coreid": "3189846",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/6/60/spitz-ahorn%28mbo%29.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "deutsch: spitz-ahorn (acer platanoides)",
+                "dcterms:creator": "martin bobka (= martin120)",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "dwc:specificEpithet": "platanoides",
+            "idigbio:dateModified": "2016-01-27T21:25:22.884015",
+            "dwc:county": "Norfolk",
+            "dwc:recordedBy": "C. W. Swan",
+            "idigbio:uuid": "7a9fda29-5231-456c-8d59-bef531e36e8e",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807914",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "L.",
+            "idigbio:recordIds": [
+              "urn:uuid:f0ea36c3-e71f-45ff-be75-61138b7ecec3",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\urn:uuid:c6b0657c-34e4-46bf-b303-844dd2828b22",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\807914"
+            ],
+            "dwc:occurrenceID": "urn:uuid:c6b0657c-34e4-46bf-b303-844dd2828b22",
+            "flag_gbif_canonicalname_added": true,
+            "id": "807914",
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "symbiota:recordEnteredBy": "Bob Swerling",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+            "dwc:stateProvince": "Massachusetts",
+            "dwc:eventDate": "1883-05-07",
+            "dwc:collectionID": "urn:lsid:biocol.org:col:14791",
+            "dwc:country": "united states",
+            "idigbio:recordId": "urn:uuid:f0ea36c3-e71f-45ff-be75-61138b7ecec3",
+            "idigbio:etag": "1f631099cc371c214fff4041e849dddb1c5078f7",
+            "dwc:collectionCode": "YU",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:kingdom": "Plantae",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_phylum_replaced": true,
+            "dwc:municipality": "Milton",
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "usa",
+            "gbif:reference": [
+              {
+                "coreid": "3189846",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "idigbio:siblings": {
+              "mediarecord": [
+                "8e25027c-64e7-445c-aaae-e80df0c67e72"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "gbif:canonicalname": "acer platanoides",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "acer",
+            "flag_dwc_multimedia_added": true,
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "YU.076200",
+            "dwc:taxonid": "3189846",
+            "dwc:taxonrank": "species",
+            "dwc:Identification": [
+              {
+                "coreid": "807914",
+                "dwc:identificationRemarks": "0",
+                "idigbio:recordId": "urn:uuid:b484aab4-0821-4654-926b-a986ee01b640",
+                "dwc:scientificName": "Acer platanoides L.",
+                "dwc:scientificNameAuthorship": "L."
+              }
+            ],
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189846",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero riccio"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable de norvège"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "érable plane",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable plane"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "érable plane"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "global invasive species database",
+                "dwc:vernacularname": "érable plane"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable platanoïde"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen ostrolistnyj"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen platanovidnyj"
+              },
+              {
+                "dwc:countrycode": "se",
+                "dwc:country": "sweden",
+                "dwc:vernacularname": "lönn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "(metsä)vaahtera",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "fi"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "(metsä)vaahtera",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "noorse esdoorn",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "noorse esdoorn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "norway maple",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "global invasive species database",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "skogslönn"
+              },
+              {
+                "dwc:countrycode": "dk",
+                "dwc:country": "denmark",
+                "dwc:vernacularname": "spids-løn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "da"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "spisslønn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nb"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "spisslønn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "spitzahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "spitzahorn",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "spitz-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "spitz-ahorn",
+                "coreid": "3189846",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "spitzahorn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "spitz-ahorn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "global invasive species database",
+                "dwc:vernacularname": "spitzahorn"
+              }
+            ],
+            "dwc:month": "5",
+            "flag_dwc_class_replaced": true,
+            "dwc:verbatimEventDate": "5-7-83 | 6-28-83",
+            "flag_dwc_continent_added": true,
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dcterms:modified": "2015-10-29 10:04:57",
+            "dwc:scientificName": "Acer platanoides",
+            "dwc:day": "7",
+            "dwc:year": "1883"
+          },
+          "data": {
+            "dwc:startDayOfYear": "127",
+            "dwc:specificEpithet": "platanoides",
+            "dwc:county": "Norfolk",
+            "dwc:recordedBy": "C. W. Swan",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807914",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:occurrenceID": "urn:uuid:c6b0657c-34e4-46bf-b303-844dd2828b22",
+            "dwc:scientificNameAuthorship": "L.",
+            "id": "807914",
+            "symbiota:recordEnteredBy": "Bob Swerling",
+            "dwc:stateProvince": "Massachusetts",
+            "dwc:eventDate": "1883-05-07",
+            "dwc:collectionID": "urn:lsid:biocol.org:col:14791",
+            "dwc:country": "United States of America",
+            "idigbio:recordId": "urn:uuid:f0ea36c3-e71f-45ff-be75-61138b7ecec3",
+            "dwc:collectionCode": "YU",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:kingdom": "Plantae",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:municipality": "Milton",
+            "dwc:phylum": "Charophyta",
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "dwc:class": "Equisetopsida",
+            "dwc:catalogNumber": "YU.076200",
+            "dwc:Identification": [
+              {
+                "coreid": "807914",
+                "dwc:identificationRemarks": "0",
+                "idigbio:recordId": "urn:uuid:b484aab4-0821-4654-926b-a986ee01b640",
+                "dwc:scientificName": "Acer platanoides L.",
+                "dwc:scientificNameAuthorship": "L."
+              }
+            ],
+            "dwc:month": "5",
+            "dwc:verbatimEventDate": "5-7-83 | 6-28-83",
+            "dcterms:modified": "2015-10-29 10:04:57",
+            "dwc:scientificName": "Acer platanoides",
+            "dwc:day": "7",
+            "dwc:year": "1883"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:c6b0657c-34e4-46bf-b303-844dd2828b22",
+          "country": "united states",
+          "dqs": 0.2318840579710145,
+          "collectioncode": "yu",
+          "canonicalname": "acer platanoides",
+          "eventdate": "1883-05-07",
+          "flags": [
+            "dwc_taxonrank_added",
+            "gbif_reference_added",
+            "gbif_canonicalname_added",
+            "dwc_country_replaced",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_parentnameusageid_added",
+            "dwc_phylum_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "dwc_multimedia_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_class_replaced",
+            "dwc_continent_added"
+          ],
+          "verbatimeventdate": "5-7-83 | 6-28-83",
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "urn:uuid:f0ea36c3-e71f-45ff-be75-61138b7ecec3",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\urn:uuid:c6b0657c-34e4-46bf-b303-844dd2828b22",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\807914"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "af9e5711-eaeb-4d07-8dd7-f7df02829377",
+        "_score": 1,
+        "_source": {
+          "family": "sapindaceae",
+          "recordset": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "dqs": 0.2463768115942029,
+          "stateprovince": "connecticut",
+          "municipality": "bridgeport",
+          "county": "fairfield county",
+          "phylum": "tracheophyta",
+          "catalognumber": "cbs.025830",
+          "startdayofyear": 151,
+          "taxonrank": "species",
+          "specificepithet": "pseudoplatanus",
+          "continent": "north america",
+          "uuid": "af9e5711-eaeb-4d07-8dd7-f7df02829377",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "hugh s. clark",
+          "institutioncode": "yale peabody museum of natural history",
+          "mediarecords": [
+            "cd8c9545-8adf-4de8-afe9-ffd8c9c265e2"
+          ],
+          "datemodified": "2016-03-21T21:43:25.444854+00:00",
+          "datecollected": "1910-05-31T00:00:00+00:00",
+          "etag": "e3c07a0a409c5f3f2582ce46d399e94a3b9581df",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "collectionid": "http://grbio.org/cool/x0m9-a3bs",
+          "taxonid": "3189870",
+          "scientificname": "acer pseudoplatanus",
+          "indexData": {
+            "dwc:startDayOfYear": "151",
+            "flag_dwc_taxonrank_added": true,
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "gnu free documentation license",
+                "dcterms:title": "a. pseudoplatanus in the bergpark wilhelmshöhe, kassel",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pseudoplatanus_005.jpg",
+                "coreid": "3189870",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/c/cd/acer_pseudoplatanus_005.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "deutsch: bergahorn (acer pseudoplatanus) im schlosspark wilhelmshöhe, kassel, hessen, deutschland english: sycamore maple (acer pseudoplatanus) in the schlosspark wilhelmshöhe, kassel, hesse, germany",
+                "dcterms:creator": "willow",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "public domain mark 1.0",
+                "dcterms:title": "berg-ahorn (acer pseudoplatanus)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pseudoplatanusaa.jpg",
+                "coreid": "3189870",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/f/fb/acer_pseudoplatanusaa.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "amsterdam, johannes allart, 1802 [-1808]",
+                "dcterms:creator": "user:mpf",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "dwc:specificEpithet": "pseudoplatanus",
+            "idigbio:dateModified": "2016-03-21T21:43:25.444854",
+            "dwc:county": "Fairfield County",
+            "dwc:recordedBy": "Hugh S. Clark",
+            "idigbio:uuid": "af9e5711-eaeb-4d07-8dd7-f7df02829377",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110334",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "L.",
+            "idigbio:recordIds": [
+              "urn:uuid:3f201839-a9b2-4869-a659-39b8509e2c8b",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\urn:uuid:c64bcab2-95df-47ed-b910-e78a8a5a9f85",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\110334"
+            ],
+            "dwc:occurrenceID": "urn:uuid:c64bcab2-95df-47ed-b910-e78a8a5a9f85",
+            "flag_gbif_canonicalname_added": true,
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189870",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero montano"
+              },
+              {
+                "dwc:countrycode": "dk",
+                "dwc:country": "denmark",
+                "dwc:vernacularname": "ahorn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "da"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "bergahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "bergahorn",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "berg-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "berg-ahorn",
+                "coreid": "3189870",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "bergahorn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "berg-ahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "érable sycomore",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable sycomore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "fr",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "érable sycomore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "false planetree"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "gewone esdoorn",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "gewone esdoorn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "great maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen lo&zcaron;noplatanovyj"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "platanlønn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nb"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "platanlønn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "scottish maple"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "sycamore",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sycamore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sycamore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "tysklönn"
+              },
+              {
+                "dwc:countrycode": "se",
+                "dwc:country": "sweden",
+                "dwc:vernacularname": "tysklönn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "vuorivaahtera",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "fi"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "vuorivaahtera",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              }
+            ],
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1910-05-31",
+            "dwc:collectionID": "http://grbio.org/cool/x0m9-a3bs",
+            "dwc:country": "united states",
+            "idigbio:recordId": "urn:uuid:3f201839-a9b2-4869-a659-39b8509e2c8b",
+            "idigbio:etag": "e3c07a0a409c5f3f2582ce46d399e94a3b9581df",
+            "dwc:collectionCode": "CBS",
+            "id": "110334",
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "41.1932",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_phylum_replaced": true,
+            "dwc:municipality": "Bridgeport",
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "usa",
+            "dwc:geodeticDatum": "WGS84",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "cd8c9545-8adf-4de8-afe9-ffd8c9c265e2"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "gbif:canonicalname": "acer pseudoplatanus",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "acer",
+            "flag_dwc_multimedia_added": true,
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "CBS.025830",
+            "dwc:taxonid": "3189870",
+            "dwc:taxonrank": "species",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:decimalLongitude": "-73.196",
+            "dwc:scientificName": "Acer pseudoplatanus",
+            "dwc:month": "5",
+            "flag_dwc_class_replaced": true,
+            "gbif:reference": [
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "l. (1753) in: sp. pl.: 1054"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "flag_dwc_continent_added": true,
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dcterms:modified": "2011-07-21 00:00:00",
+            "dwc:coordinateUncertaintyInMeters": "6473",
+            "dwc:day": "31",
+            "dwc:year": "1910"
+          },
+          "coordinateuncertainty": 6473,
+          "data": {
+            "dwc:startDayOfYear": "151",
+            "dwc:specificEpithet": "pseudoplatanus",
+            "dwc:county": "Fairfield County",
+            "dwc:recordedBy": "Hugh S. Clark",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110334",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:occurrenceID": "urn:uuid:c64bcab2-95df-47ed-b910-e78a8a5a9f85",
+            "dwc:scientificNameAuthorship": "L.",
+            "id": "110334",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1910-05-31",
+            "dwc:collectionID": "http://grbio.org/cool/x0m9-a3bs",
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "dwc:country": "USA",
+            "idigbio:recordId": "urn:uuid:3f201839-a9b2-4869-a659-39b8509e2c8b",
+            "dwc:collectionCode": "CBS",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "41.1932",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:municipality": "Bridgeport",
+            "dwc:phylum": "Charophyta",
+            "dwc:geodeticDatum": "WGS84",
+            "dwc:class": "Equisetopsida",
+            "dwc:catalogNumber": "CBS.025830",
+            "dwc:month": "5",
+            "dwc:decimalLongitude": "-73.196",
+            "dwc:coordinateUncertaintyInMeters": "6473",
+            "dcterms:modified": "2011-07-21 00:00:00",
+            "dwc:scientificName": "Acer pseudoplatanus",
+            "dwc:day": "31",
+            "dwc:year": "1910"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:c64bcab2-95df-47ed-b910-e78a8a5a9f85",
+          "country": "united states",
+          "geopoint": {
+            "lat": 41.1932,
+            "lon": -73.196
+          },
+          "collectioncode": "cbs",
+          "canonicalname": "acer pseudoplatanus",
+          "eventdate": "1910-05-31",
+          "flags": [
+            "dwc_taxonrank_added",
+            "gbif_reference_added",
+            "gbif_canonicalname_added",
+            "dwc_country_replaced",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_parentnameusageid_added",
+            "dwc_phylum_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "dwc_multimedia_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_class_replaced",
+            "dwc_continent_added"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "urn:uuid:3f201839-a9b2-4869-a659-39b8509e2c8b",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\urn:uuid:c64bcab2-95df-47ed-b910-e78a8a5a9f85",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\110334"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b35dc163-b67a-4b9d-9185-75460b7936f0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lat": 41.905,
+            "lon": -72.7025
+          },
+          "family": "sapindaceae",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.2463768115942029,
+          "stateprovince": "connecticut",
+          "institutioncode": "uconn",
+          "municipality": "windsor",
+          "county": "hartford county",
+          "phylum": "tracheophyta",
+          "catalognumber": "conn00032766",
+          "startdayofyear": 119,
+          "taxonrank": "species",
+          "specificepithet": "platanoides",
+          "continent": "north america",
+          "uuid": "b35dc163-b67a-4b9d-9185-75460b7936f0",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "tad m. zebryk",
+          "commonnames": [
+            "Norway Maple"
+          ],
+          "mediarecords": [
+            "bb3b39b6-adbe-459f-88ea-f793e6b45ccf"
+          ],
+          "datemodified": "2014-09-09T01:35:10.885000+00:00",
+          "datecollected": "1998-04-29T00:00:00+00:00",
+          "etag": "24e8f6129d6b7fd632afc0294b74700345b7123c",
+          "recordnumber": "4388",
+          "hasImage": true,
+          "kingdom": "plantae",
+          "highertaxon": "plantae; dicotyledonae; sapindales; aceraceae",
+          "commonname": "norway maple",
+          "taxonid": "3189846",
+          "scientificname": "acer platanoides l.",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "flag_dwc_family_replaced": true,
+            "dwc:specificEpithet": "platanoides",
+            "idigbio:dateModified": "2014-09-09T01:35:10.885000",
+            "dwc:countryCode": "US",
+            "dwc:county": "Hartford County",
+            "dwc:recordedBy": "Tad M. Zebryk",
+            "idigbio:uuid": "b35dc163-b67a-4b9d-9185-75460b7936f0",
+            "flag_dwc_multimedia_added": true,
+            "dwc:order": "Sapindales",
+            "dwc:habitat": "Edge Of Woods",
+            "flag_gbif_reference_added": true,
+            "idigbio:isocountrycode": "usa",
+            "flag_dwc_scientificnameauthorship_added": true,
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00032766"
+            ],
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00032766",
+            "dwc:scientificName": "Acer platanoides L.",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189846",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero riccio"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable de norvège"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "érable plane",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable plane"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "érable plane"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "global invasive species database",
+                "dwc:vernacularname": "érable plane"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable platanoïde"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen ostrolistnyj"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen platanovidnyj"
+              },
+              {
+                "dwc:countrycode": "se",
+                "dwc:country": "sweden",
+                "dwc:vernacularname": "lönn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "(metsä)vaahtera",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "fi"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "(metsä)vaahtera",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "noorse esdoorn",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "noorse esdoorn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "norway maple",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "global invasive species database",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "skogslönn"
+              },
+              {
+                "dwc:countrycode": "dk",
+                "dwc:country": "denmark",
+                "dwc:vernacularname": "spids-løn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "da"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "spisslønn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nb"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "spisslønn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "spitzahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "spitzahorn",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "spitz-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "spitz-ahorn",
+                "coreid": "3189846",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "spitzahorn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "spitz-ahorn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "global invasive species database",
+                "dwc:vernacularname": "spitzahorn"
+              }
+            ],
+            "flag_dwc_kingdom_replaced": true,
+            "flag_gbif_genericname_added": true,
+            "flag_dwc_parentnameusageid_added": true,
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dwc:stateProvince": "Connecticut",
+            "flag_dwc_taxonomicstatus_added": true,
+            "dwc:eventDate": "1998-04-29",
+            "dwc:country": "united states",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:title": "spitz-ahorn (acer platanoides)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:spitz-ahorn_(acer_platanoides)_1.jpg",
+                "coreid": "3189846",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/0/0e/spitz-ahorn_%28acer_platanoides%29_1.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:title": "norway maple leaves",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:spitz-ahorn(mbo).jpg",
+                "coreid": "3189846",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/6/60/spitz-ahorn%28mbo%29.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "deutsch: spitz-ahorn (acer platanoides)",
+                "dcterms:creator": "martin bobka (= martin120)",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "24e8f6129d6b7fd632afc0294b74700345b7123c",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "41°54' 18\" N",
+            "gbif:reference": [
+              {
+                "coreid": "3189846",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "dwc:kingdom": "plantae",
+            "dwc:decimalLatitude": "41.905",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "sapindaceae",
+            "flag_dwc_continent_added": true,
+            "flag_dwc_country_replaced": true,
+            "dwc:class": "magnoliopsida",
+            "dwc:municipality": "Windsor",
+            "flag_dwc_taxonid_added": true,
+            "dwc:previousIdentifications": "Acer platanoides L.",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "bb3b39b6-adbe-459f-88ea-f793e6b45ccf"
+              ]
+            },
+            "flag_dwc_class_added": true,
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:vernacularName": "Norway Maple",
+            "gbif:canonicalname": "acer platanoides",
+            "dwc:scientificnameauthorship": "l.",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_phylum_added": true,
+            "gbif:genericname": "acer",
+            "dwc:locality": "Northwest Park, edge of oak woods near Town Tree Nursery",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "UConn",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Sapindales; Aceraceae",
+            "dwc:catalogNumber": "CONN00032766",
+            "dwc:taxonid": "3189846",
+            "dwc:taxonrank": "species",
+            "dwc:higherGeography": "USA; Connecticut; Hartford County; Windsor",
+            "dwc:month": "4",
+            "dwc:decimalLongitude": "-72.7025",
+            "dwc:verbatimLongitude": "72°42' 09\" W",
+            "dwc:verbatimEventDate": "29-Apr-98",
+            "dwc:phylum": "tracheophyta",
+            "dwc:recordNumber": "4388",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "flag_dwc_datasetid_replaced": true,
+            "dcterms:modified": "2004-03-23T00:00-0500",
+            "dwc:coordinateUncertaintyInMeters": "5000",
+            "dwc:day": "29",
+            "dwc:datasetID": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dwc:year": "1998"
+          },
+          "hasMedia": true,
+          "coordinateuncertainty": 5000,
+          "data": {
+            "dwc:specificEpithet": "platanoides",
+            "dwc:countryCode": "US",
+            "dwc:county": "Hartford County",
+            "dwc:recordedBy": "Tad M. Zebryk",
+            "dwc:order": "Sapindales",
+            "dwc:habitat": "Edge Of Woods",
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00032766",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1998-04-29",
+            "dwc:country": "USA",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "41°54' 18\" N",
+            "dwc:kingdom": "Dicotyledonae",
+            "dwc:decimalLatitude": "41.905",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Aceraceae",
+            "dwc:coordinateUncertaintyInMeters": "5000",
+            "dwc:municipality": "Windsor",
+            "dwc:previousIdentifications": "Acer platanoides L.",
+            "dwc:vernacularName": "Norway Maple",
+            "dwc:locality": "Northwest Park, edge of oak woods near Town Tree Nursery",
+            "dwc:institutionCode": "UConn",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Sapindales; Aceraceae",
+            "dwc:catalogNumber": "CONN00032766",
+            "dwc:higherGeography": "USA; Connecticut; Hartford County; Windsor",
+            "dwc:month": "4",
+            "dwc:decimalLongitude": "-72.7025",
+            "dwc:verbatimLongitude": "72°42' 09\" W",
+            "dwc:verbatimEventDate": "29-Apr-98",
+            "dwc:recordNumber": "4388",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "dcterms:modified": "2004-03-23T00:00-0500",
+            "dwc:scientificName": "Acer platanoides L.",
+            "dwc:day": "29",
+            "dwc:datasetID": "11919",
+            "dwc:year": "1998"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:catalog:uconn:conn:conn00032766",
+          "country": "united states",
+          "locality": "northwest park, edge of oak woods near town tree nursery",
+          "collectioncode": "conn",
+          "canonicalname": "acer platanoides",
+          "eventdate": "1998-04-29",
+          "flags": [
+            "geopoint_datum_missing",
+            "dwc_taxonrank_added",
+            "dwc_family_replaced",
+            "dwc_multimedia_added",
+            "gbif_reference_added",
+            "dwc_scientificnameauthorship_added",
+            "dwc_kingdom_replaced",
+            "gbif_genericname_added",
+            "dwc_parentnameusageid_added",
+            "dwc_taxonomicstatus_added",
+            "dwc_continent_added",
+            "dwc_country_replaced",
+            "dwc_taxonid_added",
+            "dwc_class_added",
+            "idigbio_isocountrycode_added",
+            "gbif_canonicalname_added",
+            "dwc_phylum_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_datasetid_replaced"
+          ],
+          "verbatimeventdate": "29-apr-98",
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00032766"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bc9fd701-bb9d-490c-a5bf-da5177b49ae0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lat": 38.53262,
+            "lon": -95.96472
+          },
+          "family": "sapindaceae",
+          "recordset": "5baa1d0c-cfc0-4c89-8e3e-7a49359b0caa",
+          "dqs": 0.21739130434782608,
+          "stateprovince": "kansas",
+          "county": "lyon",
+          "phylum": "tracheophyta",
+          "catalognumber": "17301",
+          "startdayofyear": 112,
+          "taxonrank": "species",
+          "specificepithet": "negundo",
+          "continent": "north america",
+          "uuid": "bc9fd701-bb9d-490c-a5bf-da5177b49ae0",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "melander, m.",
+          "institutioncode": "kstc",
+          "datemodified": "2017-01-08T07:47:53.556726+00:00",
+          "datecollected": "1975-04-22T00:00:00+00:00",
+          "etag": "9a5a189ccbdbd748d5da7d3fbea1f2bee1137565",
+          "recordnumber": "27",
+          "hasImage": false,
+          "kingdom": "plantae",
+          "taxonid": "3189866",
+          "scientificname": "acer negundo",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "dwc:specificEpithet": "negundo",
+            "idigbio:dateModified": "2017-01-08T07:47:53.556726",
+            "dwc:county": "Lyon",
+            "dwc:recordedBy": "Melander, M.",
+            "idigbio:uuid": "bc9fd701-bb9d-490c-a5bf-da5177b49ae0",
+            "dwc:georeferencedDate": "2015-02-12",
+            "gbif:canonicalname": "acer negundo",
+            "flag_gbif_reference_added": true,
+            "flag_dwc_scientificnameauthorship_added": true,
+            "dwc:locality": "Reading Woods",
+            "idigbio:recordIds": [
+              "5baa1d0c-cfc0-4c89-8e3e-7a49359b0caa\\4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2"
+            ],
+            "dwc:occurrenceID": "4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2",
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "id": "4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "5baa1d0c-cfc0-4c89-8e3e-7a49359b0caa",
+            "dwc:stateProvince": "Kansas",
+            "dwc:eventDate": "1975-04-22",
+            "dwc:country": "united states",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "public domain from united states department of agriculture",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acnegundo.jpg",
+                "coreid": "3189866",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/1/18/acnegundo.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "creative commons attribution share alike 3.0 migrated",
+                "dcterms:title": "eschen-ahorn (acer negundo)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_negundo.jpg",
+                "coreid": "3189866",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/8/82/acer_negundo.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "deutsch: eschen-ahorn (acer negundo) polski: klon jesionolistny (acer negundo)",
+                "dcterms:creator": "agnieszka kwiecień - nova at pl.wikipedia",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "9a5a189ccbdbd748d5da7d3fbea1f2bee1137565",
+            "dwc:collectionCode": "Plants",
+            "flag_dwc_multimedia_added": true,
+            "flag_gbif_vernacularname_added": true,
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "38.5326200",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "North America",
+            "dwc:family": "Sapindaceae",
+            "idigbio:isocountrycode": "usa",
+            "dwc:identifiedBy": "Melander, M.",
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_taxonid_added": true,
+            "dcterms:license": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "idigbio:siblings": {},
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:order": "sapindales",
+            "dwc:scientificnameauthorship": "l.",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_phylum_added": true,
+            "gbif:genericname": "acer",
+            "dwc:georeferenceSources": "GEOLocate",
+            "dwc:institutionID": "http://biocol.org/urn:lsid:biocol.org:col:12991",
+            "dwc:institutionCode": "KSTC",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "17301",
+            "dwc:taxonid": "3189866",
+            "dwc:taxonrank": "species",
+            "dwc:month": "4",
+            "dwc:decimalLongitude": "-95.9647200",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189866",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero americano"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "ash-leaf maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "ashleaf maple"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "ash-leaved maple, box-elder",
+                "coreid": "3189866",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "ash-leaved maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "asklönn"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "aulne-buis"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "box-elder, ash-leaved maple",
+                "coreid": "3189866",
+                "dcterms:source": "invasive alien species in belgium - harmonia database",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "boxelder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "box-elder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "box-elder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "box elder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "boxelder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "box-elder maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "boxelder maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "california box-elder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "california boxelder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable à feuilles composées"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable à feuilles de frêne"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable à giguère"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable argilière"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable négondo"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "erable negundo",
+                "coreid": "3189866",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "erable negundo",
+                "coreid": "3189866",
+                "dcterms:source": "invasive alien species in belgium - harmonia database",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable négundo"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "eschen-ahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "eschenahorn",
+                "coreid": "3189866",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "eschen-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "eschen-ahorn",
+                "coreid": "3189866",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "eschenahorn"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "eschen-ahorn"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "af",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "essenblaarahorn"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "fu ye feng"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "af",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "kaliforniese esdoring"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen âsenelistnyj"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "korean peninsula flora",
+                "dwc:vernacularname": "네군도단풍"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "manitoba maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "manitoba maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "négondo"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "negundodanpung"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "plaine à giguère"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "three-leaf maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "three-leaved maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "tonerikoba-no-kaede"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "vederesdoorn",
+                "coreid": "3189866",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "vederesdoorn",
+                "coreid": "3189866",
+                "dcterms:source": "invasive alien species in belgium - harmonia database",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "vederesdoorn"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "western box-elder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "western boxelder"
+              }
+            ],
+            "flag_dwc_order_added": true,
+            "dwc:georeferencedBy": "Kerbs, Benjamin",
+            "gbif:reference": [
+              {
+                "coreid": "3189866",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "dwc:phylum": "tracheophyta",
+            "dwc:recordNumber": "27",
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_class_added": true,
+            "dwc:georeferenceProtocol": "GEOLocate",
+            "dcterms:modified": "2012-10-27 14:45:54.0",
+            "dwc:scientificName": "Acer negundo",
+            "dwc:day": "22",
+            "dwc:year": "1975"
+          },
+          "hasMedia": false,
+          "data": {
+            "dwc:specificEpithet": "negundo",
+            "dwc:county": "Lyon",
+            "dwc:recordedBy": "Melander, M.",
+            "dwc:georeferencedDate": "2015-02-12",
+            "dwc:occurrenceID": "4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2",
+            "id": "4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2",
+            "dwc:stateProvince": "Kansas",
+            "dwc:eventDate": "1975-04-22",
+            "dwc:country": "USA",
+            "dwc:collectionCode": "Plants",
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "38.5326200",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:continent": "North America",
+            "dwc:family": "Sapindaceae",
+            "dwc:identifiedBy": "Melander, M.",
+            "dwc:georeferenceSources": "GEOLocate",
+            "dcterms:license": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:locality": "Reading Woods",
+            "dwc:institutionID": "http://biocol.org/urn:lsid:biocol.org:col:12991",
+            "dwc:institutionCode": "KSTC",
+            "dwc:catalogNumber": "17301",
+            "dwc:month": "4",
+            "dwc:decimalLongitude": "-95.9647200",
+            "dwc:georeferencedBy": "Kerbs, Benjamin",
+            "dwc:recordNumber": "27",
+            "dwc:georeferenceProtocol": "GEOLocate",
+            "dcterms:modified": "2012-10-27 14:45:54.0",
+            "dwc:scientificName": "Acer negundo",
+            "dwc:day": "22",
+            "dwc:year": "1975"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2",
+          "institutionid": "http://biocol.org/urn:lsid:biocol.org:col:12991",
+          "country": "united states",
+          "locality": "reading woods",
+          "collectioncode": "plants",
+          "canonicalname": "acer negundo",
+          "eventdate": "1975-04-22",
+          "flags": [
+            "geopoint_datum_missing",
+            "dwc_taxonrank_added",
+            "gbif_reference_added",
+            "dwc_scientificnameauthorship_added",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_multimedia_added",
+            "gbif_vernacularname_added",
+            "dwc_country_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "gbif_canonicalname_added",
+            "dwc_phylum_added",
+            "gbif_taxon_corrected",
+            "dwc_order_added",
+            "dwc_parentnameusageid_added",
+            "dwc_class_added"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "5baa1d0c-cfc0-4c89-8e3e-7a49359b0caa\\4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "top_scientificname": {
+      "doc_count_error_upper_bound": 147,
+      "sum_other_doc_count": 66407,
+      "buckets": [
+        {
+          "key": "acer rubrum",
+          "doc_count": 10939
+        },
+        {
+          "key": "acer negundo",
+          "doc_count": 8715
+        },
+        {
+          "key": "acer saccharum",
+          "doc_count": 5591
+        },
+        {
+          "key": "acer saccharinum",
+          "doc_count": 5419
+        },
+        {
+          "key": "acer spicatum",
+          "doc_count": 3786
+        },
+        {
+          "key": "acer platanoides",
+          "doc_count": 3459
+        },
+        {
+          "key": "acer pensylvanicum",
+          "doc_count": 3193
+        },
+        {
+          "key": "acer macrophyllum",
+          "doc_count": 2343
+        },
+        {
+          "key": "acer glabrum",
+          "doc_count": 2255
+        },
+        {
+          "key": "acer",
+          "doc_count": 1910
+        }
+      ]
+    }
+  }
+}

--- a/__tests__/mock/search-0e6bb2d4f3b312f28b51da21d150f149.json
+++ b/__tests__/mock/search-0e6bb2d4f3b312f28b51da21d150f149.json
@@ -1,0 +1,820 @@
+{
+  "timed_out": false,
+  "_shards": {
+    "total": 48,
+    "successful": 48,
+    "failed": 0
+  },
+  "hits": {
+    "total": 83108,
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "06155592-f333-4612-a841-c8b25e6249dd",
+        "_score": 1,
+        "_routing": "17c0326e-7984-4654-a6d8-1fd2568578fa",
+        "_parent": "17c0326e-7984-4654-a6d8-1fd2568578fa",
+        "_source": {
+          "licenselogourl": "https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+          "uuid": "06155592-f333-4612-a841-c8b25e6249dd",
+          "format": "image/jpeg",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.45454545454545453,
+          "rights": "BY-NC-SA",
+          "mediatype": "images",
+          "hasSpecimen": true,
+          "records": [
+            "17c0326e-7984-4654-a6d8-1fd2568578fa"
+          ],
+          "etag": "f0fb67b7cac772b30f43b0380209bfa556d05ddf",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "idigbio:uuid": "06155592-f333-4612-a841-c8b25e6249dd",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00032251.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00032251",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00032251",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00032251"
+            ],
+            "idigbio:siblings": {
+              "record": [
+                "17c0326e-7984-4654-a6d8-1fd2568578fa"
+              ]
+            },
+            "dcterms:rights": "© University of Connecticut",
+            "idigbio:dateModified": "2014-09-09T01:38:49.314000",
+            "idigbio:etag": "f0fb67b7cac772b30f43b0380209bfa556d05ddf",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "webstatement": "http://creativecommons.org/licenses/by-nc-sa/4.0/",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00032251"
+          ],
+          "data": {
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00032251.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00032251",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00032251",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "dcterms:rights": "© University of Connecticut",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "datemodified": "2014-09-09T01:38:49.314000+00:00",
+          "accessuri": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00032251.JPG"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "097aa502-6c48-4011-89d3-ffa295b46cf3",
+        "_score": 1,
+        "_routing": "3c7fa3f8-01c3-4e91-9f9a-75c550381ff3",
+        "_parent": "3c7fa3f8-01c3-4e91-9f9a-75c550381ff3",
+        "_source": {
+          "licenselogourl": "https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+          "uuid": "097aa502-6c48-4011-89d3-ffa295b46cf3",
+          "format": "image/jpeg",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.45454545454545453,
+          "rights": "BY-NC-SA",
+          "mediatype": "images",
+          "hasSpecimen": true,
+          "records": [
+            "3c7fa3f8-01c3-4e91-9f9a-75c550381ff3"
+          ],
+          "etag": "ba5b48d755fc106ada509260bf732101149bbd8a",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "idigbio:uuid": "097aa502-6c48-4011-89d3-ffa295b46cf3",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00021995.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00021995",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00021995",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00021995"
+            ],
+            "idigbio:siblings": {
+              "record": [
+                "3c7fa3f8-01c3-4e91-9f9a-75c550381ff3"
+              ]
+            },
+            "dcterms:rights": "© University of Connecticut",
+            "idigbio:dateModified": "2014-09-12T19:39:15.755000",
+            "idigbio:etag": "ba5b48d755fc106ada509260bf732101149bbd8a",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "webstatement": "http://creativecommons.org/licenses/by-nc-sa/4.0/",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00021995"
+          ],
+          "data": {
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00021995.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00021995",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00021995",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "dcterms:rights": "© University of Connecticut",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "datemodified": "2014-09-12T19:39:15.755000+00:00",
+          "accessuri": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00021995.JPG"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0b2fc030-1294-421b-9b9d-a3b1ed22bc37",
+        "_score": 1,
+        "_routing": "18cafbe5-3412-4620-890a-9ffe10a7e633",
+        "_parent": "18cafbe5-3412-4620-890a-9ffe10a7e633",
+        "_source": {
+          "licenselogourl": "https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+          "uuid": "0b2fc030-1294-421b-9b9d-a3b1ed22bc37",
+          "format": "image/jpeg",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.45454545454545453,
+          "rights": "BY-NC-SA",
+          "mediatype": "images",
+          "hasSpecimen": true,
+          "records": [
+            "18cafbe5-3412-4620-890a-9ffe10a7e633"
+          ],
+          "etag": "0f35a52f4da103f6e13b7cf6381d5d5d4a6dc2e9",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "idigbio:uuid": "0b2fc030-1294-421b-9b9d-a3b1ed22bc37",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00078840.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00078840",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00078840",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00078840"
+            ],
+            "idigbio:siblings": {
+              "record": [
+                "18cafbe5-3412-4620-890a-9ffe10a7e633"
+              ]
+            },
+            "dcterms:rights": "© University of Connecticut",
+            "idigbio:dateModified": "2014-09-09T02:40:37.515000",
+            "idigbio:etag": "0f35a52f4da103f6e13b7cf6381d5d5d4a6dc2e9",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "webstatement": "http://creativecommons.org/licenses/by-nc-sa/4.0/",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00078840"
+          ],
+          "data": {
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00078840.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00078840",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00078840",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "dcterms:rights": "© University of Connecticut",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "datemodified": "2014-09-09T02:40:37.515000+00:00",
+          "accessuri": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00078840.JPG"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0b72a8c0-bcb5-40a6-8abf-a4e5a30b4e49",
+        "_score": 1,
+        "_routing": "0bc984e9-4e03-441b-94a8-75f433c26e70",
+        "_parent": "0bc984e9-4e03-441b-94a8-75f433c26e70",
+        "_source": {
+          "licenselogourl": "https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+          "uuid": "0b72a8c0-bcb5-40a6-8abf-a4e5a30b4e49",
+          "format": "image/jpeg",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.45454545454545453,
+          "rights": "BY-NC-SA",
+          "mediatype": "images",
+          "hasSpecimen": true,
+          "records": [
+            "0bc984e9-4e03-441b-94a8-75f433c26e70"
+          ],
+          "etag": "2ff675afd19846d40b50d7d36965bbb4c90c6a2c",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "idigbio:uuid": "0b72a8c0-bcb5-40a6-8abf-a4e5a30b4e49",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00078518.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00078518",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00078518",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00078518"
+            ],
+            "idigbio:siblings": {
+              "record": [
+                "0bc984e9-4e03-441b-94a8-75f433c26e70"
+              ]
+            },
+            "dcterms:rights": "© University of Connecticut",
+            "idigbio:dateModified": "2014-09-09T01:28:25.004000",
+            "idigbio:etag": "2ff675afd19846d40b50d7d36965bbb4c90c6a2c",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "webstatement": "http://creativecommons.org/licenses/by-nc-sa/4.0/",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00078518"
+          ],
+          "data": {
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00078518.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00078518",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00078518",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "dcterms:rights": "© University of Connecticut",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "datemodified": "2014-09-09T01:28:25.004000+00:00",
+          "accessuri": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00078518.JPG"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "120c9d5a-5faa-41c6-93f4-4b680e0ca311",
+        "_score": 1,
+        "_routing": "f7506eff-4f5c-4ede-b06a-b18753373c8a",
+        "_parent": "f7506eff-4f5c-4ede-b06a-b18753373c8a",
+        "_source": {
+          "hasSpecimen": true,
+          "uuid": "120c9d5a-5faa-41c6-93f4-4b680e0ca311",
+          "format": "image/jpeg",
+          "recordset": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "dqs": 0.2727272727272727,
+          "rights": "Public Domain",
+          "mediatype": "images",
+          "records": [
+            "f7506eff-4f5c-4ede-b06a-b18753373c8a"
+          ],
+          "etag": "040004a97d744908f6d1b8ce705a712265ee53ef",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "ac:comments": "http://creativecommons.org/publicdomain/mark/1.0/",
+            "idigbio:parent": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+            "xmpRights:UsageTerms": "Public Domain",
+            "ac:thumbnailAccessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-SDnv8PCUXTU3breruiboRG?resize=1250&format=jpeg",
+            "ac:goodQualityAccessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-SDnv8PCUXTU3breruiboRG?resize=1250&format=jpeg",
+            "coreid": "807963",
+            "dcterms:identifier": "http://bisque.iplantcollaborative.org/image_service/image/00-SDnv8PCUXTU3breruiboRG?resize=1250&format=jpeg",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "idigbio:dateModified": "2016-04-21T13:40:35.966214",
+            "ac:metadataLanguage": "en",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807963",
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:5b42d543-b5e6-43c8-b68a-9bb97b086f47",
+            "ac:subtype": "Photograph",
+            "idigbio:etag": "040004a97d744908f6d1b8ce705a712265ee53ef",
+            "dcterms:format": "image/jpeg",
+            "idigbio:siblings": {
+              "record": [
+                "f7506eff-4f5c-4ede-b06a-b18753373c8a"
+              ]
+            },
+            "ac:caption": "YU YU.076242 Acer spicatum Lam.",
+            "idigbio:recordIds": [
+              "urn:uuid:5b42d543-b5e6-43c8-b68a-9bb97b086f47",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\media\\http://bovary.iplantcollaborative.org/image_service/image/00-sdnv8pcuxtu3breruiborg",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\media\\http://bisque.iplantcollaborative.org/image_service/image/00-sdnv8pcuxtu3breruiborg?resize=1250&format=jpeg"
+            ],
+            "ac:accessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-SDnv8PCUXTU3breruiboRG?resize=1250&format=jpeg",
+            "xmp:MetadataDate": "2015-02-04 18:09:11",
+            "idigbio:uuid": "120c9d5a-5faa-41c6-93f4-4b680e0ca311"
+          },
+          "recordids": [
+            "urn:uuid:5b42d543-b5e6-43c8-b68a-9bb97b086f47",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\media\\http://bovary.iplantcollaborative.org/image_service/image/00-sdnv8pcuxtu3breruiborg",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\media\\http://bisque.iplantcollaborative.org/image_service/image/00-sdnv8pcuxtu3breruiborg?resize=1250&format=jpeg"
+          ],
+          "data": {
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:5b42d543-b5e6-43c8-b68a-9bb97b086f47",
+            "ac:subtype": "Photograph",
+            "ac:metadataLanguage": "en",
+            "xmpRights:UsageTerms": "Public Domain",
+            "ac:comments": "http://creativecommons.org/publicdomain/mark/1.0/",
+            "dcterms:format": "image/jpeg",
+            "ac:goodQualityAccessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-SDnv8PCUXTU3breruiboRG?resize=1250&format=jpeg",
+            "coreid": "807963",
+            "dcterms:identifier": "http://bisque.iplantcollaborative.org/image_service/image/00-SDnv8PCUXTU3breruiboRG?resize=1250&format=jpeg",
+            "ac:caption": "YU YU.076242 Acer spicatum Lam.",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "ac:thumbnailAccessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-SDnv8PCUXTU3breruiboRG?resize=1250&format=jpeg",
+            "ac:accessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-SDnv8PCUXTU3breruiboRG?resize=1250&format=jpeg",
+            "xmp:MetadataDate": "2015-02-04 18:09:11",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807963"
+          },
+          "datemodified": "2016-04-21T13:40:35.966214+00:00",
+          "accessuri": "http://bisque.iplantcollaborative.org/image_service/image/00-SDnv8PCUXTU3breruiboRG?resize=1250&format=jpeg"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "16201bed-b9cc-4065-813b-78a9938b3d1c",
+        "_score": 1,
+        "_routing": "8b34495c-42ae-4ba2-8377-0a5b034397e0",
+        "_parent": "8b34495c-42ae-4ba2-8377-0a5b034397e0",
+        "_source": {
+          "licenselogourl": "https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+          "uuid": "16201bed-b9cc-4065-813b-78a9938b3d1c",
+          "format": "image/jpeg",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.45454545454545453,
+          "rights": "BY-NC-SA",
+          "mediatype": "images",
+          "hasSpecimen": true,
+          "records": [
+            "8b34495c-42ae-4ba2-8377-0a5b034397e0"
+          ],
+          "etag": "0d72beeac600bca7a7cdf18ca518afdee6745eef",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "idigbio:uuid": "16201bed-b9cc-4065-813b-78a9938b3d1c",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00078650.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00078650",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00078650",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00078650"
+            ],
+            "idigbio:siblings": {
+              "record": [
+                "8b34495c-42ae-4ba2-8377-0a5b034397e0"
+              ]
+            },
+            "dcterms:rights": "© University of Connecticut",
+            "idigbio:dateModified": "2014-09-09T05:02:47.586000",
+            "idigbio:etag": "0d72beeac600bca7a7cdf18ca518afdee6745eef",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "webstatement": "http://creativecommons.org/licenses/by-nc-sa/4.0/",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00078650"
+          ],
+          "data": {
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00078650.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00078650",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00078650",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "dcterms:rights": "© University of Connecticut",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "datemodified": "2014-09-09T05:02:47.586000+00:00",
+          "accessuri": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00078650.JPG"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "eefcd5db-9ac1-4b74-9cb2-529152eef6a6",
+        "_score": 1,
+        "_routing": "22984faf-06f3-43bf-8dc9-db30d4a06e6f",
+        "_parent": "22984faf-06f3-43bf-8dc9-db30d4a06e6f",
+        "_source": {
+          "licenselogourl": "http://i.creativecommons.org/p/zero/1.0/88x31.png",
+          "uuid": "eefcd5db-9ac1-4b74-9cb2-529152eef6a6",
+          "format": "image/jpeg",
+          "recordset": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "dqs": 0.45454545454545453,
+          "rights": "CC0",
+          "mediatype": "images",
+          "hasSpecimen": true,
+          "records": [
+            "22984faf-06f3-43bf-8dc9-db30d4a06e6f"
+          ],
+          "etag": "3f7598c51ab9110d57da01649ac1199ac064a68f",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "idigbio:parent": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:adc1cf49-83f0-4228-be67-181cf7469f49",
+            "ac:subtype": "Photograph",
+            "xmp:MetadataDate": "2012-10-08 20:53:21",
+            "xmpRights:UsageTerms": "Yale Peabody Museum of Natural History",
+            "ac:thumbnailAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204999/format/1",
+            "idigbio:etag": "3f7598c51ab9110d57da01649ac1199ac064a68f",
+            "dcterms:format": "image/jpeg",
+            "idigbio:recordIds": [
+              "urn:uuid:adc1cf49-83f0-4228-be67-181cf7469f49",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\media\\http://deliver.odai.yale.edu/content/repository/ypm/id/204999/format/3"
+            ],
+            "ac:goodQualityAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204999/format/3",
+            "coreid": "269794",
+            "dcterms:identifier": "http://deliver.odai.yale.edu/content/repository/YPM/id/204999/format/3",
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "idigbio:siblings": {
+              "record": [
+                "22984faf-06f3-43bf-8dc9-db30d4a06e6f"
+              ]
+            },
+            "idigbio:dateModified": "2016-04-21T13:40:34.206773",
+            "ac:accessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204999/format/3",
+            "ac:metadataLanguage": "en",
+            "idigbio:uuid": "eefcd5db-9ac1-4b74-9cb2-529152eef6a6",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=269794"
+          },
+          "webstatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+          "recordids": [
+            "urn:uuid:adc1cf49-83f0-4228-be67-181cf7469f49",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\media\\http://deliver.odai.yale.edu/content/repository/ypm/id/204999/format/3"
+          ],
+          "data": {
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:adc1cf49-83f0-4228-be67-181cf7469f49",
+            "ac:subtype": "Photograph",
+            "ac:metadataLanguage": "en",
+            "xmpRights:UsageTerms": "Yale Peabody Museum of Natural History",
+            "ac:thumbnailAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204999/format/1",
+            "dcterms:format": "image/jpeg",
+            "ac:goodQualityAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204999/format/3",
+            "coreid": "269794",
+            "dcterms:identifier": "http://deliver.odai.yale.edu/content/repository/YPM/id/204999/format/3",
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "ac:accessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204999/format/3",
+            "xmp:MetadataDate": "2012-10-08 20:53:21",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=269794"
+          },
+          "datemodified": "2016-04-21T13:40:34.206773+00:00",
+          "accessuri": "http://deliver.odai.yale.edu/content/repository/YPM/id/204999/format/3"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "ef158cc6-2f94-48e5-92be-e608631f990f",
+        "_score": 1,
+        "_routing": "df6e800e-e2e1-4fcf-9940-fb738b70e7ed",
+        "_parent": "df6e800e-e2e1-4fcf-9940-fb738b70e7ed",
+        "_source": {
+          "hasSpecimen": true,
+          "uuid": "ef158cc6-2f94-48e5-92be-e608631f990f",
+          "format": "image/jpeg",
+          "recordset": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "dqs": 0.2727272727272727,
+          "rights": "Public Domain",
+          "mediatype": "images",
+          "records": [
+            "df6e800e-e2e1-4fcf-9940-fb738b70e7ed"
+          ],
+          "etag": "e94e1b945eb0bbe0af87a790d7fd36f5e8eb13c4",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "ac:comments": "http://creativecommons.org/publicdomain/mark/1.0/",
+            "idigbio:parent": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+            "xmpRights:UsageTerms": "Public Domain",
+            "ac:thumbnailAccessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-aetigLi3e4EjEhpFQFyddL?resize=1250&format=jpeg",
+            "ac:goodQualityAccessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-aetigLi3e4EjEhpFQFyddL?resize=1250&format=jpeg",
+            "coreid": "807945",
+            "dcterms:identifier": "http://bisque.iplantcollaborative.org/image_service/image/00-aetigLi3e4EjEhpFQFyddL?resize=1250&format=jpeg",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "idigbio:dateModified": "2016-04-21T13:40:35.966214",
+            "ac:metadataLanguage": "en",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807945",
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:7705ca3c-df7a-40c4-9ff9-270b091a3f5f",
+            "ac:subtype": "Photograph",
+            "idigbio:etag": "e94e1b945eb0bbe0af87a790d7fd36f5e8eb13c4",
+            "dcterms:format": "image/jpeg",
+            "idigbio:siblings": {
+              "record": [
+                "df6e800e-e2e1-4fcf-9940-fb738b70e7ed"
+              ]
+            },
+            "ac:caption": "YU YU.076227 Acer saccharum Marsh.",
+            "idigbio:recordIds": [
+              "urn:uuid:7705ca3c-df7a-40c4-9ff9-270b091a3f5f",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\media\\http://bovary.iplantcollaborative.org/image_service/image/00-aetigli3e4ejehpfqfyddl",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\media\\http://bisque.iplantcollaborative.org/image_service/image/00-aetigli3e4ejehpfqfyddl?resize=1250&format=jpeg"
+            ],
+            "ac:accessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-aetigLi3e4EjEhpFQFyddL?resize=1250&format=jpeg",
+            "xmp:MetadataDate": "2015-02-04 18:08:03",
+            "idigbio:uuid": "ef158cc6-2f94-48e5-92be-e608631f990f"
+          },
+          "recordids": [
+            "urn:uuid:7705ca3c-df7a-40c4-9ff9-270b091a3f5f",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\media\\http://bovary.iplantcollaborative.org/image_service/image/00-aetigli3e4ejehpfqfyddl",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\media\\http://bisque.iplantcollaborative.org/image_service/image/00-aetigli3e4ejehpfqfyddl?resize=1250&format=jpeg"
+          ],
+          "data": {
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:7705ca3c-df7a-40c4-9ff9-270b091a3f5f",
+            "ac:subtype": "Photograph",
+            "ac:metadataLanguage": "en",
+            "xmpRights:UsageTerms": "Public Domain",
+            "ac:comments": "http://creativecommons.org/publicdomain/mark/1.0/",
+            "dcterms:format": "image/jpeg",
+            "ac:goodQualityAccessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-aetigLi3e4EjEhpFQFyddL?resize=1250&format=jpeg",
+            "coreid": "807945",
+            "dcterms:identifier": "http://bisque.iplantcollaborative.org/image_service/image/00-aetigLi3e4EjEhpFQFyddL?resize=1250&format=jpeg",
+            "ac:caption": "YU YU.076227 Acer saccharum Marsh.",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "ac:thumbnailAccessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-aetigLi3e4EjEhpFQFyddL?resize=1250&format=jpeg",
+            "ac:accessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-aetigLi3e4EjEhpFQFyddL?resize=1250&format=jpeg",
+            "xmp:MetadataDate": "2015-02-04 18:08:03",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807945"
+          },
+          "datemodified": "2016-04-21T13:40:35.966214+00:00",
+          "accessuri": "http://bisque.iplantcollaborative.org/image_service/image/00-aetigLi3e4EjEhpFQFyddL?resize=1250&format=jpeg"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "eff82e1c-8962-4673-9885-0172c4c38ae1",
+        "_score": 1,
+        "_routing": "07d81427-448e-43aa-841a-8191b8bed86b",
+        "_parent": "07d81427-448e-43aa-841a-8191b8bed86b",
+        "_source": {
+          "licenselogourl": "http://i.creativecommons.org/p/zero/1.0/88x31.png",
+          "uuid": "eff82e1c-8962-4673-9885-0172c4c38ae1",
+          "format": "image/jpeg",
+          "recordset": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "dqs": 0.45454545454545453,
+          "rights": "CC0",
+          "mediatype": "images",
+          "hasSpecimen": true,
+          "records": [
+            "07d81427-448e-43aa-841a-8191b8bed86b"
+          ],
+          "etag": "50481b54c26c47888b4fa6b3eef92e546d6c2df3",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "idigbio:parent": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:e3f6005d-fd20-4924-a77f-5adc32da8481",
+            "ac:subtype": "Photograph",
+            "xmp:MetadataDate": "2012-10-08 20:53:21",
+            "xmpRights:UsageTerms": "Yale Peabody Museum of Natural History",
+            "ac:thumbnailAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204975/format/1",
+            "idigbio:etag": "50481b54c26c47888b4fa6b3eef92e546d6c2df3",
+            "dcterms:format": "image/jpeg",
+            "idigbio:recordIds": [
+              "urn:uuid:e3f6005d-fd20-4924-a77f-5adc32da8481",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\media\\http://deliver.odai.yale.edu/content/repository/ypm/id/204975/format/3"
+            ],
+            "ac:goodQualityAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204975/format/3",
+            "coreid": "110466",
+            "dcterms:identifier": "http://deliver.odai.yale.edu/content/repository/YPM/id/204975/format/3",
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "idigbio:siblings": {
+              "record": [
+                "07d81427-448e-43aa-841a-8191b8bed86b"
+              ]
+            },
+            "idigbio:dateModified": "2016-04-21T13:40:34.206773",
+            "ac:accessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204975/format/3",
+            "ac:metadataLanguage": "en",
+            "idigbio:uuid": "eff82e1c-8962-4673-9885-0172c4c38ae1",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110466"
+          },
+          "webstatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+          "recordids": [
+            "urn:uuid:e3f6005d-fd20-4924-a77f-5adc32da8481",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\media\\http://deliver.odai.yale.edu/content/repository/ypm/id/204975/format/3"
+          ],
+          "data": {
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:e3f6005d-fd20-4924-a77f-5adc32da8481",
+            "ac:subtype": "Photograph",
+            "ac:metadataLanguage": "en",
+            "xmpRights:UsageTerms": "Yale Peabody Museum of Natural History",
+            "ac:thumbnailAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204975/format/1",
+            "dcterms:format": "image/jpeg",
+            "ac:goodQualityAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204975/format/3",
+            "coreid": "110466",
+            "dcterms:identifier": "http://deliver.odai.yale.edu/content/repository/YPM/id/204975/format/3",
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "ac:accessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204975/format/3",
+            "xmp:MetadataDate": "2012-10-08 20:53:21",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110466"
+          },
+          "datemodified": "2016-04-21T13:40:34.206773+00:00",
+          "accessuri": "http://deliver.odai.yale.edu/content/repository/YPM/id/204975/format/3"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "f0caf08c-a500-4327-9012-e839d62017ea",
+        "_score": 1,
+        "_routing": "9a8fb7bd-de66-499f-a229-366f76d4c08d",
+        "_parent": "9a8fb7bd-de66-499f-a229-366f76d4c08d",
+        "_source": {
+          "licenselogourl": "http://i.creativecommons.org/p/zero/1.0/88x31.png",
+          "uuid": "f0caf08c-a500-4327-9012-e839d62017ea",
+          "format": "image/jpeg",
+          "recordset": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "dqs": 0.45454545454545453,
+          "rights": "CC0",
+          "mediatype": "images",
+          "hasSpecimen": true,
+          "records": [
+            "9a8fb7bd-de66-499f-a229-366f76d4c08d"
+          ],
+          "etag": "1fbdecaca33b319aa26bb9a6192ff0ed38cfe230",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "idigbio:parent": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:ff3d1719-b933-4008-b5d6-d64da618ed65",
+            "ac:subtype": "Photograph",
+            "xmp:MetadataDate": "2012-10-08 20:53:21",
+            "xmpRights:UsageTerms": "Yale Peabody Museum of Natural History",
+            "ac:thumbnailAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/205022/format/1",
+            "idigbio:etag": "1fbdecaca33b319aa26bb9a6192ff0ed38cfe230",
+            "dcterms:format": "image/jpeg",
+            "idigbio:recordIds": [
+              "urn:uuid:ff3d1719-b933-4008-b5d6-d64da618ed65",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\media\\http://deliver.odai.yale.edu/content/repository/ypm/id/205022/format/3"
+            ],
+            "ac:goodQualityAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/205022/format/3",
+            "coreid": "110498",
+            "dcterms:identifier": "http://deliver.odai.yale.edu/content/repository/YPM/id/205022/format/3",
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "idigbio:siblings": {
+              "record": [
+                "9a8fb7bd-de66-499f-a229-366f76d4c08d"
+              ]
+            },
+            "idigbio:dateModified": "2016-04-21T13:40:34.206773",
+            "ac:accessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/205022/format/3",
+            "ac:metadataLanguage": "en",
+            "idigbio:uuid": "f0caf08c-a500-4327-9012-e839d62017ea",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110498"
+          },
+          "webstatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+          "recordids": [
+            "urn:uuid:ff3d1719-b933-4008-b5d6-d64da618ed65",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\media\\http://deliver.odai.yale.edu/content/repository/ypm/id/205022/format/3"
+          ],
+          "data": {
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:ff3d1719-b933-4008-b5d6-d64da618ed65",
+            "ac:subtype": "Photograph",
+            "ac:metadataLanguage": "en",
+            "xmpRights:UsageTerms": "Yale Peabody Museum of Natural History",
+            "ac:thumbnailAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/205022/format/1",
+            "dcterms:format": "image/jpeg",
+            "ac:goodQualityAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/205022/format/3",
+            "coreid": "110498",
+            "dcterms:identifier": "http://deliver.odai.yale.edu/content/repository/YPM/id/205022/format/3",
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "ac:accessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/205022/format/3",
+            "xmp:MetadataDate": "2012-10-08 20:53:21",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110498"
+          },
+          "datemodified": "2016-04-21T13:40:34.206773+00:00",
+          "accessuri": "http://deliver.odai.yale.edu/content/repository/YPM/id/205022/format/3"
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "top_recordset": {
+      "doc_count_error_upper_bound": 114,
+      "sum_other_doc_count": 39171,
+      "buckets": [
+        {
+          "key": "fabcdc12-9d29-4bd2-912b-176e71818144",
+          "doc_count": 8348
+        },
+        {
+          "key": "7450a9e3-ef95-4f9e-8260-09b498d2c5e6",
+          "doc_count": 7298
+        },
+        {
+          "key": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+          "doc_count": 5892
+        },
+        {
+          "key": "36d35b23-113e-4633-90ec-19d265a3b5f6",
+          "doc_count": 5816
+        },
+        {
+          "key": "a6eee223-cf3b-4079-8bb2-b77dad8cae9d",
+          "doc_count": 4873
+        },
+        {
+          "key": "4e3043a6-d48a-4a35-b5fb-f67d50cbc158",
+          "doc_count": 2872
+        },
+        {
+          "key": "65536dcd-7bb2-44e5-af3f-4a13f08e53d0",
+          "doc_count": 2737
+        },
+        {
+          "key": "beab5209-9628-4d4d-851e-2bc9bb1a0105",
+          "doc_count": 2313
+        },
+        {
+          "key": "e60301d9-9b40-483f-92de-065769b9d3dd",
+          "doc_count": 2112
+        },
+        {
+          "key": "db6c3db9-1e6d-4def-af29-33aa0339bfa9",
+          "doc_count": 1676
+        }
+      ]
+    }
+  }
+}

--- a/__tests__/mock/search-20868169551d29d094f366e845538e85.json
+++ b/__tests__/mock/search-20868169551d29d094f366e845538e85.json
@@ -1,0 +1,4032 @@
+{
+  "timed_out": false,
+  "_shards": {
+    "total": 48,
+    "successful": 48,
+    "failed": 0
+  },
+  "hits": {
+    "total": 114017,
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a04854e2-2a22-433a-8e9a-8bbd14e8105b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lat": 41.76527,
+            "lon": -72.19861
+          },
+          "family": "sapindaceae",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.2463768115942029,
+          "stateprovince": "connecticut",
+          "institutioncode": "uconn",
+          "municipality": "mansfield",
+          "county": "tolland county",
+          "phylum": "tracheophyta",
+          "catalognumber": "conn00070249",
+          "startdayofyear": 50,
+          "taxonrank": "species",
+          "specificepithet": "saccharinum",
+          "continent": "north america",
+          "uuid": "a04854e2-2a22-433a-8e9a-8bbd14e8105b",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "jody foley",
+          "commonnames": [
+            "Silver Maple"
+          ],
+          "mediarecords": [
+            "b51105ab-33eb-457a-bafc-43a57d77643d"
+          ],
+          "datemodified": "2014-09-09T02:54:49.495000+00:00",
+          "datecollected": "1999-02-19T00:00:00+00:00",
+          "etag": "2d2c88d7840bafc1ab38d4d76878a5d6193a6bc1",
+          "recordnumber": "40",
+          "hasImage": true,
+          "kingdom": "plantae",
+          "highertaxon": "plantae; dicotyledonae; sapindales; aceraceae",
+          "commonname": "silver maple",
+          "taxonid": "3189837",
+          "scientificname": "acer saccharinum l.",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "flag_dwc_family_replaced": true,
+            "dwc:specificEpithet": "saccharinum",
+            "idigbio:dateModified": "2014-09-09T02:54:49.495000",
+            "dwc:countryCode": "US",
+            "dwc:county": "Tolland County",
+            "dwc:recordedBy": "Jody Foley",
+            "idigbio:uuid": "a04854e2-2a22-433a-8e9a-8bbd14e8105b",
+            "dwc:locationAccordingTo": "seconds added from gazetteer",
+            "dwc:order": "Sapindales",
+            "flag_gbif_reference_added": true,
+            "idigbio:isocountrycode": "usa",
+            "flag_dwc_scientificnameauthorship_added": true,
+            "dwc:locality": "Mansfield Center, Wolfrock section of Nipmuck Trail, Crane Hill Road.",
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00070249"
+            ],
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00070249",
+            "dwc:scientificName": "Acer saccharinum L.",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189837",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero argentato"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable argenté"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable blanc"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:source": "korean peninsula flora",
+                "dwc:vernacularname": "은단풍"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "plaine blanche"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "plaine de france"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "river maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "silber-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "silber-ahorn",
+                "coreid": "3189837",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "silberahorn"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "silverlönn"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "silver maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "silver maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "silver maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "silver maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "soft maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "soft maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "white maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "white maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "witte esdoorn"
+              }
+            ],
+            "flag_dwc_kingdom_replaced": true,
+            "flag_gbif_genericname_added": true,
+            "flag_dwc_parentnameusageid_added": true,
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dwc:stateProvince": "Connecticut",
+            "flag_dwc_taxonomicstatus_added": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:eventDate": "1999-02-19",
+            "dwc:country": "united states",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "gnu free documentation license",
+                "dcterms:title": "blattoberseite",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_saccharinum_002.jpg",
+                "coreid": "3189837",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/0/08/acer_saccharinum_002.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "de: silber-ahorn (acer saccharinum) im neuen botanischen garten marburg, hessen, deutschland en: silver maple (acer saccharinum) in the new botanical garden marburg, hesse, germany",
+                "dcterms:creator": "willow",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:silber-ahorn_(acer_saccharinum).jpg",
+                "coreid": "3189837",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/6/64/silber-ahorn_%28acer_saccharinum%29.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "gnu free documentation license",
+                "dcterms:title": "silber-ahorn (acer saccharinum)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_saccharinum_001.jpg",
+                "coreid": "3189837",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/d/db/acer_saccharinum_001.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "de: silber-ahorn (acer saccharinum) im neuen botanischen garten marburg, hessen, deutschland en: silver maple (acer saccharinum) in the new botanical garden marburg, hesse, germany",
+                "dcterms:creator": "willow",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "2d2c88d7840bafc1ab38d4d76878a5d6193a6bc1",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "41°45' 55\" N",
+            "gbif:reference": [
+              {
+                "coreid": "3189837",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "l. (1753) in: sp. pl. 1055"
+              }
+            ],
+            "dwc:kingdom": "plantae",
+            "dwc:decimalLatitude": "41.76527",
+            "dwc:occurrenceRemarks": "Tree 35 ft. tall by 19 in. wide, south of Wolf Rock, on east side of trail.",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "sapindaceae",
+            "flag_dwc_continent_added": true,
+            "flag_dwc_country_replaced": true,
+            "dwc:class": "magnoliopsida",
+            "dwc:municipality": "Mansfield",
+            "flag_dwc_taxonid_added": true,
+            "dwc:previousIdentifications": "Acer saccharinum L.",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "b51105ab-33eb-457a-bafc-43a57d77643d"
+              ]
+            },
+            "flag_dwc_class_added": true,
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:vernacularName": "Silver Maple",
+            "gbif:canonicalname": "acer saccharinum",
+            "dwc:scientificnameauthorship": "l.",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_phylum_added": true,
+            "gbif:genericname": "acer",
+            "dwc:georeferenceSources": "no date. Topozone. TopoZone.com © Maps a la carte, Inc. - All rights reserved.",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "UConn",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:reproductiveCondition": "winter / dormant condition",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Sapindales; Aceraceae",
+            "dwc:catalogNumber": "CONN00070249",
+            "dwc:taxonid": "3189837",
+            "dwc:taxonrank": "species",
+            "dwc:higherGeography": "USA; Connecticut; Tolland County; Mansfield",
+            "dwc:month": "2",
+            "dwc:decimalLongitude": "-72.19861",
+            "dwc:verbatimLongitude": "72°11' 55\" W",
+            "dwc:verbatimEventDate": "19-Feb-99",
+            "dwc:phylum": "tracheophyta",
+            "dwc:recordNumber": "40",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "flag_dwc_multimedia_added": true,
+            "flag_dwc_datasetid_replaced": true,
+            "dcterms:modified": "2012-04-05T00:00-0500",
+            "dwc:coordinateUncertaintyInMeters": "20000",
+            "dwc:day": "19",
+            "dwc:datasetID": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dwc:year": "1999"
+          },
+          "hasMedia": true,
+          "coordinateuncertainty": 20000,
+          "data": {
+            "dwc:specificEpithet": "saccharinum",
+            "dwc:countryCode": "US",
+            "dwc:county": "Tolland County",
+            "dwc:recordedBy": "Jody Foley",
+            "dwc:georeferenceSources": "no date. Topozone. TopoZone.com © Maps a la carte, Inc. - All rights reserved.",
+            "dwc:order": "Sapindales",
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00070249",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1999-02-19",
+            "dwc:country": "USA",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "41°45' 55\" N",
+            "dwc:kingdom": "Dicotyledonae",
+            "dwc:decimalLatitude": "41.76527",
+            "dwc:occurrenceRemarks": "Tree 35 ft. tall by 19 in. wide, south of Wolf Rock, on east side of trail.",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Aceraceae",
+            "dwc:coordinateUncertaintyInMeters": "20000",
+            "dwc:municipality": "Mansfield",
+            "dwc:previousIdentifications": "Acer saccharinum L.",
+            "dwc:vernacularName": "Silver Maple",
+            "dwc:locationAccordingTo": "seconds added from gazetteer",
+            "dwc:locality": "Mansfield Center, Wolfrock section of Nipmuck Trail, Crane Hill Road.",
+            "dwc:institutionCode": "UConn",
+            "dwc:reproductiveCondition": "winter / dormant condition",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Sapindales; Aceraceae",
+            "dwc:catalogNumber": "CONN00070249",
+            "dwc:higherGeography": "USA; Connecticut; Tolland County; Mansfield",
+            "dwc:month": "2",
+            "dwc:decimalLongitude": "-72.19861",
+            "dwc:verbatimLongitude": "72°11' 55\" W",
+            "dwc:verbatimEventDate": "19-Feb-99",
+            "dwc:recordNumber": "40",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "dcterms:modified": "2012-04-05T00:00-0500",
+            "dwc:scientificName": "Acer saccharinum L.",
+            "dwc:day": "19",
+            "dwc:datasetID": "62967",
+            "dwc:year": "1999"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:catalog:uconn:conn:conn00070249",
+          "country": "united states",
+          "locality": "mansfield center, wolfrock section of nipmuck trail, crane hill road.",
+          "collectioncode": "conn",
+          "canonicalname": "acer saccharinum",
+          "eventdate": "1999-02-19",
+          "flags": [
+            "geopoint_datum_missing",
+            "dwc_taxonrank_added",
+            "dwc_family_replaced",
+            "gbif_reference_added",
+            "dwc_scientificnameauthorship_added",
+            "dwc_kingdom_replaced",
+            "gbif_genericname_added",
+            "dwc_parentnameusageid_added",
+            "dwc_taxonomicstatus_added",
+            "dwc_continent_added",
+            "dwc_country_replaced",
+            "dwc_taxonid_added",
+            "dwc_class_added",
+            "idigbio_isocountrycode_added",
+            "gbif_canonicalname_added",
+            "dwc_phylum_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_multimedia_added",
+            "dwc_datasetid_replaced"
+          ],
+          "verbatimeventdate": "19-feb-99",
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00070249"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9a8fb7bd-de66-499f-a229-366f76d4c08d",
+        "_score": 1,
+        "_source": {
+          "family": "sapindaceae",
+          "recordset": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "dqs": 0.2318840579710145,
+          "stateprovince": "connecticut",
+          "municipality": "cheshire",
+          "county": "new haven county",
+          "phylum": "tracheophyta",
+          "catalognumber": "cbs.026036",
+          "startdayofyear": 269,
+          "taxonrank": "species",
+          "specificepithet": "spicatum",
+          "continent": "north america",
+          "uuid": "9a8fb7bd-de66-499f-a229-366f76d4c08d",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "arthur edmond blewitt",
+          "institutioncode": "yale peabody museum of natural history",
+          "mediarecords": [
+            "f0caf08c-a500-4327-9012-e839d62017ea"
+          ],
+          "datemodified": "2016-03-21T21:43:25.444854+00:00",
+          "datecollected": "1907-09-26T00:00:00+00:00",
+          "etag": "41d85c320a71e032c1fb6eddca3af7ca1daa97fe",
+          "recordnumber": "4290",
+          "hasImage": true,
+          "kingdom": "plantae",
+          "collectionid": "http://grbio.org/cool/x0m9-a3bs",
+          "taxonid": "3189848",
+          "scientificname": "acer spicatum",
+          "indexData": {
+            "dwc:startDayOfYear": "269",
+            "flag_dwc_taxonrank_added": true,
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "creative commons attribution share alike 3.0 unported",
+                "dcterms:title": "blätter",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_spicatum_jpg1l.jpg",
+                "coreid": "3189848",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/e/e3/acer_spicatum_jpg1l.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "français : feuilles d’érable à épis ou plaine bâtarde – acer spicatum année de plantation : 1998 position exacte : arboretum robert lenoir (s28 - 2968) - rendeux (belgique). english: hornbeam maple acer spicatum leaves planting date : 1998 precise location : arboretum robert lenoir (s28 - 2968) rendeux (belgium). walon: fouyes di bastaurde plane acer carpinifolium annéye do plantis' : 1998 place rècta : arboretum robert lenoir (s28 - 2968) - rindeu (bèljike).",
+                "dcterms:creator": "jean-pol grandmont",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "creative commons attribution share alike 3.0 unported",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_spicatum_jpg1l.jpg",
+                "coreid": "3189848",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/e/e3/acer_spicatum_jpg1l.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "français : feuilles d’érable à épis ou plaine bâtarde – acer spicatum année de plantation : 1998 position exacte : arboretum robert lenoir (s28 - 2968) - rendeux (belgique). english: hornbeam maple acer spicatum leaves planting date : 1998 precise location : arboretum robert lenoir (s28 - 2968) rendeux (belgium). walon: fouyes di bastaurde plane acer carpinifolium annéye do plantis' : 1998 place rècta : arboretum robert lenoir (s28 - 2968) - rindeu (bèljike).",
+                "dcterms:creator": "jean-pol grandmont",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "dwc:specificEpithet": "spicatum",
+            "idigbio:dateModified": "2016-03-21T21:43:25.444854",
+            "dwc:county": "New Haven County",
+            "dwc:recordedBy": "Arthur Edmond Blewitt",
+            "idigbio:uuid": "9a8fb7bd-de66-499f-a229-366f76d4c08d",
+            "flag_dwc_multimedia_added": true,
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110498",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "lam.",
+            "idigbio:recordIds": [
+              "urn:uuid:6c916224-a076-40d4-bb04-7670f7e7cfa2",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\urn:uuid:9fc10d21-7148-4590-b1bd-259bf1e2548b",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\110498"
+            ],
+            "dwc:occurrenceID": "urn:uuid:9fc10d21-7148-4590-b1bd-259bf1e2548b",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1907-09-26",
+            "flag_dwc_scientificnameauthorship_replaced": true,
+            "dwc:collectionID": "http://grbio.org/cool/x0m9-a3bs",
+            "dwc:country": "united states",
+            "idigbio:recordId": "urn:uuid:6c916224-a076-40d4-bb04-7670f7e7cfa2",
+            "idigbio:etag": "41d85c320a71e032c1fb6eddca3af7ca1daa97fe",
+            "dwc:collectionCode": "CBS",
+            "id": "110498",
+            "dwc:kingdom": "Plantae",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_phylum_replaced": true,
+            "dwc:municipality": "Cheshire",
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "usa",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "f0caf08c-a500-4327-9012-e839d62017ea"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "gbif:canonicalname": "acer spicatum",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "acer",
+            "dwc:locality": "The Notch",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "CBS.026036",
+            "dwc:taxonid": "3189848",
+            "dwc:taxonrank": "species",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189848",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "axlönn"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable à épis"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable bâtard"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "moose maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "moose maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "moose maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "mountain maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "mountain maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "mountain maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "mountain maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "plaine bâtarde"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "plaine bleue"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "vermont-ahorn"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "white maple"
+              }
+            ],
+            "dwc:month": "9",
+            "flag_dwc_class_replaced": true,
+            "gbif:reference": [
+              {
+                "coreid": "3189848",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "lam. (1786) in: encyc. 2: 381"
+              }
+            ],
+            "flag_dwc_continent_added": true,
+            "dwc:recordNumber": "4290",
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dcterms:modified": "2011-07-23 00:00:00",
+            "dwc:scientificName": "Acer spicatum",
+            "dwc:day": "26",
+            "dwc:year": "1907"
+          },
+          "hasMedia": true,
+          "data": {
+            "dwc:startDayOfYear": "269",
+            "dwc:specificEpithet": "spicatum",
+            "dwc:county": "New Haven County",
+            "dwc:recordedBy": "Arthur Edmond Blewitt",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110498",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:occurrenceID": "urn:uuid:9fc10d21-7148-4590-b1bd-259bf1e2548b",
+            "dwc:scientificNameAuthorship": "Lam.",
+            "id": "110498",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1907-09-26",
+            "dwc:collectionID": "http://grbio.org/cool/x0m9-a3bs",
+            "dwc:country": "USA",
+            "idigbio:recordId": "urn:uuid:6c916224-a076-40d4-bb04-7670f7e7cfa2",
+            "dwc:collectionCode": "CBS",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:kingdom": "Plantae",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:municipality": "Cheshire",
+            "dwc:phylum": "Charophyta",
+            "dwc:locality": "The Notch",
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "dwc:class": "Equisetopsida",
+            "dwc:catalogNumber": "CBS.026036",
+            "dwc:month": "9",
+            "dwc:recordNumber": "4290",
+            "dcterms:modified": "2011-07-23 00:00:00",
+            "dwc:scientificName": "Acer spicatum",
+            "dwc:day": "26",
+            "dwc:year": "1907"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:9fc10d21-7148-4590-b1bd-259bf1e2548b",
+          "country": "united states",
+          "locality": "the notch",
+          "collectioncode": "cbs",
+          "canonicalname": "acer spicatum",
+          "eventdate": "1907-09-26",
+          "flags": [
+            "dwc_taxonrank_added",
+            "dwc_multimedia_added",
+            "gbif_reference_added",
+            "gbif_canonicalname_added",
+            "dwc_country_replaced",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_scientificnameauthorship_replaced",
+            "dwc_parentnameusageid_added",
+            "dwc_phylum_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_class_replaced",
+            "dwc_continent_added"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "urn:uuid:6c916224-a076-40d4-bb04-7670f7e7cfa2",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\urn:uuid:9fc10d21-7148-4590-b1bd-259bf1e2548b",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\110498"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e81e2a6e-36f8-44e1-a80a-dbabcf7c1a41",
+        "_score": 1,
+        "_source": {
+          "family": "sapindaceae",
+          "recordset": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+          "dqs": 0.13043478260869565,
+          "stateprovince": "75 paris",
+          "phylum": "tracheophyta",
+          "catalognumber": "p00047742",
+          "taxonrank": "species",
+          "specificepithet": "pseudoplatanus",
+          "verbatimlocality": "terrasse du collège henry iv",
+          "datemodified": "2021-04-19T22:06:14.550973+00:00",
+          "uuid": "e81e2a6e-36f8-44e1-a80a-dbabcf7c1a41",
+          "countrycode": "fra",
+          "basisofrecord": "preservedspecimen",
+          "collector": "crevoisier, e.",
+          "institutioncode": "mnhn",
+          "mediarecords": [
+            "39c5f12d-5933-4def-97d6-3019f6bf54d4",
+            "42747526-ebb3-4959-ae2b-7607c00281b1"
+          ],
+          "continent": "europe",
+          "etag": "68040292ab2202cd6418889587e8cf35fa856f82",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "taxonid": "3189870",
+          "scientificname": "acer pseudoplatanus l.",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "idigbio:dateModified": "2021-04-19T22:06:14.550973",
+            "dwc:countryCode": "fr",
+            "dwc:kingdom": "plantae",
+            "dwc:recordedBy": "Crevoisier, E.",
+            "idigbio:uuid": "e81e2a6e-36f8-44e1-a80a-dbabcf7c1a41",
+            "flag_dwc_multimedia_added": true,
+            "gbif:canonicalname": "acer pseudoplatanus",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "L.",
+            "idigbio:recordIds": [
+              "616857b7-f952-44ef-9b6f-576dc1e65b51\\http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742"
+            ],
+            "dwc:occurrenceID": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+            "flag_dwc_specificepithet_added": true,
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "id": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+            "dwc:stateProvince": "75 Paris",
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dwc:country": "France",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "gnu free documentation license",
+                "dcterms:title": "a. pseudoplatanus in the bergpark wilhelmshöhe, kassel",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pseudoplatanus_005.jpg",
+                "coreid": "3189870",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/c/cd/acer_pseudoplatanus_005.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "deutsch: bergahorn (acer pseudoplatanus) im schlosspark wilhelmshöhe, kassel, hessen, deutschland english: sycamore maple (acer pseudoplatanus) in the schlosspark wilhelmshöhe, kassel, hesse, germany",
+                "dcterms:creator": "willow",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "public domain mark 1.0",
+                "dcterms:title": "berg-ahorn (acer pseudoplatanus)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pseudoplatanusaa.jpg",
+                "coreid": "3189870",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/f/fb/acer_pseudoplatanusaa.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "amsterdam, johannes allart, 1802 [-1808]",
+                "dcterms:creator": "user:mpf",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "68040292ab2202cd6418889587e8cf35fa856f82",
+            "dwc:collectionCode": "P",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "europe",
+            "dwc:family": "Sapindaceae",
+            "flag_dwc_continent_added": true,
+            "flag_dwc_parentnameusageid_added": true,
+            "dwc:specificepithet": "pseudoplatanus",
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "fra",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "39c5f12d-5933-4def-97d6-3019f6bf54d4",
+                "42747526-ebb3-4959-ae2b-7607c00281b1"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:order": "sapindales",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_phylum_added": true,
+            "gbif:genericname": "acer",
+            "dwc:locality": "Paris",
+            "dwc:fieldNotes": "Dicotylédone - acérinée - acer / fleurs en panicules racémiformes pendantes . feuilles blanches en dessous.",
+            "dwc:institutionCode": "MNHN",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "P00047742",
+            "dwc:taxonid": "3189870",
+            "gbif:Identifier": [
+              {
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+                "dcterms:identifier": "E6046C4ADB0D4075BF7D0D7AF082DCF0",
+                "dcterms:subject": "e-recolnat"
+              }
+            ],
+            "dwc:taxonrank": "species",
+            "dwc:Identification": [
+              {
+                "dwc:taxonID": "SONNERAT|13980",
+                "dwc:identificationVerificationStatus": "1",
+                "dwc:specificEpithet": "pseudoplatanus",
+                "dwc:scientificNameAuthorship": "L.",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+                "dwc:identificationID": "SONNERAT|66764",
+                "dwc:genus": "Acer",
+                "dwc:scientificName": "Acer pseudoplatanus L.",
+                "dwc:higherClassification": "Acer;Sapindaceae",
+                "dwc:family": "Sapindaceae"
+              },
+              {
+                "dwc:taxonID": "SONNERAT|13980",
+                "dwc:identificationRemarks": "operation de numerisation 2010-2012",
+                "dwc:specificEpithet": "pseudoplatanus",
+                "dwc:identificationID": "SONNERAT|7170284",
+                "dwc:identificationVerificationStatus": "0",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+                "dwc:scientificNameAuthorship": "L.",
+                "dwc:genus": "Acer",
+                "dwc:scientificName": "Acer pseudoplatanus L.",
+                "dwc:higherClassification": "Acer;Sapindaceae",
+                "dwc:family": "Sapindaceae"
+              }
+            ],
+            "dwc:month": "5",
+            "flag_dwc_order_added": true,
+            "dwc:verbatimLocality": "terrasse du collège Henry IV",
+            "gbif:reference": [
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "l. (1753) in: sp. pl.: 1054"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "dwc:phylum": "tracheophyta",
+            "dwc:preparations": "hb",
+            "flag_dwc_class_added": true,
+            "dcterms:modified": "2015-09-15 16:03:36.0",
+            "dwc:scientificName": "Acer pseudoplatanus L.",
+            "dwc:day": "20",
+            "flag_dwc_kingdom_added": true,
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189870",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero montano"
+              },
+              {
+                "dwc:countrycode": "dk",
+                "dwc:country": "denmark",
+                "dwc:vernacularname": "ahorn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "da"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "bergahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "bergahorn",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "berg-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "berg-ahorn",
+                "coreid": "3189870",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "bergahorn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "berg-ahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "érable sycomore",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable sycomore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "fr",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "érable sycomore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "false planetree"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "gewone esdoorn",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "gewone esdoorn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "great maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen lo&zcaron;noplatanovyj"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "platanlønn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nb"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "platanlønn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "scottish maple"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "sycamore",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sycamore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sycamore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "tysklönn"
+              },
+              {
+                "dwc:countrycode": "se",
+                "dwc:country": "sweden",
+                "dwc:vernacularname": "tysklönn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "vuorivaahtera",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "fi"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "vuorivaahtera",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              }
+            ]
+          },
+          "data": {
+            "dwc:countryCode": "fr",
+            "dwc:recordedBy": "Crevoisier, E.",
+            "dwc:scientificNameAuthorship": "L.",
+            "dwc:occurrenceID": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+            "id": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+            "dwc:stateProvince": "75 Paris",
+            "dwc:country": "France",
+            "dwc:collectionCode": "P",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:preparations": "hb",
+            "dwc:locality": "Paris",
+            "dwc:fieldNotes": "Dicotylédone - acérinée - acer / fleurs en panicules racémiformes pendantes . feuilles blanches en dessous.",
+            "dwc:institutionCode": "MNHN",
+            "dwc:catalogNumber": "P00047742",
+            "gbif:Identifier": [
+              {
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+                "dcterms:identifier": "E6046C4ADB0D4075BF7D0D7AF082DCF0",
+                "dcterms:subject": "e-recolnat"
+              }
+            ],
+            "dwc:Identification": [
+              {
+                "dwc:taxonID": "SONNERAT|13980",
+                "dwc:identificationVerificationStatus": "1",
+                "dwc:specificEpithet": "pseudoplatanus",
+                "dwc:scientificNameAuthorship": "L.",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+                "dwc:identificationID": "SONNERAT|66764",
+                "dwc:genus": "Acer",
+                "dwc:scientificName": "Acer pseudoplatanus L.",
+                "dwc:higherClassification": "Acer;Sapindaceae",
+                "dwc:family": "Sapindaceae"
+              },
+              {
+                "dwc:taxonID": "SONNERAT|13980",
+                "dwc:identificationRemarks": "operation de numerisation 2010-2012",
+                "dwc:specificEpithet": "pseudoplatanus",
+                "dwc:scientificNameAuthorship": "L.",
+                "dwc:identificationVerificationStatus": "0",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+                "dwc:identificationID": "SONNERAT|7170284",
+                "dwc:genus": "Acer",
+                "dwc:scientificName": "Acer pseudoplatanus L.",
+                "dwc:higherClassification": "Acer;Sapindaceae",
+                "dwc:family": "Sapindaceae"
+              }
+            ],
+            "dwc:month": "5",
+            "dwc:verbatimLocality": "terrasse du collège Henry IV",
+            "dwc:family": "Sapindaceae",
+            "dcterms:modified": "2015-09-15 16:03:36.0",
+            "dwc:scientificName": "Acer pseudoplatanus L.",
+            "dwc:day": "20"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+          "country": "france",
+          "locality": "paris",
+          "collectioncode": "p",
+          "canonicalname": "acer pseudoplatanus",
+          "flags": [
+            "dwc_taxonrank_added",
+            "dwc_multimedia_added",
+            "gbif_reference_added",
+            "dwc_specificepithet_added",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "gbif_vernacularname_added",
+            "dwc_continent_added",
+            "dwc_parentnameusageid_added",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "gbif_canonicalname_added",
+            "dwc_phylum_added",
+            "gbif_taxon_corrected",
+            "dwc_order_added",
+            "dwc_class_added",
+            "dwc_kingdom_added"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "616857b7-f952-44ef-9b6f-576dc1e65b51\\http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "de605db9-65a3-4fd0-950b-82a88c6d2828",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lat": 41.56444,
+            "lon": -72.79527
+          },
+          "family": "sapindaceae",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.2463768115942029,
+          "stateprovince": "connecticut",
+          "institutioncode": "uconn",
+          "municipality": "meriden",
+          "county": "new haven county",
+          "phylum": "tracheophyta",
+          "catalognumber": "conn00078635",
+          "startdayofyear": 138,
+          "taxonrank": "species",
+          "specificepithet": "pensylvanicum",
+          "continent": "north america",
+          "uuid": "de605db9-65a3-4fd0-950b-82a88c6d2828",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "g.s. torrey",
+          "commonnames": [
+            "Moosewood; Snake-Bark Maple; Striped Maple"
+          ],
+          "mediarecords": [
+            "8ad43dd0-da79-4834-bcb6-442793fbbaa2"
+          ],
+          "datemodified": "2014-09-09T02:58:24.436000+00:00",
+          "datecollected": "1958-05-18T00:00:00+00:00",
+          "etag": "f5d5c7a1a14fc111ff24aeecb39c9ec51e4d431d",
+          "recordnumber": "5528",
+          "hasImage": true,
+          "kingdom": "plantae",
+          "highertaxon": "plantae; dicotyledonae; sapindales; aceraceae",
+          "commonname": "moosewood; snake-bark maple; striped maple",
+          "taxonid": "3189836",
+          "scientificname": "acer pensylvanicum l.",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "flag_dwc_family_replaced": true,
+            "dwc:specificEpithet": "pensylvanicum",
+            "idigbio:dateModified": "2014-09-09T02:58:24.436000",
+            "dwc:countryCode": "US",
+            "dwc:county": "New Haven County",
+            "dwc:recordedBy": "G.S. Torrey",
+            "idigbio:uuid": "de605db9-65a3-4fd0-950b-82a88c6d2828",
+            "dwc:georeferenceSources": "no date. Topozone. TopoZone.com © Maps a la carte, Inc. - All rights reserved.",
+            "dwc:order": "Sapindales",
+            "flag_gbif_reference_added": true,
+            "idigbio:isocountrycode": "usa",
+            "flag_dwc_scientificnameauthorship_added": true,
+            "dwc:locality": "Trap ridge woods, Cathole Pass, Meriden, CT.",
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00078635"
+            ],
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00078635",
+            "dwc:scientificName": "Acer pensylvanicum L.",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189836",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "amerikansk strimlönn"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "bois barré"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "bois d'orignal"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable bois-barré"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable de pennsylvanie"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "goosefoot"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "moose maple"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "moosewood"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "moosewood"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "moosewood"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "pennsylvanischer ahorn"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "snakebark maple"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "snakebark maple"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "streifen-ahorn"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "streifenahorn"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "striped maple"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "striped maple"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "striped maple"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "striped maple"
+              }
+            ],
+            "flag_dwc_kingdom_replaced": true,
+            "flag_gbif_genericname_added": true,
+            "flag_dwc_parentnameusageid_added": true,
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dwc:stateProvince": "Connecticut",
+            "flag_dwc_taxonomicstatus_added": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:eventDate": "1958-05-18",
+            "dwc:country": "united states",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "public domain",
+                "dcterms:title": "striped maple leaves, cranberry wilderness, west virginia",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:moosewood_leaves.jpg",
+                "coreid": "3189836",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/7/72/moosewood_leaves.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "english: photo taken july, 2005, cranberry wilderness, west virginia",
+                "dcterms:creator": "original uploader was jaknouse at en.wikipedia",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "creative commons attribution share alike 3.0 migrated",
+                "dcterms:title": "streifen-ahorn (acer pensylvanicum)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pensylvanicum3.jpg",
+                "coreid": "3189836",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/7/74/acer_pensylvanicum3.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "f5d5c7a1a14fc111ff24aeecb39c9ec51e4d431d",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "41°32' 112\" N",
+            "gbif:reference": [
+              {
+                "coreid": "3189836",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "l. (1753) in: sp. pl. 1055"
+              }
+            ],
+            "dwc:kingdom": "plantae",
+            "dwc:decimalLatitude": "41.56444",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "sapindaceae",
+            "flag_dwc_continent_added": true,
+            "flag_dwc_country_replaced": true,
+            "dwc:class": "magnoliopsida",
+            "dwc:municipality": "Meriden",
+            "flag_dwc_taxonid_added": true,
+            "dwc:previousIdentifications": "Acer pensylvanicum L.",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "8ad43dd0-da79-4834-bcb6-442793fbbaa2"
+              ]
+            },
+            "flag_dwc_class_added": true,
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:vernacularName": "Moosewood; Snake-Bark Maple; Striped Maple",
+            "gbif:canonicalname": "acer pensylvanicum",
+            "dwc:scientificnameauthorship": "l.",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_phylum_added": true,
+            "gbif:genericname": "acer",
+            "dwc:locationAccordingTo": "seconds added from gazetteer",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "UConn",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:reproductiveCondition": "flowering",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Sapindales; Aceraceae",
+            "dwc:catalogNumber": "CONN00078635",
+            "dwc:taxonid": "3189836",
+            "dwc:taxonrank": "species",
+            "dwc:higherGeography": "USA; Connecticut; New Haven County; Meriden",
+            "dwc:month": "5",
+            "dwc:decimalLongitude": "-72.79527",
+            "dwc:verbatimLongitude": "72°47' 43\" W",
+            "dwc:verbatimEventDate": "18-May-58",
+            "dwc:phylum": "tracheophyta",
+            "dwc:recordNumber": "5528",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "flag_dwc_multimedia_added": true,
+            "flag_dwc_datasetid_replaced": true,
+            "dcterms:modified": "2009-05-21T00:00-0500",
+            "dwc:coordinateUncertaintyInMeters": "20000",
+            "dwc:day": "18",
+            "dwc:datasetID": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dwc:year": "1958"
+          },
+          "hasMedia": true,
+          "coordinateuncertainty": 20000,
+          "data": {
+            "dwc:specificEpithet": "pensylvanicum",
+            "dwc:countryCode": "US",
+            "dwc:county": "New Haven County",
+            "dwc:recordedBy": "G.S. Torrey",
+            "dwc:georeferenceSources": "no date. Topozone. TopoZone.com © Maps a la carte, Inc. - All rights reserved.",
+            "dwc:order": "Sapindales",
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00078635",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1958-05-18",
+            "dwc:country": "USA",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "41°32' 112\" N",
+            "dwc:kingdom": "Dicotyledonae",
+            "dwc:decimalLatitude": "41.56444",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Aceraceae",
+            "dwc:coordinateUncertaintyInMeters": "20000",
+            "dwc:municipality": "Meriden",
+            "dwc:previousIdentifications": "Acer pensylvanicum L.",
+            "dwc:vernacularName": "Moosewood; Snake-Bark Maple; Striped Maple",
+            "dwc:locationAccordingTo": "seconds added from gazetteer",
+            "dwc:locality": "Trap ridge woods, Cathole Pass, Meriden, CT.",
+            "dwc:institutionCode": "UConn",
+            "dwc:reproductiveCondition": "flowering",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Sapindales; Aceraceae",
+            "dwc:catalogNumber": "CONN00078635",
+            "dwc:higherGeography": "USA; Connecticut; New Haven County; Meriden",
+            "dwc:month": "5",
+            "dwc:decimalLongitude": "-72.79527",
+            "dwc:verbatimLongitude": "72°47' 43\" W",
+            "dwc:verbatimEventDate": "18-May-58",
+            "dwc:recordNumber": "5528",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "dcterms:modified": "2009-05-21T00:00-0500",
+            "dwc:scientificName": "Acer pensylvanicum L.",
+            "dwc:day": "18",
+            "dwc:datasetID": "68670",
+            "dwc:year": "1958"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:catalog:uconn:conn:conn00078635",
+          "country": "united states",
+          "locality": "trap ridge woods, cathole pass, meriden, ct.",
+          "collectioncode": "conn",
+          "canonicalname": "acer pensylvanicum",
+          "eventdate": "1958-05-18",
+          "flags": [
+            "geopoint_datum_missing",
+            "dwc_taxonrank_added",
+            "dwc_family_replaced",
+            "gbif_reference_added",
+            "dwc_scientificnameauthorship_added",
+            "dwc_kingdom_replaced",
+            "gbif_genericname_added",
+            "dwc_parentnameusageid_added",
+            "dwc_taxonomicstatus_added",
+            "dwc_continent_added",
+            "dwc_country_replaced",
+            "dwc_taxonid_added",
+            "dwc_class_added",
+            "idigbio_isocountrycode_added",
+            "gbif_canonicalname_added",
+            "dwc_phylum_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_multimedia_added",
+            "dwc_datasetid_replaced"
+          ],
+          "verbatimeventdate": "18-may-58",
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00078635"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "df6e800e-e2e1-4fcf-9940-fb738b70e7ed",
+        "_score": 1,
+        "_source": {
+          "family": "sapindaceae",
+          "recordset": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "stateprovince": "massachusetts",
+          "phylum": "tracheophyta",
+          "catalognumber": "yu.076227",
+          "startdayofyear": 134,
+          "taxonrank": "species",
+          "specificepithet": "saccharum",
+          "continent": "north america",
+          "uuid": "df6e800e-e2e1-4fcf-9940-fb738b70e7ed",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "c. w. swan",
+          "institutioncode": "yale peabody museum of natural history",
+          "mediarecords": [
+            "ef158cc6-2f94-48e5-92be-e608631f990f"
+          ],
+          "datemodified": "2016-01-27T21:25:22.884015+00:00",
+          "datecollected": "1883-05-14T00:00:00+00:00",
+          "etag": "40afcc8743e5335c309c3e97915d13e0c8ec57eb",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "collectionid": "urn:lsid:biocol.org:col:14791",
+          "taxonid": "3189859",
+          "scientificname": "acer saccharum",
+          "indexData": {
+            "dwc:startDayOfYear": "134",
+            "flag_dwc_taxonrank_added": true,
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:title": "zucker-ahorn (acer saccharum)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_saccharum_jpg01.jpg",
+                "coreid": "3189859",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/0/04/acer_saccharum_jpg01.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "français : meise (belgique), jardin national botanique de belgique - acer saccharum - Érable à sucre. english: meise (belgium), national garden of belgium - plant palace - acer saccharum - sugarmaple. nederlands: meise (belgië), nationale plantentuin van belgië - plantenpaleis – acer saccharum - suikeresdoorn. walon: meise (bèljike), djârdin national di bèljike - acer saccharum - aube a suke.",
+                "dcterms:creator": "jean-pol grandmont",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:title": "sugar maple in morton arboretum",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_saccharum.jpg",
+                "coreid": "3189859",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/2/26/acer_saccharum.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "sugar maple tree, acer saccharum. specimen at morton arboretum, lisle, illinois. accession 258-78-1.",
+                "dcterms:creator": "bruce marlin",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "dwc:specificEpithet": "saccharum",
+            "idigbio:dateModified": "2016-01-27T21:25:22.884015",
+            "dwc:kingdom": "Plantae",
+            "dwc:recordedBy": "C. W. Swan",
+            "idigbio:uuid": "df6e800e-e2e1-4fcf-9940-fb738b70e7ed",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807945",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "marshall",
+            "idigbio:recordIds": [
+              "urn:uuid:3e7dd858-0ee0-44c4-98c4-72a95a275b0c",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\urn:uuid:6504d3db-a170-45ef-af81-c01de16d6f85",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\807945"
+            ],
+            "dwc:occurrenceID": "urn:uuid:6504d3db-a170-45ef-af81-c01de16d6f85",
+            "flag_gbif_canonicalname_added": true,
+            "id": "807945",
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "symbiota:recordEnteredBy": "Bob Swerling",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+            "dwc:stateProvince": "Massachusetts",
+            "dwc:eventDate": "1883-05-14",
+            "flag_dwc_scientificnameauthorship_replaced": true,
+            "dwc:collectionID": "urn:lsid:biocol.org:col:14791",
+            "dwc:country": "united states",
+            "idigbio:recordId": "urn:uuid:3e7dd858-0ee0-44c4-98c4-72a95a275b0c",
+            "idigbio:etag": "40afcc8743e5335c309c3e97915d13e0c8ec57eb",
+            "dwc:collectionCode": "YU",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_phylum_replaced": true,
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "usa",
+            "gbif:reference": [
+              {
+                "coreid": "3189834",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "idigbio:siblings": {
+              "mediarecord": [
+                "ef158cc6-2f94-48e5-92be-e608631f990f"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "gbif:canonicalname": "acer saccharum",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "acer",
+            "flag_dwc_multimedia_added": true,
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "YU.076227",
+            "dwc:taxonid": "3189859",
+            "dwc:taxonrank": "species",
+            "dwc:Identification": [
+              {
+                "coreid": "807945",
+                "dwc:identificationRemarks": "0",
+                "idigbio:recordId": "urn:uuid:f82d1222-8a7b-4349-9b71-189e31334b13",
+                "dwc:scientificName": "Acer saccharum Marsh.",
+                "dwc:scientificNameAuthorship": "Marsh."
+              }
+            ],
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189859",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable à sucre"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable franc"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable franche"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "hard maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:source": "korean peninsula flora",
+                "dwc:vernacularname": "설탕단풍"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "rock maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "sugar maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "sugar maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "en",
+                "dcterms:source": "english wikipedia - species pages",
+                "dwc:vernacularname": "sugar maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sugar maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sugar maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "zucker-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "zucker-ahorn",
+                "coreid": "3189859",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              }
+            ],
+            "dwc:month": "5",
+            "flag_dwc_class_replaced": true,
+            "dwc:verbatimEventDate": "5-14-83",
+            "flag_dwc_continent_added": true,
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dcterms:modified": "2015-06-17 13:01:45",
+            "dwc:scientificName": "Acer saccharum",
+            "dwc:day": "14",
+            "dwc:year": "1883"
+          },
+          "data": {
+            "dwc:startDayOfYear": "134",
+            "dwc:specificEpithet": "saccharum",
+            "dwc:kingdom": "Plantae",
+            "dwc:recordedBy": "C. W. Swan",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807945",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:occurrenceID": "urn:uuid:6504d3db-a170-45ef-af81-c01de16d6f85",
+            "dwc:scientificNameAuthorship": "Marsh.",
+            "id": "807945",
+            "symbiota:recordEnteredBy": "Bob Swerling",
+            "dwc:stateProvince": "Massachusetts",
+            "dwc:eventDate": "1883-05-14",
+            "dwc:collectionID": "urn:lsid:biocol.org:col:14791",
+            "dwc:country": "United States of America",
+            "idigbio:recordId": "urn:uuid:3e7dd858-0ee0-44c4-98c4-72a95a275b0c",
+            "dwc:collectionCode": "YU",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:phylum": "Charophyta",
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "dwc:class": "Equisetopsida",
+            "dwc:catalogNumber": "YU.076227",
+            "dwc:Identification": [
+              {
+                "coreid": "807945",
+                "dwc:identificationRemarks": "0",
+                "idigbio:recordId": "urn:uuid:f82d1222-8a7b-4349-9b71-189e31334b13",
+                "dwc:scientificName": "Acer saccharum Marsh.",
+                "dwc:scientificNameAuthorship": "Marsh."
+              }
+            ],
+            "dwc:month": "5",
+            "dwc:verbatimEventDate": "5-14-83",
+            "dcterms:modified": "2015-06-17 13:01:45",
+            "dwc:scientificName": "Acer saccharum",
+            "dwc:day": "14",
+            "dwc:year": "1883"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:6504d3db-a170-45ef-af81-c01de16d6f85",
+          "country": "united states",
+          "dqs": 0.18840579710144928,
+          "collectioncode": "yu",
+          "canonicalname": "acer saccharum",
+          "eventdate": "1883-05-14",
+          "flags": [
+            "dwc_taxonrank_added",
+            "gbif_reference_added",
+            "gbif_canonicalname_added",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_scientificnameauthorship_replaced",
+            "dwc_parentnameusageid_added",
+            "dwc_phylum_replaced",
+            "dwc_country_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "dwc_multimedia_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_class_replaced",
+            "dwc_continent_added"
+          ],
+          "verbatimeventdate": "5-14-83",
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "urn:uuid:3e7dd858-0ee0-44c4-98c4-72a95a275b0c",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\urn:uuid:6504d3db-a170-45ef-af81-c01de16d6f85",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\807945"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e0690554-8c60-494b-85f0-d07553b9e59e",
+        "_score": 1,
+        "_source": {
+          "family": "sapindaceae",
+          "recordset": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "dqs": 0.2463768115942029,
+          "stateprovince": "connecticut",
+          "municipality": "wethersfield",
+          "county": "hartford county",
+          "phylum": "tracheophyta",
+          "catalognumber": "cbs.025833",
+          "startdayofyear": 145,
+          "taxonrank": "species",
+          "specificepithet": "pseudoplatanus",
+          "continent": "north america",
+          "uuid": "e0690554-8c60-494b-85f0-d07553b9e59e",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "hugh s. clark",
+          "institutioncode": "yale peabody museum of natural history",
+          "mediarecords": [
+            "c9f1880b-39de-4aaf-95d1-2365f9cae04d"
+          ],
+          "datemodified": "2016-03-21T21:43:25.444854+00:00",
+          "datecollected": "1901-05-25T00:00:00+00:00",
+          "etag": "10b5d8c49419e7524281708a71780f39e898f68c",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "collectionid": "http://grbio.org/cool/x0m9-a3bs",
+          "taxonid": "3189870",
+          "scientificname": "acer pseudoplatanus",
+          "indexData": {
+            "dwc:startDayOfYear": "145",
+            "flag_dwc_taxonrank_added": true,
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "gnu free documentation license",
+                "dcterms:title": "a. pseudoplatanus in the bergpark wilhelmshöhe, kassel",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pseudoplatanus_005.jpg",
+                "coreid": "3189870",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/c/cd/acer_pseudoplatanus_005.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "deutsch: bergahorn (acer pseudoplatanus) im schlosspark wilhelmshöhe, kassel, hessen, deutschland english: sycamore maple (acer pseudoplatanus) in the schlosspark wilhelmshöhe, kassel, hesse, germany",
+                "dcterms:creator": "willow",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "public domain mark 1.0",
+                "dcterms:title": "berg-ahorn (acer pseudoplatanus)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pseudoplatanusaa.jpg",
+                "coreid": "3189870",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/f/fb/acer_pseudoplatanusaa.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "amsterdam, johannes allart, 1802 [-1808]",
+                "dcterms:creator": "user:mpf",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "dwc:specificEpithet": "pseudoplatanus",
+            "idigbio:dateModified": "2016-03-21T21:43:25.444854",
+            "dwc:county": "Hartford County",
+            "dwc:recordedBy": "Hugh S. Clark",
+            "idigbio:uuid": "e0690554-8c60-494b-85f0-d07553b9e59e",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110335",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "L.",
+            "idigbio:recordIds": [
+              "urn:uuid:c183a846-5fe6-4901-8e6a-79147feead7d",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\urn:uuid:bc642633-9440-430f-a6e4-b2c21fc10237",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\110335"
+            ],
+            "dwc:occurrenceID": "urn:uuid:bc642633-9440-430f-a6e4-b2c21fc10237",
+            "flag_gbif_canonicalname_added": true,
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189870",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero montano"
+              },
+              {
+                "dwc:countrycode": "dk",
+                "dwc:country": "denmark",
+                "dwc:vernacularname": "ahorn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "da"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "bergahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "bergahorn",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "berg-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "berg-ahorn",
+                "coreid": "3189870",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "bergahorn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "berg-ahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "érable sycomore",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable sycomore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "fr",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "érable sycomore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "false planetree"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "gewone esdoorn",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "gewone esdoorn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "great maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen lo&zcaron;noplatanovyj"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "platanlønn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nb"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "platanlønn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "scottish maple"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "sycamore",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sycamore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sycamore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "tysklönn"
+              },
+              {
+                "dwc:countrycode": "se",
+                "dwc:country": "sweden",
+                "dwc:vernacularname": "tysklönn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "vuorivaahtera",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "fi"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "vuorivaahtera",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              }
+            ],
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1901-05-25",
+            "dwc:collectionID": "http://grbio.org/cool/x0m9-a3bs",
+            "dwc:country": "united states",
+            "idigbio:recordId": "urn:uuid:c183a846-5fe6-4901-8e6a-79147feead7d",
+            "idigbio:etag": "10b5d8c49419e7524281708a71780f39e898f68c",
+            "dwc:collectionCode": "CBS",
+            "id": "110335",
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "41.7012",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_phylum_replaced": true,
+            "dwc:municipality": "Wethersfield",
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "usa",
+            "dwc:geodeticDatum": "WGS84",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "c9f1880b-39de-4aaf-95d1-2365f9cae04d"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "gbif:canonicalname": "acer pseudoplatanus",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "acer",
+            "flag_dwc_multimedia_added": true,
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "CBS.025833",
+            "dwc:taxonid": "3189870",
+            "dwc:taxonrank": "species",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:decimalLongitude": "-72.6704",
+            "dwc:scientificName": "Acer pseudoplatanus",
+            "dwc:month": "5",
+            "flag_dwc_class_replaced": true,
+            "gbif:reference": [
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "l. (1753) in: sp. pl.: 1054"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "flag_dwc_continent_added": true,
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dcterms:modified": "2011-07-20 00:00:00",
+            "dwc:coordinateUncertaintyInMeters": "4657",
+            "dwc:day": "25",
+            "dwc:year": "1901"
+          },
+          "coordinateuncertainty": 4657,
+          "data": {
+            "dwc:startDayOfYear": "145",
+            "dwc:specificEpithet": "pseudoplatanus",
+            "dwc:county": "Hartford County",
+            "dwc:recordedBy": "Hugh S. Clark",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110335",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:occurrenceID": "urn:uuid:bc642633-9440-430f-a6e4-b2c21fc10237",
+            "dwc:scientificNameAuthorship": "L.",
+            "id": "110335",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1901-05-25",
+            "dwc:collectionID": "http://grbio.org/cool/x0m9-a3bs",
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "dwc:country": "USA",
+            "idigbio:recordId": "urn:uuid:c183a846-5fe6-4901-8e6a-79147feead7d",
+            "dwc:collectionCode": "CBS",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "41.7012",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:municipality": "Wethersfield",
+            "dwc:phylum": "Charophyta",
+            "dwc:geodeticDatum": "WGS84",
+            "dwc:class": "Equisetopsida",
+            "dwc:catalogNumber": "CBS.025833",
+            "dwc:month": "5",
+            "dwc:decimalLongitude": "-72.6704",
+            "dwc:coordinateUncertaintyInMeters": "4657",
+            "dcterms:modified": "2011-07-20 00:00:00",
+            "dwc:scientificName": "Acer pseudoplatanus",
+            "dwc:day": "25",
+            "dwc:year": "1901"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:bc642633-9440-430f-a6e4-b2c21fc10237",
+          "country": "united states",
+          "geopoint": {
+            "lat": 41.7012,
+            "lon": -72.6704
+          },
+          "collectioncode": "cbs",
+          "canonicalname": "acer pseudoplatanus",
+          "eventdate": "1901-05-25",
+          "flags": [
+            "dwc_taxonrank_added",
+            "gbif_reference_added",
+            "gbif_canonicalname_added",
+            "dwc_country_replaced",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_parentnameusageid_added",
+            "dwc_phylum_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "dwc_multimedia_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_class_replaced",
+            "dwc_continent_added"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "urn:uuid:c183a846-5fe6-4901-8e6a-79147feead7d",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\urn:uuid:bc642633-9440-430f-a6e4-b2c21fc10237",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\110335"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7a9fda29-5231-456c-8d59-bef531e36e8e",
+        "_score": 1,
+        "_source": {
+          "family": "sapindaceae",
+          "recordset": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "stateprovince": "massachusetts",
+          "municipality": "milton",
+          "county": "norfolk",
+          "phylum": "tracheophyta",
+          "catalognumber": "yu.076200",
+          "startdayofyear": 127,
+          "taxonrank": "species",
+          "specificepithet": "platanoides",
+          "continent": "north america",
+          "uuid": "7a9fda29-5231-456c-8d59-bef531e36e8e",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "c. w. swan",
+          "institutioncode": "yale peabody museum of natural history",
+          "mediarecords": [
+            "8e25027c-64e7-445c-aaae-e80df0c67e72"
+          ],
+          "datemodified": "2016-01-27T21:25:22.884015+00:00",
+          "datecollected": "1883-05-07T00:00:00+00:00",
+          "etag": "1f631099cc371c214fff4041e849dddb1c5078f7",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "collectionid": "urn:lsid:biocol.org:col:14791",
+          "taxonid": "3189846",
+          "scientificname": "acer platanoides",
+          "indexData": {
+            "dwc:startDayOfYear": "127",
+            "flag_dwc_taxonrank_added": true,
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:title": "spitz-ahorn (acer platanoides)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:spitz-ahorn_(acer_platanoides)_1.jpg",
+                "coreid": "3189846",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/0/0e/spitz-ahorn_%28acer_platanoides%29_1.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:title": "norway maple leaves",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:spitz-ahorn(mbo).jpg",
+                "coreid": "3189846",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/6/60/spitz-ahorn%28mbo%29.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "deutsch: spitz-ahorn (acer platanoides)",
+                "dcterms:creator": "martin bobka (= martin120)",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "dwc:specificEpithet": "platanoides",
+            "idigbio:dateModified": "2016-01-27T21:25:22.884015",
+            "dwc:county": "Norfolk",
+            "dwc:recordedBy": "C. W. Swan",
+            "idigbio:uuid": "7a9fda29-5231-456c-8d59-bef531e36e8e",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807914",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "L.",
+            "idigbio:recordIds": [
+              "urn:uuid:f0ea36c3-e71f-45ff-be75-61138b7ecec3",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\urn:uuid:c6b0657c-34e4-46bf-b303-844dd2828b22",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\807914"
+            ],
+            "dwc:occurrenceID": "urn:uuid:c6b0657c-34e4-46bf-b303-844dd2828b22",
+            "flag_gbif_canonicalname_added": true,
+            "id": "807914",
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "symbiota:recordEnteredBy": "Bob Swerling",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+            "dwc:stateProvince": "Massachusetts",
+            "dwc:eventDate": "1883-05-07",
+            "dwc:collectionID": "urn:lsid:biocol.org:col:14791",
+            "dwc:country": "united states",
+            "idigbio:recordId": "urn:uuid:f0ea36c3-e71f-45ff-be75-61138b7ecec3",
+            "idigbio:etag": "1f631099cc371c214fff4041e849dddb1c5078f7",
+            "dwc:collectionCode": "YU",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:kingdom": "Plantae",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_phylum_replaced": true,
+            "dwc:municipality": "Milton",
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "usa",
+            "gbif:reference": [
+              {
+                "coreid": "3189846",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "idigbio:siblings": {
+              "mediarecord": [
+                "8e25027c-64e7-445c-aaae-e80df0c67e72"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "gbif:canonicalname": "acer platanoides",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "acer",
+            "flag_dwc_multimedia_added": true,
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "YU.076200",
+            "dwc:taxonid": "3189846",
+            "dwc:taxonrank": "species",
+            "dwc:Identification": [
+              {
+                "coreid": "807914",
+                "dwc:identificationRemarks": "0",
+                "idigbio:recordId": "urn:uuid:b484aab4-0821-4654-926b-a986ee01b640",
+                "dwc:scientificName": "Acer platanoides L.",
+                "dwc:scientificNameAuthorship": "L."
+              }
+            ],
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189846",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero riccio"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable de norvège"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "érable plane",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable plane"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "érable plane"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "global invasive species database",
+                "dwc:vernacularname": "érable plane"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable platanoïde"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen ostrolistnyj"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen platanovidnyj"
+              },
+              {
+                "dwc:countrycode": "se",
+                "dwc:country": "sweden",
+                "dwc:vernacularname": "lönn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "(metsä)vaahtera",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "fi"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "(metsä)vaahtera",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "noorse esdoorn",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "noorse esdoorn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "norway maple",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "global invasive species database",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "skogslönn"
+              },
+              {
+                "dwc:countrycode": "dk",
+                "dwc:country": "denmark",
+                "dwc:vernacularname": "spids-løn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "da"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "spisslønn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nb"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "spisslønn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "spitzahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "spitzahorn",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "spitz-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "spitz-ahorn",
+                "coreid": "3189846",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "spitzahorn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "spitz-ahorn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "global invasive species database",
+                "dwc:vernacularname": "spitzahorn"
+              }
+            ],
+            "dwc:month": "5",
+            "flag_dwc_class_replaced": true,
+            "dwc:verbatimEventDate": "5-7-83 | 6-28-83",
+            "flag_dwc_continent_added": true,
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dcterms:modified": "2015-10-29 10:04:57",
+            "dwc:scientificName": "Acer platanoides",
+            "dwc:day": "7",
+            "dwc:year": "1883"
+          },
+          "data": {
+            "dwc:startDayOfYear": "127",
+            "dwc:specificEpithet": "platanoides",
+            "dwc:county": "Norfolk",
+            "dwc:recordedBy": "C. W. Swan",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807914",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:occurrenceID": "urn:uuid:c6b0657c-34e4-46bf-b303-844dd2828b22",
+            "dwc:scientificNameAuthorship": "L.",
+            "id": "807914",
+            "symbiota:recordEnteredBy": "Bob Swerling",
+            "dwc:stateProvince": "Massachusetts",
+            "dwc:eventDate": "1883-05-07",
+            "dwc:collectionID": "urn:lsid:biocol.org:col:14791",
+            "dwc:country": "United States of America",
+            "idigbio:recordId": "urn:uuid:f0ea36c3-e71f-45ff-be75-61138b7ecec3",
+            "dwc:collectionCode": "YU",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:kingdom": "Plantae",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:municipality": "Milton",
+            "dwc:phylum": "Charophyta",
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "dwc:class": "Equisetopsida",
+            "dwc:catalogNumber": "YU.076200",
+            "dwc:Identification": [
+              {
+                "coreid": "807914",
+                "dwc:identificationRemarks": "0",
+                "idigbio:recordId": "urn:uuid:b484aab4-0821-4654-926b-a986ee01b640",
+                "dwc:scientificName": "Acer platanoides L.",
+                "dwc:scientificNameAuthorship": "L."
+              }
+            ],
+            "dwc:month": "5",
+            "dwc:verbatimEventDate": "5-7-83 | 6-28-83",
+            "dcterms:modified": "2015-10-29 10:04:57",
+            "dwc:scientificName": "Acer platanoides",
+            "dwc:day": "7",
+            "dwc:year": "1883"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:c6b0657c-34e4-46bf-b303-844dd2828b22",
+          "country": "united states",
+          "dqs": 0.2318840579710145,
+          "collectioncode": "yu",
+          "canonicalname": "acer platanoides",
+          "eventdate": "1883-05-07",
+          "flags": [
+            "dwc_taxonrank_added",
+            "gbif_reference_added",
+            "gbif_canonicalname_added",
+            "dwc_country_replaced",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_parentnameusageid_added",
+            "dwc_phylum_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "dwc_multimedia_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_class_replaced",
+            "dwc_continent_added"
+          ],
+          "verbatimeventdate": "5-7-83 | 6-28-83",
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "urn:uuid:f0ea36c3-e71f-45ff-be75-61138b7ecec3",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\urn:uuid:c6b0657c-34e4-46bf-b303-844dd2828b22",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\807914"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "af9e5711-eaeb-4d07-8dd7-f7df02829377",
+        "_score": 1,
+        "_source": {
+          "family": "sapindaceae",
+          "recordset": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "dqs": 0.2463768115942029,
+          "stateprovince": "connecticut",
+          "municipality": "bridgeport",
+          "county": "fairfield county",
+          "phylum": "tracheophyta",
+          "catalognumber": "cbs.025830",
+          "startdayofyear": 151,
+          "taxonrank": "species",
+          "specificepithet": "pseudoplatanus",
+          "continent": "north america",
+          "uuid": "af9e5711-eaeb-4d07-8dd7-f7df02829377",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "hugh s. clark",
+          "institutioncode": "yale peabody museum of natural history",
+          "mediarecords": [
+            "cd8c9545-8adf-4de8-afe9-ffd8c9c265e2"
+          ],
+          "datemodified": "2016-03-21T21:43:25.444854+00:00",
+          "datecollected": "1910-05-31T00:00:00+00:00",
+          "etag": "e3c07a0a409c5f3f2582ce46d399e94a3b9581df",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "collectionid": "http://grbio.org/cool/x0m9-a3bs",
+          "taxonid": "3189870",
+          "scientificname": "acer pseudoplatanus",
+          "indexData": {
+            "dwc:startDayOfYear": "151",
+            "flag_dwc_taxonrank_added": true,
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "gnu free documentation license",
+                "dcterms:title": "a. pseudoplatanus in the bergpark wilhelmshöhe, kassel",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pseudoplatanus_005.jpg",
+                "coreid": "3189870",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/c/cd/acer_pseudoplatanus_005.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "deutsch: bergahorn (acer pseudoplatanus) im schlosspark wilhelmshöhe, kassel, hessen, deutschland english: sycamore maple (acer pseudoplatanus) in the schlosspark wilhelmshöhe, kassel, hesse, germany",
+                "dcterms:creator": "willow",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "public domain mark 1.0",
+                "dcterms:title": "berg-ahorn (acer pseudoplatanus)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pseudoplatanusaa.jpg",
+                "coreid": "3189870",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/f/fb/acer_pseudoplatanusaa.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "amsterdam, johannes allart, 1802 [-1808]",
+                "dcterms:creator": "user:mpf",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "dwc:specificEpithet": "pseudoplatanus",
+            "idigbio:dateModified": "2016-03-21T21:43:25.444854",
+            "dwc:county": "Fairfield County",
+            "dwc:recordedBy": "Hugh S. Clark",
+            "idigbio:uuid": "af9e5711-eaeb-4d07-8dd7-f7df02829377",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110334",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "L.",
+            "idigbio:recordIds": [
+              "urn:uuid:3f201839-a9b2-4869-a659-39b8509e2c8b",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\urn:uuid:c64bcab2-95df-47ed-b910-e78a8a5a9f85",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\110334"
+            ],
+            "dwc:occurrenceID": "urn:uuid:c64bcab2-95df-47ed-b910-e78a8a5a9f85",
+            "flag_gbif_canonicalname_added": true,
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189870",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero montano"
+              },
+              {
+                "dwc:countrycode": "dk",
+                "dwc:country": "denmark",
+                "dwc:vernacularname": "ahorn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "da"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "bergahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "bergahorn",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "berg-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "berg-ahorn",
+                "coreid": "3189870",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "bergahorn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "berg-ahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "érable sycomore",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable sycomore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "fr",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "érable sycomore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "false planetree"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "gewone esdoorn",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "gewone esdoorn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "great maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen lo&zcaron;noplatanovyj"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "platanlønn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nb"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "platanlønn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "scottish maple"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "sycamore",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sycamore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sycamore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "tysklönn"
+              },
+              {
+                "dwc:countrycode": "se",
+                "dwc:country": "sweden",
+                "dwc:vernacularname": "tysklönn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "vuorivaahtera",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "fi"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "vuorivaahtera",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              }
+            ],
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1910-05-31",
+            "dwc:collectionID": "http://grbio.org/cool/x0m9-a3bs",
+            "dwc:country": "united states",
+            "idigbio:recordId": "urn:uuid:3f201839-a9b2-4869-a659-39b8509e2c8b",
+            "idigbio:etag": "e3c07a0a409c5f3f2582ce46d399e94a3b9581df",
+            "dwc:collectionCode": "CBS",
+            "id": "110334",
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "41.1932",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_phylum_replaced": true,
+            "dwc:municipality": "Bridgeport",
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "usa",
+            "dwc:geodeticDatum": "WGS84",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "cd8c9545-8adf-4de8-afe9-ffd8c9c265e2"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "gbif:canonicalname": "acer pseudoplatanus",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "acer",
+            "flag_dwc_multimedia_added": true,
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "CBS.025830",
+            "dwc:taxonid": "3189870",
+            "dwc:taxonrank": "species",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:decimalLongitude": "-73.196",
+            "dwc:scientificName": "Acer pseudoplatanus",
+            "dwc:month": "5",
+            "flag_dwc_class_replaced": true,
+            "gbif:reference": [
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "l. (1753) in: sp. pl.: 1054"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "flag_dwc_continent_added": true,
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dcterms:modified": "2011-07-21 00:00:00",
+            "dwc:coordinateUncertaintyInMeters": "6473",
+            "dwc:day": "31",
+            "dwc:year": "1910"
+          },
+          "coordinateuncertainty": 6473,
+          "data": {
+            "dwc:startDayOfYear": "151",
+            "dwc:specificEpithet": "pseudoplatanus",
+            "dwc:county": "Fairfield County",
+            "dwc:recordedBy": "Hugh S. Clark",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110334",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:occurrenceID": "urn:uuid:c64bcab2-95df-47ed-b910-e78a8a5a9f85",
+            "dwc:scientificNameAuthorship": "L.",
+            "id": "110334",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1910-05-31",
+            "dwc:collectionID": "http://grbio.org/cool/x0m9-a3bs",
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "dwc:country": "USA",
+            "idigbio:recordId": "urn:uuid:3f201839-a9b2-4869-a659-39b8509e2c8b",
+            "dwc:collectionCode": "CBS",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "41.1932",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:municipality": "Bridgeport",
+            "dwc:phylum": "Charophyta",
+            "dwc:geodeticDatum": "WGS84",
+            "dwc:class": "Equisetopsida",
+            "dwc:catalogNumber": "CBS.025830",
+            "dwc:month": "5",
+            "dwc:decimalLongitude": "-73.196",
+            "dwc:coordinateUncertaintyInMeters": "6473",
+            "dcterms:modified": "2011-07-21 00:00:00",
+            "dwc:scientificName": "Acer pseudoplatanus",
+            "dwc:day": "31",
+            "dwc:year": "1910"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:c64bcab2-95df-47ed-b910-e78a8a5a9f85",
+          "country": "united states",
+          "geopoint": {
+            "lat": 41.1932,
+            "lon": -73.196
+          },
+          "collectioncode": "cbs",
+          "canonicalname": "acer pseudoplatanus",
+          "eventdate": "1910-05-31",
+          "flags": [
+            "dwc_taxonrank_added",
+            "gbif_reference_added",
+            "gbif_canonicalname_added",
+            "dwc_country_replaced",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_parentnameusageid_added",
+            "dwc_phylum_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "dwc_multimedia_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_class_replaced",
+            "dwc_continent_added"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "urn:uuid:3f201839-a9b2-4869-a659-39b8509e2c8b",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\urn:uuid:c64bcab2-95df-47ed-b910-e78a8a5a9f85",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\110334"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b35dc163-b67a-4b9d-9185-75460b7936f0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lat": 41.905,
+            "lon": -72.7025
+          },
+          "family": "sapindaceae",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.2463768115942029,
+          "stateprovince": "connecticut",
+          "institutioncode": "uconn",
+          "municipality": "windsor",
+          "county": "hartford county",
+          "phylum": "tracheophyta",
+          "catalognumber": "conn00032766",
+          "startdayofyear": 119,
+          "taxonrank": "species",
+          "specificepithet": "platanoides",
+          "continent": "north america",
+          "uuid": "b35dc163-b67a-4b9d-9185-75460b7936f0",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "tad m. zebryk",
+          "commonnames": [
+            "Norway Maple"
+          ],
+          "mediarecords": [
+            "bb3b39b6-adbe-459f-88ea-f793e6b45ccf"
+          ],
+          "datemodified": "2014-09-09T01:35:10.885000+00:00",
+          "datecollected": "1998-04-29T00:00:00+00:00",
+          "etag": "24e8f6129d6b7fd632afc0294b74700345b7123c",
+          "recordnumber": "4388",
+          "hasImage": true,
+          "kingdom": "plantae",
+          "highertaxon": "plantae; dicotyledonae; sapindales; aceraceae",
+          "commonname": "norway maple",
+          "taxonid": "3189846",
+          "scientificname": "acer platanoides l.",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "flag_dwc_family_replaced": true,
+            "dwc:specificEpithet": "platanoides",
+            "idigbio:dateModified": "2014-09-09T01:35:10.885000",
+            "dwc:countryCode": "US",
+            "dwc:county": "Hartford County",
+            "dwc:recordedBy": "Tad M. Zebryk",
+            "idigbio:uuid": "b35dc163-b67a-4b9d-9185-75460b7936f0",
+            "flag_dwc_multimedia_added": true,
+            "dwc:order": "Sapindales",
+            "dwc:habitat": "Edge Of Woods",
+            "flag_gbif_reference_added": true,
+            "idigbio:isocountrycode": "usa",
+            "flag_dwc_scientificnameauthorship_added": true,
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00032766"
+            ],
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00032766",
+            "dwc:scientificName": "Acer platanoides L.",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189846",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero riccio"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable de norvège"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "érable plane",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable plane"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "érable plane"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "global invasive species database",
+                "dwc:vernacularname": "érable plane"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable platanoïde"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen ostrolistnyj"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen platanovidnyj"
+              },
+              {
+                "dwc:countrycode": "se",
+                "dwc:country": "sweden",
+                "dwc:vernacularname": "lönn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "(metsä)vaahtera",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "fi"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "(metsä)vaahtera",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "noorse esdoorn",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "noorse esdoorn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "norway maple",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "global invasive species database",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "skogslönn"
+              },
+              {
+                "dwc:countrycode": "dk",
+                "dwc:country": "denmark",
+                "dwc:vernacularname": "spids-løn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "da"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "spisslønn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nb"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "spisslønn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "spitzahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "spitzahorn",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "spitz-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "spitz-ahorn",
+                "coreid": "3189846",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "spitzahorn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "spitz-ahorn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "global invasive species database",
+                "dwc:vernacularname": "spitzahorn"
+              }
+            ],
+            "flag_dwc_kingdom_replaced": true,
+            "flag_gbif_genericname_added": true,
+            "flag_dwc_parentnameusageid_added": true,
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dwc:stateProvince": "Connecticut",
+            "flag_dwc_taxonomicstatus_added": true,
+            "dwc:eventDate": "1998-04-29",
+            "dwc:country": "united states",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:title": "spitz-ahorn (acer platanoides)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:spitz-ahorn_(acer_platanoides)_1.jpg",
+                "coreid": "3189846",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/0/0e/spitz-ahorn_%28acer_platanoides%29_1.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:title": "norway maple leaves",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:spitz-ahorn(mbo).jpg",
+                "coreid": "3189846",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/6/60/spitz-ahorn%28mbo%29.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "deutsch: spitz-ahorn (acer platanoides)",
+                "dcterms:creator": "martin bobka (= martin120)",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "24e8f6129d6b7fd632afc0294b74700345b7123c",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "41°54' 18\" N",
+            "gbif:reference": [
+              {
+                "coreid": "3189846",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "dwc:kingdom": "plantae",
+            "dwc:decimalLatitude": "41.905",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "sapindaceae",
+            "flag_dwc_continent_added": true,
+            "flag_dwc_country_replaced": true,
+            "dwc:class": "magnoliopsida",
+            "dwc:municipality": "Windsor",
+            "flag_dwc_taxonid_added": true,
+            "dwc:previousIdentifications": "Acer platanoides L.",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "bb3b39b6-adbe-459f-88ea-f793e6b45ccf"
+              ]
+            },
+            "flag_dwc_class_added": true,
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:vernacularName": "Norway Maple",
+            "gbif:canonicalname": "acer platanoides",
+            "dwc:scientificnameauthorship": "l.",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_phylum_added": true,
+            "gbif:genericname": "acer",
+            "dwc:locality": "Northwest Park, edge of oak woods near Town Tree Nursery",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "UConn",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Sapindales; Aceraceae",
+            "dwc:catalogNumber": "CONN00032766",
+            "dwc:taxonid": "3189846",
+            "dwc:taxonrank": "species",
+            "dwc:higherGeography": "USA; Connecticut; Hartford County; Windsor",
+            "dwc:month": "4",
+            "dwc:decimalLongitude": "-72.7025",
+            "dwc:verbatimLongitude": "72°42' 09\" W",
+            "dwc:verbatimEventDate": "29-Apr-98",
+            "dwc:phylum": "tracheophyta",
+            "dwc:recordNumber": "4388",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "flag_dwc_datasetid_replaced": true,
+            "dcterms:modified": "2004-03-23T00:00-0500",
+            "dwc:coordinateUncertaintyInMeters": "5000",
+            "dwc:day": "29",
+            "dwc:datasetID": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dwc:year": "1998"
+          },
+          "hasMedia": true,
+          "coordinateuncertainty": 5000,
+          "data": {
+            "dwc:specificEpithet": "platanoides",
+            "dwc:countryCode": "US",
+            "dwc:county": "Hartford County",
+            "dwc:recordedBy": "Tad M. Zebryk",
+            "dwc:order": "Sapindales",
+            "dwc:habitat": "Edge Of Woods",
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00032766",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1998-04-29",
+            "dwc:country": "USA",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "41°54' 18\" N",
+            "dwc:kingdom": "Dicotyledonae",
+            "dwc:decimalLatitude": "41.905",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Aceraceae",
+            "dwc:coordinateUncertaintyInMeters": "5000",
+            "dwc:municipality": "Windsor",
+            "dwc:previousIdentifications": "Acer platanoides L.",
+            "dwc:vernacularName": "Norway Maple",
+            "dwc:locality": "Northwest Park, edge of oak woods near Town Tree Nursery",
+            "dwc:institutionCode": "UConn",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Sapindales; Aceraceae",
+            "dwc:catalogNumber": "CONN00032766",
+            "dwc:higherGeography": "USA; Connecticut; Hartford County; Windsor",
+            "dwc:month": "4",
+            "dwc:decimalLongitude": "-72.7025",
+            "dwc:verbatimLongitude": "72°42' 09\" W",
+            "dwc:verbatimEventDate": "29-Apr-98",
+            "dwc:recordNumber": "4388",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "dcterms:modified": "2004-03-23T00:00-0500",
+            "dwc:scientificName": "Acer platanoides L.",
+            "dwc:day": "29",
+            "dwc:datasetID": "11919",
+            "dwc:year": "1998"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:catalog:uconn:conn:conn00032766",
+          "country": "united states",
+          "locality": "northwest park, edge of oak woods near town tree nursery",
+          "collectioncode": "conn",
+          "canonicalname": "acer platanoides",
+          "eventdate": "1998-04-29",
+          "flags": [
+            "geopoint_datum_missing",
+            "dwc_taxonrank_added",
+            "dwc_family_replaced",
+            "dwc_multimedia_added",
+            "gbif_reference_added",
+            "dwc_scientificnameauthorship_added",
+            "dwc_kingdom_replaced",
+            "gbif_genericname_added",
+            "dwc_parentnameusageid_added",
+            "dwc_taxonomicstatus_added",
+            "dwc_continent_added",
+            "dwc_country_replaced",
+            "dwc_taxonid_added",
+            "dwc_class_added",
+            "idigbio_isocountrycode_added",
+            "gbif_canonicalname_added",
+            "dwc_phylum_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_datasetid_replaced"
+          ],
+          "verbatimeventdate": "29-apr-98",
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00032766"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bc9fd701-bb9d-490c-a5bf-da5177b49ae0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lat": 38.53262,
+            "lon": -95.96472
+          },
+          "family": "sapindaceae",
+          "recordset": "5baa1d0c-cfc0-4c89-8e3e-7a49359b0caa",
+          "dqs": 0.21739130434782608,
+          "stateprovince": "kansas",
+          "county": "lyon",
+          "phylum": "tracheophyta",
+          "catalognumber": "17301",
+          "startdayofyear": 112,
+          "taxonrank": "species",
+          "specificepithet": "negundo",
+          "continent": "north america",
+          "uuid": "bc9fd701-bb9d-490c-a5bf-da5177b49ae0",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "melander, m.",
+          "institutioncode": "kstc",
+          "datemodified": "2017-01-08T07:47:53.556726+00:00",
+          "datecollected": "1975-04-22T00:00:00+00:00",
+          "etag": "9a5a189ccbdbd748d5da7d3fbea1f2bee1137565",
+          "recordnumber": "27",
+          "hasImage": false,
+          "kingdom": "plantae",
+          "taxonid": "3189866",
+          "scientificname": "acer negundo",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "dwc:specificEpithet": "negundo",
+            "idigbio:dateModified": "2017-01-08T07:47:53.556726",
+            "dwc:county": "Lyon",
+            "dwc:recordedBy": "Melander, M.",
+            "idigbio:uuid": "bc9fd701-bb9d-490c-a5bf-da5177b49ae0",
+            "dwc:georeferencedDate": "2015-02-12",
+            "gbif:canonicalname": "acer negundo",
+            "flag_gbif_reference_added": true,
+            "flag_dwc_scientificnameauthorship_added": true,
+            "dwc:locality": "Reading Woods",
+            "idigbio:recordIds": [
+              "5baa1d0c-cfc0-4c89-8e3e-7a49359b0caa\\4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2"
+            ],
+            "dwc:occurrenceID": "4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2",
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "id": "4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "5baa1d0c-cfc0-4c89-8e3e-7a49359b0caa",
+            "dwc:stateProvince": "Kansas",
+            "dwc:eventDate": "1975-04-22",
+            "dwc:country": "united states",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "public domain from united states department of agriculture",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acnegundo.jpg",
+                "coreid": "3189866",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/1/18/acnegundo.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "creative commons attribution share alike 3.0 migrated",
+                "dcterms:title": "eschen-ahorn (acer negundo)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_negundo.jpg",
+                "coreid": "3189866",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/8/82/acer_negundo.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "deutsch: eschen-ahorn (acer negundo) polski: klon jesionolistny (acer negundo)",
+                "dcterms:creator": "agnieszka kwiecień - nova at pl.wikipedia",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "9a5a189ccbdbd748d5da7d3fbea1f2bee1137565",
+            "dwc:collectionCode": "Plants",
+            "flag_dwc_multimedia_added": true,
+            "flag_gbif_vernacularname_added": true,
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "38.5326200",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "North America",
+            "dwc:family": "Sapindaceae",
+            "idigbio:isocountrycode": "usa",
+            "dwc:identifiedBy": "Melander, M.",
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_taxonid_added": true,
+            "dcterms:license": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "idigbio:siblings": {},
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:order": "sapindales",
+            "dwc:scientificnameauthorship": "l.",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_phylum_added": true,
+            "gbif:genericname": "acer",
+            "dwc:georeferenceSources": "GEOLocate",
+            "dwc:institutionID": "http://biocol.org/urn:lsid:biocol.org:col:12991",
+            "dwc:institutionCode": "KSTC",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "17301",
+            "dwc:taxonid": "3189866",
+            "dwc:taxonrank": "species",
+            "dwc:month": "4",
+            "dwc:decimalLongitude": "-95.9647200",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189866",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero americano"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "ash-leaf maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "ashleaf maple"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "ash-leaved maple, box-elder",
+                "coreid": "3189866",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "ash-leaved maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "asklönn"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "aulne-buis"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "box-elder, ash-leaved maple",
+                "coreid": "3189866",
+                "dcterms:source": "invasive alien species in belgium - harmonia database",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "boxelder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "box-elder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "box-elder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "box elder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "boxelder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "box-elder maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "boxelder maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "california box-elder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "california boxelder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable à feuilles composées"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable à feuilles de frêne"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable à giguère"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable argilière"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable négondo"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "erable negundo",
+                "coreid": "3189866",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "erable negundo",
+                "coreid": "3189866",
+                "dcterms:source": "invasive alien species in belgium - harmonia database",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable négundo"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "eschen-ahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "eschenahorn",
+                "coreid": "3189866",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "eschen-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "eschen-ahorn",
+                "coreid": "3189866",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "eschenahorn"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "eschen-ahorn"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "af",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "essenblaarahorn"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "fu ye feng"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "af",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "kaliforniese esdoring"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen âsenelistnyj"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "korean peninsula flora",
+                "dwc:vernacularname": "네군도단풍"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "manitoba maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "manitoba maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "négondo"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "negundodanpung"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "plaine à giguère"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "three-leaf maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "three-leaved maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "tonerikoba-no-kaede"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "vederesdoorn",
+                "coreid": "3189866",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "vederesdoorn",
+                "coreid": "3189866",
+                "dcterms:source": "invasive alien species in belgium - harmonia database",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "vederesdoorn"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "western box-elder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "western boxelder"
+              }
+            ],
+            "flag_dwc_order_added": true,
+            "dwc:georeferencedBy": "Kerbs, Benjamin",
+            "gbif:reference": [
+              {
+                "coreid": "3189866",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "dwc:phylum": "tracheophyta",
+            "dwc:recordNumber": "27",
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_class_added": true,
+            "dwc:georeferenceProtocol": "GEOLocate",
+            "dcterms:modified": "2012-10-27 14:45:54.0",
+            "dwc:scientificName": "Acer negundo",
+            "dwc:day": "22",
+            "dwc:year": "1975"
+          },
+          "hasMedia": false,
+          "data": {
+            "dwc:specificEpithet": "negundo",
+            "dwc:county": "Lyon",
+            "dwc:recordedBy": "Melander, M.",
+            "dwc:georeferencedDate": "2015-02-12",
+            "dwc:occurrenceID": "4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2",
+            "id": "4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2",
+            "dwc:stateProvince": "Kansas",
+            "dwc:eventDate": "1975-04-22",
+            "dwc:country": "USA",
+            "dwc:collectionCode": "Plants",
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "38.5326200",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:continent": "North America",
+            "dwc:family": "Sapindaceae",
+            "dwc:identifiedBy": "Melander, M.",
+            "dwc:georeferenceSources": "GEOLocate",
+            "dcterms:license": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:locality": "Reading Woods",
+            "dwc:institutionID": "http://biocol.org/urn:lsid:biocol.org:col:12991",
+            "dwc:institutionCode": "KSTC",
+            "dwc:catalogNumber": "17301",
+            "dwc:month": "4",
+            "dwc:decimalLongitude": "-95.9647200",
+            "dwc:georeferencedBy": "Kerbs, Benjamin",
+            "dwc:recordNumber": "27",
+            "dwc:georeferenceProtocol": "GEOLocate",
+            "dcterms:modified": "2012-10-27 14:45:54.0",
+            "dwc:scientificName": "Acer negundo",
+            "dwc:day": "22",
+            "dwc:year": "1975"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2",
+          "institutionid": "http://biocol.org/urn:lsid:biocol.org:col:12991",
+          "country": "united states",
+          "locality": "reading woods",
+          "collectioncode": "plants",
+          "canonicalname": "acer negundo",
+          "eventdate": "1975-04-22",
+          "flags": [
+            "geopoint_datum_missing",
+            "dwc_taxonrank_added",
+            "gbif_reference_added",
+            "dwc_scientificnameauthorship_added",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_multimedia_added",
+            "gbif_vernacularname_added",
+            "dwc_country_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "gbif_canonicalname_added",
+            "dwc_phylum_added",
+            "gbif_taxon_corrected",
+            "dwc_order_added",
+            "dwc_parentnameusageid_added",
+            "dwc_class_added"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "5baa1d0c-cfc0-4c89-8e3e-7a49359b0caa\\4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "fdh": {
+      "doc_count": 376,
+      "dh": {
+        "buckets": [
+          {
+            "key_as_string": "2014-01-01",
+            "key": 1388534400000,
+            "doc_count": 376
+          }
+        ]
+      }
+    }
+  }
+}

--- a/__tests__/mock/search-2b6a3cbdb4ac559a3119a9c51502772d.json
+++ b/__tests__/mock/search-2b6a3cbdb4ac559a3119a9c51502772d.json
@@ -1,0 +1,3506 @@
+{
+  "timed_out": false,
+  "_shards": {
+    "total": 48,
+    "successful": 48,
+    "failed": 0
+  },
+  "hits": {
+    "total": 50776115,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "000992e7-6519-4fae-ab02-d990234e3752",
+        "_score": null,
+        "_routing": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_parent": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "003b2287-1f6c-4897-bd59-2e58f6022739",
+        "_score": null,
+        "_routing": "4bd36c58-e935-4c2b-82f5-21a83b359557",
+        "_parent": "4bd36c58-e935-4c2b-82f5-21a83b359557",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "007977cb-7a8d-49bd-8450-45800bec15af",
+        "_score": null,
+        "_routing": "599f5853-b35c-43eb-90d3-5143ebbf9d21",
+        "_parent": "599f5853-b35c-43eb-90d3-5143ebbf9d21",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0089b314-b365-4244-9f93-8cec2f29be98",
+        "_score": null,
+        "_routing": "9a059a20-1927-4ea0-be70-7b7c5d3a430d",
+        "_parent": "9a059a20-1927-4ea0-be70-7b7c5d3a430d",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00b06c30-4949-415b-9a5f-342fe99abca2",
+        "_score": null,
+        "_routing": "95d7ee27-3a69-4f29-b7f9-4e0c6123264a",
+        "_parent": "95d7ee27-3a69-4f29-b7f9-4e0c6123264a",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00bda874-9f9d-48d4-b582-c5bcac4a08b5",
+        "_score": null,
+        "_routing": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_parent": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00c7c963-860b-4b70-a55e-571bfef030fd",
+        "_score": null,
+        "_routing": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_parent": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00edde43-e608-4e84-862c-f9cb9af9b21a",
+        "_score": null,
+        "_routing": "7c5f4753-8a79-42df-b87f-5501f1f1676b",
+        "_parent": "7c5f4753-8a79-42df-b87f-5501f1f1676b",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00f8d929-db1c-4478-bef2-ef0babf1d576",
+        "_score": null,
+        "_routing": "53d4865e-8083-4884-8393-08277937e408",
+        "_parent": "53d4865e-8083-4884-8393-08277937e408",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0119c9f7-8706-4114-8a26-6d25ccf3964b",
+        "_score": null,
+        "_routing": "3a00b94a-ab08-411b-b781-0df20f0a9379",
+        "_parent": "3a00b94a-ab08-411b-b781-0df20f0a9379",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "011a1397-b055-4090-b6fd-9bd644eb02bf",
+        "_score": null,
+        "_routing": "9a059a20-1927-4ea0-be70-7b7c5d3a430d",
+        "_parent": "9a059a20-1927-4ea0-be70-7b7c5d3a430d",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "014d1271-6165-44d0-b4f0-f493358c0acb",
+        "_score": null,
+        "_routing": "dab39256-4cb9-4c5e-b3fd-db398fa8848b",
+        "_parent": "dab39256-4cb9-4c5e-b3fd-db398fa8848b",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0151eb78-720f-4af2-b2c0-395a1000b7d1",
+        "_score": null,
+        "_routing": "1ed2b128-b2f6-4784-984b-69ec5aae9c24",
+        "_parent": "1ed2b128-b2f6-4784-984b-69ec5aae9c24",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "019841c5-ec17-4a80-b92d-eeb0680682aa",
+        "_score": null,
+        "_routing": "888f773c-2655-4806-abdd-370f12716543",
+        "_parent": "888f773c-2655-4806-abdd-370f12716543",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "01a34b4c-74fd-4a33-8bbf-79d3a25622f8",
+        "_score": null,
+        "_routing": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_parent": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "01c35b3c-f014-4344-abf4-9cc03511ec5e",
+        "_score": null,
+        "_routing": "2ab6d7a9-4730-43f4-96ea-b7e943fe9640",
+        "_parent": "2ab6d7a9-4730-43f4-96ea-b7e943fe9640",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "01cf1085-c956-4597-a958-5adf29298ebf",
+        "_score": null,
+        "_routing": "95d7ee27-3a69-4f29-b7f9-4e0c6123264a",
+        "_parent": "95d7ee27-3a69-4f29-b7f9-4e0c6123264a",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "01f4f3e3-632f-41bb-acbd-db138d35e03b",
+        "_score": null,
+        "_routing": "eb4640cf-4771-4dfe-89db-36372badd257",
+        "_parent": "eb4640cf-4771-4dfe-89db-36372badd257",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "02104779-3467-4775-8540-fad66ae1eabd",
+        "_score": null,
+        "_routing": "9d0077e2-574d-461c-8b67-d6e01221e81b",
+        "_parent": "9d0077e2-574d-461c-8b67-d6e01221e81b",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0251dfab-5668-4e01-bc77-88703b3dee95",
+        "_score": null,
+        "_routing": "fb6942c0-4577-4009-8c90-460b8d6650cc",
+        "_parent": "fb6942c0-4577-4009-8c90-460b8d6650cc",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "02546cb5-5284-497f-9aaa-66917f309fcf",
+        "_score": null,
+        "_routing": "836320a3-b003-490d-8712-3ca2375f8f21",
+        "_parent": "836320a3-b003-490d-8712-3ca2375f8f21",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "02607712-5923-4eff-91db-512db1fe6a84",
+        "_score": null,
+        "_routing": "460a8a37-121d-434d-ab97-1a79b30dafa8",
+        "_parent": "460a8a37-121d-434d-ab97-1a79b30dafa8",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0284bdfc-ec3b-4248-8b2d-99d348b81f1a",
+        "_score": null,
+        "_routing": "421db2c2-f39f-44e2-bb03-316efa33f66c",
+        "_parent": "421db2c2-f39f-44e2-bb03-316efa33f66c",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "028e3db3-a575-4261-a8b4-78c963300ac0",
+        "_score": null,
+        "_routing": "c4bbcb7a-5942-4148-98cf-4d802476b082",
+        "_parent": "c4bbcb7a-5942-4148-98cf-4d802476b082",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "028e4c83-dbb0-4e17-b2e0-9b7788fe6d50",
+        "_score": null,
+        "_routing": "edcc76a9-ccd0-477b-97e3-3ef3b5156e06",
+        "_parent": "edcc76a9-ccd0-477b-97e3-3ef3b5156e06",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "028f8982-e28d-4f38-af58-6211f4ea8316",
+        "_score": null,
+        "_routing": "a3a90786-7774-4654-819b-79c991a5b485",
+        "_parent": "a3a90786-7774-4654-819b-79c991a5b485",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "02985101-ec9a-433e-823a-8258b04193cf",
+        "_score": null,
+        "_routing": "14f651aa-2ed6-4d4d-9566-39a5edc5b4e9",
+        "_parent": "14f651aa-2ed6-4d4d-9566-39a5edc5b4e9",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "02fbb412-8f3e-40e2-afa2-c3a340c10cd8",
+        "_score": null,
+        "_routing": "58a5591f-5979-4023-abf9-b1fd8211e76b",
+        "_parent": "58a5591f-5979-4023-abf9-b1fd8211e76b",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "03301337-9f1e-430b-af3a-f322cdc1ac8d",
+        "_score": null,
+        "_routing": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_parent": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "03510df7-b380-46b1-8709-314d676550eb",
+        "_score": null,
+        "_routing": "83255e81-1685-4a79-840b-0ef82235ab8c",
+        "_parent": "83255e81-1685-4a79-840b-0ef82235ab8c",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "036dfeb3-b1fc-4253-9350-4596a3663d5f",
+        "_score": null,
+        "_routing": "be5a87f5-76b0-41d8-8ce5-8c626b1e28ea",
+        "_parent": "be5a87f5-76b0-41d8-8ce5-8c626b1e28ea",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "038054f3-e87a-4e66-8501-bb4daf29ac90",
+        "_score": null,
+        "_routing": "e02cd9f0-ac0a-4a0a-9bf0-f97237e48397",
+        "_parent": "e02cd9f0-ac0a-4a0a-9bf0-f97237e48397",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "03a3fbfe-1cbb-49f4-b4ce-c4560dc0a172",
+        "_score": null,
+        "_routing": "cc3ca348-444f-4787-8043-7dda29898b55",
+        "_parent": "cc3ca348-444f-4787-8043-7dda29898b55",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "03ad0e7a-2511-497f-88dd-1fde388b25a5",
+        "_score": null,
+        "_routing": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_parent": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "03d39c02-9c79-4171-8d75-913246f746c1",
+        "_score": null,
+        "_routing": "fb6942c0-4577-4009-8c90-460b8d6650cc",
+        "_parent": "fb6942c0-4577-4009-8c90-460b8d6650cc",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "03f0ffe5-caf3-4e6a-b68a-0f908ccd3097",
+        "_score": null,
+        "_routing": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_parent": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0465e85c-4917-4f2e-977f-12b34ce5a129",
+        "_score": null,
+        "_routing": "7b3187a7-ce18-4bbb-973f-8a75c182e277",
+        "_parent": "7b3187a7-ce18-4bbb-973f-8a75c182e277",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "04f2d4b4-9ce1-4ed9-8ccd-a4a9dae8f171",
+        "_score": null,
+        "_routing": "12035a01-47eb-4e72-b3f3-ed6fc465eea0",
+        "_parent": "12035a01-47eb-4e72-b3f3-ed6fc465eea0",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "050f03d4-c0aa-45e0-9dda-5b916cd2f7f6",
+        "_score": null,
+        "_routing": "4bd36c58-e935-4c2b-82f5-21a83b359557",
+        "_parent": "4bd36c58-e935-4c2b-82f5-21a83b359557",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0534d962-8909-4157-a991-b439cad77e86",
+        "_score": null,
+        "_routing": "a5b19037-3b2f-4e02-bbc3-f31b17ddcd2b",
+        "_parent": "a5b19037-3b2f-4e02-bbc3-f31b17ddcd2b",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "053c36a3-edd7-49a5-bcfc-8df1f8911a1c",
+        "_score": null,
+        "_routing": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_parent": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0566dc2a-e1b0-408f-ab15-8eaca19addef",
+        "_score": null,
+        "_routing": "1a2ae543-db57-4d52-91e7-7879917cbf85",
+        "_parent": "1a2ae543-db57-4d52-91e7-7879917cbf85",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "056e8574-f500-4612-8f36-d88c3c30cfe7",
+        "_score": null,
+        "_routing": "5ea146c5-318e-4854-bc3e-c214d22b9dc4",
+        "_parent": "5ea146c5-318e-4854-bc3e-c214d22b9dc4",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "057683ab-1d35-4784-ab59-63edcfdef852",
+        "_score": null,
+        "_routing": "dbfd579d-4170-42ae-ab17-a1f850b07dd1",
+        "_parent": "dbfd579d-4170-42ae-ab17-a1f850b07dd1",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "05f2a0a7-ec10-4ce1-a1fa-78eddb7273c3",
+        "_score": null,
+        "_routing": "d0dbaa27-0eb1-4173-b4fd-a5d047d0c62c",
+        "_parent": "d0dbaa27-0eb1-4173-b4fd-a5d047d0c62c",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "079635a6-4d3b-4973-8044-11c40f499ddd",
+        "_score": null,
+        "_routing": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_parent": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "07b24646-1ef8-4d40-98f9-b1e0eb595335",
+        "_score": null,
+        "_routing": "e90ff1f8-f7c2-464b-b680-ccf3b0f2f032",
+        "_parent": "e90ff1f8-f7c2-464b-b680-ccf3b0f2f032",
+        "_source": {},
+        "sort": [
+          0.90909094
+        ]
+      }
+    ]
+  },
+  "aggregations": {
+    "rs": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+          "doc_count": 5576909
+        },
+        {
+          "key": "a6eee223-cf3b-4079-8bb2-b77dad8cae9d",
+          "doc_count": 5135183
+        },
+        {
+          "key": "fabcdc12-9d29-4bd2-912b-176e71818144",
+          "doc_count": 4596608
+        },
+        {
+          "key": "3c9420c9-c4a8-47dc-88b7-b5638ca5e716",
+          "doc_count": 3801254
+        },
+        {
+          "key": "36d35b23-113e-4633-90ec-19d265a3b5f6",
+          "doc_count": 3537264
+        },
+        {
+          "key": "7450a9e3-ef95-4f9e-8260-09b498d2c5e6",
+          "doc_count": 1372219
+        },
+        {
+          "key": "5386d272-06c6-4027-b5d5-d588c2afe5e5",
+          "doc_count": 928757
+        },
+        {
+          "key": "e6ccc2bd-9451-4802-8a51-8640d9f09793",
+          "doc_count": 819632
+        },
+        {
+          "key": "0583609b-202f-40d0-8021-4c019635d4c9",
+          "doc_count": 707693
+        },
+        {
+          "key": "953b0329-c3e4-4816-a038-7afbd2bb2547",
+          "doc_count": 698464
+        },
+        {
+          "key": "710a8a54-783c-41aa-ad9a-05544cdb4c55",
+          "doc_count": 609014
+        },
+        {
+          "key": "205fa34c-2fcb-4492-b992-972b18560f6f",
+          "doc_count": 608981
+        },
+        {
+          "key": "65536dcd-7bb2-44e5-af3f-4a13f08e53d0",
+          "doc_count": 543365
+        },
+        {
+          "key": "285a4be0-5cfe-4d4f-9c8b-b0f0f3571079",
+          "doc_count": 489273
+        },
+        {
+          "key": "271a9ce9-c6d3-4b63-a722-cb0adc48863f",
+          "doc_count": 468247
+        },
+        {
+          "key": "b6ec6203-09db-4d6e-8cba-ee4bebd2934c",
+          "doc_count": 417978
+        },
+        {
+          "key": "4e3043a6-d48a-4a35-b5fb-f67d50cbc158",
+          "doc_count": 408346
+        },
+        {
+          "key": "e60301d9-9b40-483f-92de-065769b9d3dd",
+          "doc_count": 380640
+        },
+        {
+          "key": "a4e6033a-d1eb-46d3-869d-7c0328f09aa7",
+          "doc_count": 343844
+        },
+        {
+          "key": "9e5aede6-bee5-4a3d-a255-513771b20035",
+          "doc_count": 316956
+        },
+        {
+          "key": "4523e216-ee13-4b15-a3f7-a6fd56431604",
+          "doc_count": 306235
+        },
+        {
+          "key": "137ed4cd-5172-45a5-acdb-8e1de9a64e32",
+          "doc_count": 299965
+        },
+        {
+          "key": "2d7910d9-7f63-4bde-918a-9e0265f1c245",
+          "doc_count": 294161
+        },
+        {
+          "key": "9151bc4c-8505-4b22-a16b-9dbf337535fa",
+          "doc_count": 294161
+        },
+        {
+          "key": "53091d18-f173-4fc0-b9d9-20a1494e2466",
+          "doc_count": 291399
+        },
+        {
+          "key": "beab5209-9628-4d4d-851e-2bc9bb1a0105",
+          "doc_count": 276792
+        },
+        {
+          "key": "3027c437-cdb3-4072-9410-5a46ec3b1fd5",
+          "doc_count": 275401
+        },
+        {
+          "key": "a2b36fdf-50bc-44ef-a6a4-ca6dc1dc148a",
+          "doc_count": 253201
+        },
+        {
+          "key": "72d4c3c7-3413-4588-a803-e1a63e0d7c6c",
+          "doc_count": 252250
+        },
+        {
+          "key": "ded380b5-1ba2-4089-8e0c-0aa1b4140785",
+          "doc_count": 245491
+        },
+        {
+          "key": "d53132e6-7997-4850-8607-4fec5a3f9c3f",
+          "doc_count": 241932
+        },
+        {
+          "key": "207b6c64-7b58-4d6a-816d-bc759c27eafc",
+          "doc_count": 241497
+        },
+        {
+          "key": "f1cf8457-237e-487a-9d13-5de7d81b9de4",
+          "doc_count": 238178
+        },
+        {
+          "key": "da67ebd9-52de-444d-b114-e23c03111ac6",
+          "doc_count": 220286
+        },
+        {
+          "key": "e2def7e2-1455-4856-9823-6d3738417d24",
+          "doc_count": 214256
+        },
+        {
+          "key": "f062cb7d-c03e-4762-b1c4-49118fee1a56",
+          "doc_count": 195002
+        },
+        {
+          "key": "db6c3db9-1e6d-4def-af29-33aa0339bfa9",
+          "doc_count": 192851
+        },
+        {
+          "key": "70abba3e-5f2a-4276-87f3-261706e24453",
+          "doc_count": 192778
+        },
+        {
+          "key": "40250f4d-7aa6-4fcc-ac38-2868fa4846bd",
+          "doc_count": 187242
+        },
+        {
+          "key": "e881a3e2-f7ba-43c8-ae9a-11fcbfd741bb",
+          "doc_count": 185371
+        },
+        {
+          "key": "0fd6e726-6828-4f62-ba8d-6ec316fe0b52",
+          "doc_count": 180782
+        },
+        {
+          "key": "01017cef-5065-48b2-9db8-3e428971d702",
+          "doc_count": 172853
+        },
+        {
+          "key": "58402fe3-37c1-4d15-9e07-0ff1c4c9fb11",
+          "doc_count": 171183
+        },
+        {
+          "key": "703b5bdc-4581-47e3-b4b6-e6f32d0eec54",
+          "doc_count": 170392
+        },
+        {
+          "key": "d4ea4495-c4b2-4d05-b524-163423f17cd7",
+          "doc_count": 168645
+        },
+        {
+          "key": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "doc_count": 166689
+        },
+        {
+          "key": "6c6f34ed-58a4-4ba2-b9c7-34524f79a349",
+          "doc_count": 163095
+        },
+        {
+          "key": "0dab1fc7-ca99-456b-9985-76edbac003e0",
+          "doc_count": 161405
+        },
+        {
+          "key": "59efaf7d-60b5-4295-abb3-27ba42eb5231",
+          "doc_count": 157291
+        },
+        {
+          "key": "1527b668-b797-42be-94d3-0058e1393e94",
+          "doc_count": 147919
+        },
+        {
+          "key": "8057906f-17c9-4e25-b173-4e7fb938078b",
+          "doc_count": 141503
+        },
+        {
+          "key": "48b4b812-c52e-4f47-9327-e761f6fc2e28",
+          "doc_count": 138133
+        },
+        {
+          "key": "6258d160-a7aa-4937-bce3-3538eebd374f",
+          "doc_count": 137717
+        },
+        {
+          "key": "cdb6ec43-935e-4da2-8798-71e40ca6d12a",
+          "doc_count": 134508
+        },
+        {
+          "key": "2c00c297-9ebd-498a-b701-d3ebde4b49f3",
+          "doc_count": 133295
+        },
+        {
+          "key": "96662fa9-ff60-495b-912a-284f3b98ed72",
+          "doc_count": 126289
+        },
+        {
+          "key": "cf42855e-a54a-4488-a79e-beac086ba1d4",
+          "doc_count": 123875
+        },
+        {
+          "key": "df22987f-d20d-41db-b8eb-8b5f5fca6df0",
+          "doc_count": 121441
+        },
+        {
+          "key": "beecd160-a96c-46fc-bdce-7dcb7024d473",
+          "doc_count": 120720
+        },
+        {
+          "key": "b531ea59-025d-4c29-9d23-99ae75bcd55f",
+          "doc_count": 118459
+        },
+        {
+          "key": "d2217bca-3a93-4407-bb56-087afa000cbc",
+          "doc_count": 107269
+        },
+        {
+          "key": "aca26f37-3ec8-4e9e-b927-50b4944a0096",
+          "doc_count": 102740
+        },
+        {
+          "key": "ba042ffa-8175-4a47-8eb1-08b4d6319ccf",
+          "doc_count": 102728
+        },
+        {
+          "key": "35c43eda-1f4a-4713-bb69-e3fbe1bf792f",
+          "doc_count": 102464
+        },
+        {
+          "key": "31c140bc-e6f1-4acc-beaf-b825cf288ad9",
+          "doc_count": 100206
+        },
+        {
+          "key": "215eeaf0-0a88-409e-a75d-aec98b7c41eb",
+          "doc_count": 100041
+        },
+        {
+          "key": "6cc31636-c3e5-4887-bbee-2e56621771c4",
+          "doc_count": 96684
+        },
+        {
+          "key": "f84d528a-7d08-467e-b532-ace707316f1d",
+          "doc_count": 95826
+        },
+        {
+          "key": "71bf994a-3af5-484d-983b-b146aa1512d1",
+          "doc_count": 93283
+        },
+        {
+          "key": "0bc60df1-a162-4173-9a73-c51e09031843",
+          "doc_count": 92054
+        },
+        {
+          "key": "ccd17772-d220-4088-8fa3-df3729f14df4",
+          "doc_count": 91822
+        },
+        {
+          "key": "995cc7f1-69c3-4317-ab77-28fd48f1e535",
+          "doc_count": 91120
+        },
+        {
+          "key": "02fceae6-c71c-4db9-8b2f-e235ced6624a",
+          "doc_count": 90591
+        },
+        {
+          "key": "f00b6a32-5337-406b-a850-17f5d78470ad",
+          "doc_count": 90018
+        },
+        {
+          "key": "61a1c0ce-8327-4e2a-9766-449751a49b7a",
+          "doc_count": 89789
+        },
+        {
+          "key": "781fd581-7b93-471e-a025-413e4bcd8491",
+          "doc_count": 89195
+        },
+        {
+          "key": "c481fbc6-4bd7-4c50-8537-ba1993d4eb88",
+          "doc_count": 87485
+        },
+        {
+          "key": "d78d13a7-3852-4244-ba34-86ef5765fa99",
+          "doc_count": 86774
+        },
+        {
+          "key": "26f7cbde-fbcb-4500-80a9-a99daa0ead9d",
+          "doc_count": 85734
+        },
+        {
+          "key": "7644703a-ce24-4f7b-b800-66ddf8812f86",
+          "doc_count": 85277
+        },
+        {
+          "key": "46c11153-2154-495d-89d2-7cdef6425cdb",
+          "doc_count": 85172
+        },
+        {
+          "key": "ee9d38ef-c1db-44de-b8f2-62acb7049370",
+          "doc_count": 82837
+        },
+        {
+          "key": "8b0c1f4b-9de7-4521-98c2-983e0bfd33c7",
+          "doc_count": 81586
+        },
+        {
+          "key": "c569e530-7322-40b8-9b66-1e0ed96fefcb",
+          "doc_count": 81456
+        },
+        {
+          "key": "cf641fbf-fa31-481a-993b-9204f2ee1884",
+          "doc_count": 80738
+        },
+        {
+          "key": "b667cef4-96fe-42e8-a9fa-6298aa80bb14",
+          "doc_count": 80713
+        },
+        {
+          "key": "83ad8494-136b-485a-87d4-8ce01dd6a8de",
+          "doc_count": 79509
+        },
+        {
+          "key": "b9ab58cf-785e-44a7-a873-1966e14a6715",
+          "doc_count": 79181
+        },
+        {
+          "key": "d7540872-1c53-48ac-a617-2d0739eadcbd",
+          "doc_count": 79113
+        },
+        {
+          "key": "ddef79ec-043c-4027-9876-c4a298feff6d",
+          "doc_count": 78656
+        },
+        {
+          "key": "b2b294ed-1742-4479-b0c8-a8891fccd7eb",
+          "doc_count": 77886
+        },
+        {
+          "key": "5e29dbcc-ce45-4f05-9bb0-212baffa8932",
+          "doc_count": 77700
+        },
+        {
+          "key": "264c48ec-8636-451f-a7e0-74131bc6f84c",
+          "doc_count": 77595
+        },
+        {
+          "key": "ba54ba45-caac-4708-a389-ac94642976f8",
+          "doc_count": 77466
+        },
+        {
+          "key": "20360fae-574a-4d63-b9f6-47b1cc07fd22",
+          "doc_count": 76898
+        },
+        {
+          "key": "ff89320d-e232-4edd-9cdd-4b6acc672ad3",
+          "doc_count": 76125
+        },
+        {
+          "key": "ec6cef7d-d8aa-43b4-b352-908f172a378e",
+          "doc_count": 75488
+        },
+        {
+          "key": "5835f642-2560-4e3e-9c25-741a12cc3fe8",
+          "doc_count": 75384
+        },
+        {
+          "key": "8dc14464-57b3-423e-8cb0-950ab8f36b6f",
+          "doc_count": 74455
+        },
+        {
+          "key": "7c1a1d78-aeaa-4501-87e1-83eceb8ca8ea",
+          "doc_count": 74122
+        },
+        {
+          "key": "dd232f5c-7f53-48ec-9bb7-7205702c3dc8",
+          "doc_count": 72999
+        },
+        {
+          "key": "844875a9-9927-48a5-90b4-76c5f227f145",
+          "doc_count": 70991
+        },
+        {
+          "key": "e5f57bb0-07ec-4405-90b6-dc89647a1cb5",
+          "doc_count": 70947
+        },
+        {
+          "key": "5a660a44-afdd-45ac-8c48-1a6c570ce0b5",
+          "doc_count": 70928
+        },
+        {
+          "key": "026a4216-957a-4efb-acf1-506499ec474e",
+          "doc_count": 70918
+        },
+        {
+          "key": "76fd34da-4892-4821-858d-98fe9e28ba8b",
+          "doc_count": 68987
+        },
+        {
+          "key": "e48bb88f-9594-461e-8230-522a3a5572fe",
+          "doc_count": 68353
+        },
+        {
+          "key": "4830ffb8-669a-4717-bec8-2f2374f52120",
+          "doc_count": 68346
+        },
+        {
+          "key": "1bb33d2d-0714-4fc9-968e-b66bab1cf3d3",
+          "doc_count": 66199
+        },
+        {
+          "key": "7809d96b-7edf-4ef7-9f12-59967e9a01a6",
+          "doc_count": 65733
+        },
+        {
+          "key": "767c78b4-1c16-4cac-ad04-66333ac5a7f2",
+          "doc_count": 65505
+        },
+        {
+          "key": "8ec76c75-a673-4682-bfde-00a18bc12794",
+          "doc_count": 65365
+        },
+        {
+          "key": "d82fa49b-915e-4aa8-acc6-51df3d431884",
+          "doc_count": 64222
+        },
+        {
+          "key": "5ab348ab-439a-4697-925c-d6abe0c09b92",
+          "doc_count": 63025
+        },
+        {
+          "key": "b26fa674-6300-4ea0-a8e3-fc0ce32b5226",
+          "doc_count": 62139
+        },
+        {
+          "key": "fc7b78d7-82d4-4648-8185-87a0ba209c20",
+          "doc_count": 60909
+        },
+        {
+          "key": "9ef17d55-0498-44cf-9da4-dde3e3acb570",
+          "doc_count": 60669
+        },
+        {
+          "key": "ea12da76-1b2e-4944-8709-1de3af1c65e2",
+          "doc_count": 58835
+        },
+        {
+          "key": "e5b0c46a-5eb6-4b94-9d4c-fb1000f534b0",
+          "doc_count": 58665
+        },
+        {
+          "key": "09a3fcf2-55a1-488f-aa42-f103bdce0536",
+          "doc_count": 58250
+        },
+        {
+          "key": "5626f61a-822e-4692-b432-51f53d053e4d",
+          "doc_count": 58071
+        },
+        {
+          "key": "e1b03497-7632-4ba4-a9e0-dd230d06638c",
+          "doc_count": 56827
+        },
+        {
+          "key": "ec4acc26-ff1b-4131-a1df-a950fe31bb0e",
+          "doc_count": 56622
+        },
+        {
+          "key": "cb33cf97-2a7b-4b45-9b73-5aca568332a6",
+          "doc_count": 55502
+        },
+        {
+          "key": "f0174bc9-0cca-450e-a941-655d80040139",
+          "doc_count": 54865
+        },
+        {
+          "key": "8f3b62fb-56ec-49e8-9f8f-bb257348291f",
+          "doc_count": 54453
+        },
+        {
+          "key": "9ff03c57-ba5a-4127-9439-4bf3e838c4df",
+          "doc_count": 54392
+        },
+        {
+          "key": "471835cc-feb6-4d05-a8d1-62ce71399326",
+          "doc_count": 54131
+        },
+        {
+          "key": "9b725e43-93c9-423b-adf8-a11d08a83d13",
+          "doc_count": 53487
+        },
+        {
+          "key": "1f2b44b8-8556-4d6e-8247-4611689551cf",
+          "doc_count": 53268
+        },
+        {
+          "key": "1701a75c-5a57-48c3-84c2-234a53f4c3e2",
+          "doc_count": 52027
+        },
+        {
+          "key": "b88033dd-5dbb-4377-b374-2210f32ece16",
+          "doc_count": 50850
+        },
+        {
+          "key": "fdf7bb59-aad2-4f10-879f-6c0e7d3baa64",
+          "doc_count": 50838
+        },
+        {
+          "key": "e36691ec-c4f8-4bec-b331-b48ffa82ff49",
+          "doc_count": 50713
+        },
+        {
+          "key": "62254613-2696-4834-8c58-5c465f70df56",
+          "doc_count": 50672
+        },
+        {
+          "key": "72b6dbee-bc4d-4e35-a32c-8df0422771fb",
+          "doc_count": 50672
+        },
+        {
+          "key": "005ac06a-3d9a-46ad-ac3c-062aaa5b7059",
+          "doc_count": 50655
+        },
+        {
+          "key": "667a12e7-c6d8-4de0-933f-ce2f07cb7a92",
+          "doc_count": 50445
+        },
+        {
+          "key": "14f8f83f-7a0c-458c-b6d5-6da7dc8eaa0a",
+          "doc_count": 49996
+        },
+        {
+          "key": "b5f4526b-f4fb-4d90-8ce0-975e0cda8ff6",
+          "doc_count": 49612
+        },
+        {
+          "key": "910eadc8-8131-428c-b28a-91d0e2890f1d",
+          "doc_count": 49530
+        },
+        {
+          "key": "40987883-03cf-494a-a5cf-7c77c7aadb79",
+          "doc_count": 49396
+        },
+        {
+          "key": "2ec3b31e-c86b-4ce9-b265-77c8c3f9643c",
+          "doc_count": 49335
+        },
+        {
+          "key": "3998ec8d-4aae-46db-9370-179c19b69356",
+          "doc_count": 48835
+        },
+        {
+          "key": "15aa4812-aad2-4b26-a1d8-d4f8d79e6163",
+          "doc_count": 48468
+        },
+        {
+          "key": "b688c17c-3761-4ccd-a42f-88219f5fcff4",
+          "doc_count": 48321
+        },
+        {
+          "key": "e34cf41b-196c-4199-85d5-4d2ca5954b09",
+          "doc_count": 48249
+        },
+        {
+          "key": "ef77ec72-6537-41ab-a418-17f9a58e6e73",
+          "doc_count": 48030
+        },
+        {
+          "key": "e6eba8cd-fa2c-4ba2-bec0-6841e7633695",
+          "doc_count": 47925
+        },
+        {
+          "key": "f31a5f98-efd3-476a-9627-de3add582acd",
+          "doc_count": 47407
+        },
+        {
+          "key": "a16dc8d8-ff4a-4d62-a684-2937fb292b8d",
+          "doc_count": 46459
+        },
+        {
+          "key": "645bcd10-a74f-4207-a375-0254b954b7ad",
+          "doc_count": 45833
+        },
+        {
+          "key": "7f497d81-4c7e-4e06-b166-a459968b14e3",
+          "doc_count": 45585
+        },
+        {
+          "key": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "doc_count": 45123
+        },
+        {
+          "key": "7a31ab80-1cc0-4456-9dea-61c2e9031a6f",
+          "doc_count": 45032
+        },
+        {
+          "key": "120d557c-c5be-474d-98f0-1ba00ae16b40",
+          "doc_count": 43931
+        },
+        {
+          "key": "be31dfd1-c721-4697-8ee0-f7043c070810",
+          "doc_count": 43179
+        },
+        {
+          "key": "2cf2843f-567c-45c1-a328-cc210af76fc1",
+          "doc_count": 42486
+        },
+        {
+          "key": "e794b292-4a94-471e-ab84-6aaef1fea1b3",
+          "doc_count": 41979
+        },
+        {
+          "key": "a69decc7-76ba-496a-a66e-f91049c02cf0",
+          "doc_count": 40857
+        },
+        {
+          "key": "e7ac8c4a-64bd-491b-b764-232de9b4bfe5",
+          "doc_count": 40732
+        },
+        {
+          "key": "8f689b8b-5b65-4638-9555-f2a5d237a624",
+          "doc_count": 40574
+        },
+        {
+          "key": "d0d1c390-e662-4980-97e3-ae0039a06de8",
+          "doc_count": 40469
+        },
+        {
+          "key": "6b5e29d3-b462-44d8-ba38-d68af5088067",
+          "doc_count": 40079
+        },
+        {
+          "key": "46374ee7-7c70-48d8-bf16-2e6c1626565e",
+          "doc_count": 39597
+        },
+        {
+          "key": "0f19f6d6-79a4-434e-ba0b-a4f49f334078",
+          "doc_count": 39118
+        },
+        {
+          "key": "8e58cd34-3cbb-46f7-9c25-527251881a6f",
+          "doc_count": 38676
+        },
+        {
+          "key": "c55ac6d0-180d-41be-829a-e82898c5ca54",
+          "doc_count": 37628
+        },
+        {
+          "key": "8fc08919-1137-42e4-9fa5-9e64f1e5757b",
+          "doc_count": 36996
+        },
+        {
+          "key": "d2c71720-e156-4943-8182-0a7bbe477a37",
+          "doc_count": 36771
+        },
+        {
+          "key": "32d433aa-9e2b-4ff9-bc55-5c3e30112207",
+          "doc_count": 35816
+        },
+        {
+          "key": "9e66257f-21a9-491a-ac23-06b7b62ceeb7",
+          "doc_count": 35406
+        },
+        {
+          "key": "8445ab25-ff89-44b0-90f8-bf0790f50afc",
+          "doc_count": 35403
+        },
+        {
+          "key": "23a47a5f-2ac1-4f81-acd3-21d5b82ed22a",
+          "doc_count": 35280
+        },
+        {
+          "key": "589ad4bd-a0aa-4949-bb92-0533ba7edaf2",
+          "doc_count": 35108
+        },
+        {
+          "key": "3056112e-97c6-4d0d-b6c2-3c0a9adaca24",
+          "doc_count": 34921
+        },
+        {
+          "key": "e39f6dee-f2cf-4eff-afc9-4600cafe660c",
+          "doc_count": 34553
+        },
+        {
+          "key": "99b04c9f-908e-42bd-92bc-41aa94b72949",
+          "doc_count": 33449
+        },
+        {
+          "key": "aced32f9-e511-48c7-8e9e-b625777bdf7f",
+          "doc_count": 33118
+        },
+        {
+          "key": "e4ff51ba-5007-4c40-9a86-e8c6f4db77b7",
+          "doc_count": 33097
+        },
+        {
+          "key": "0266a3f4-872b-4d21-a6b4-5c9818d8742b",
+          "doc_count": 32818
+        },
+        {
+          "key": "9a06cc34-be24-4ebf-b599-cbb1d4b8ac7b",
+          "doc_count": 31844
+        },
+        {
+          "key": "c5b7dae8-b483-4742-9954-d7f9226daa34",
+          "doc_count": 31809
+        },
+        {
+          "key": "ced8c9bc-e8b5-49e7-860a-289fc913860c",
+          "doc_count": 31549
+        },
+        {
+          "key": "6b565194-9707-42da-8052-9f9cf5f9aa60",
+          "doc_count": 31217
+        },
+        {
+          "key": "e0e37702-32af-405b-b652-ee54b5bb94e2",
+          "doc_count": 30656
+        },
+        {
+          "key": "5e893602-84ca-4c8c-bac1-99111c777582",
+          "doc_count": 30515
+        },
+        {
+          "key": "244ee82a-438c-4e77-a2ce-4e2af9ddbe4d",
+          "doc_count": 30171
+        },
+        {
+          "key": "774a153b-e556-47f6-95d1-bab49e61cc58",
+          "doc_count": 29572
+        },
+        {
+          "key": "654e092c-edbd-456c-8cce-2bcbdff71a04",
+          "doc_count": 29162
+        },
+        {
+          "key": "9cecfba6-6501-401c-9043-e95ba70164f3",
+          "doc_count": 29159
+        },
+        {
+          "key": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "doc_count": 28729
+        },
+        {
+          "key": "678dc436-3370-4992-a361-761dab8c3fda",
+          "doc_count": 28624
+        },
+        {
+          "key": "9b27c2f1-8b0a-4482-8424-8a9bb3bf0cf9",
+          "doc_count": 28520
+        },
+        {
+          "key": "570dcca6-a84f-43aa-8053-1a2ac60d9ead",
+          "doc_count": 28478
+        },
+        {
+          "key": "4f8c3594-d7b2-4985-8dd9-1ae77f9187d4",
+          "doc_count": 28155
+        },
+        {
+          "key": "e27f0218-47e0-41bc-9086-9d9169096e90",
+          "doc_count": 28062
+        },
+        {
+          "key": "e185415c-15c4-4612-89f3-27cfebbca0d9",
+          "doc_count": 27982
+        },
+        {
+          "key": "0220907a-0463-4ae0-8a0b-77f5e80fff40",
+          "doc_count": 27865
+        },
+        {
+          "key": "d29b9265-07e6-4e73-8f72-fc42d3d83fb1",
+          "doc_count": 27711
+        },
+        {
+          "key": "4db72a36-c08b-4a6b-8c68-ab45ebb0efce",
+          "doc_count": 27680
+        },
+        {
+          "key": "6bb853ab-e8ea-43b1-bd83-47318fc4c345",
+          "doc_count": 27614
+        },
+        {
+          "key": "37213da3-a1c7-4644-917e-8f8440e1c4d4",
+          "doc_count": 27344
+        },
+        {
+          "key": "181352ea-3598-4f32-b919-c8f6097f4c65",
+          "doc_count": 27092
+        },
+        {
+          "key": "a7020dbf-35fc-46e8-a441-c0a6b957193c",
+          "doc_count": 26701
+        },
+        {
+          "key": "7fbf76b1-6bd6-4217-a5bc-1d89e45f6a68",
+          "doc_count": 26605
+        },
+        {
+          "key": "e1e0f2cc-a50c-40d4-9031-c2d90a826247",
+          "doc_count": 26601
+        },
+        {
+          "key": "51b958bb-9d5f-48d7-9a97-e372c0c747c3",
+          "doc_count": 26514
+        },
+        {
+          "key": "1a44dfa0-6a54-4584-8c57-d98669d7f033",
+          "doc_count": 26323
+        },
+        {
+          "key": "025a810b-28f6-427d-b342-16fdf5f74f4b",
+          "doc_count": 26260
+        },
+        {
+          "key": "7ad07cff-f782-4ddf-b780-3a757cdb77e0",
+          "doc_count": 26149
+        },
+        {
+          "key": "d598446c-2b25-4d5d-a983-99be53001203",
+          "doc_count": 26125
+        },
+        {
+          "key": "1bfc0147-2df1-4488-bcf7-d140e24dda51",
+          "doc_count": 25733
+        },
+        {
+          "key": "dfd53a42-8f63-4040-93a5-3f1347ce7686",
+          "doc_count": 25569
+        },
+        {
+          "key": "f1a78c0f-449c-45fa-9472-0b92cc2a58da",
+          "doc_count": 24997
+        },
+        {
+          "key": "1c729855-f3dd-439d-b326-54d62f57b0fd",
+          "doc_count": 24922
+        },
+        {
+          "key": "364a24d9-d4a8-4e0b-8e50-07b90f844548",
+          "doc_count": 24529
+        },
+        {
+          "key": "6b2c3ca9-69ad-4316-a2d1-33399e9f547e",
+          "doc_count": 24481
+        },
+        {
+          "key": "518518b7-9e85-42ea-b419-2d23a3ef546a",
+          "doc_count": 24109
+        },
+        {
+          "key": "ef59f7cc-ed42-45fc-9abc-5edfb2c8caec",
+          "doc_count": 23979
+        },
+        {
+          "key": "fccc3c1d-d9df-4ffd-b7e1-1b9eb11f95b1",
+          "doc_count": 23820
+        },
+        {
+          "key": "531537fc-6349-4a20-ae42-540d61797086",
+          "doc_count": 23767
+        },
+        {
+          "key": "7e4aacd3-0a24-49ab-b019-518b7069b682",
+          "doc_count": 23576
+        },
+        {
+          "key": "04d9b721-259c-4d6b-b48f-2e23edf66c9f",
+          "doc_count": 23409
+        },
+        {
+          "key": "7110b8ba-0ead-4666-8279-e30f53e343d0",
+          "doc_count": 23286
+        },
+        {
+          "key": "c49bc91d-0a50-497b-8b17-d77808745cf9",
+          "doc_count": 23045
+        },
+        {
+          "key": "45544aa4-8762-4bf0-bfc6-890d08dc6ead",
+          "doc_count": 22907
+        },
+        {
+          "key": "2941b767-e90b-41b9-9627-6e589e0c0c85",
+          "doc_count": 22552
+        },
+        {
+          "key": "042dbdba-a449-4291-8777-577a5a4045de",
+          "doc_count": 22203
+        },
+        {
+          "key": "21b563bc-70c2-46d5-bce8-2489db2db3d8",
+          "doc_count": 21645
+        },
+        {
+          "key": "1e054b9b-0193-4ff3-b623-9264cf982d4d",
+          "doc_count": 21052
+        },
+        {
+          "key": "5aef068f-efd3-4851-a623-f542e97350cd",
+          "doc_count": 20465
+        },
+        {
+          "key": "e7016bd5-cb10-45b9-8959-0f5750f7a5db",
+          "doc_count": 20384
+        },
+        {
+          "key": "b000920c-6f7d-49d3-9d0f-2bb630d2e01a",
+          "doc_count": 20310
+        },
+        {
+          "key": "3f508496-c860-4701-93e4-84e940c8395e",
+          "doc_count": 20172
+        },
+        {
+          "key": "98ece30d-bf85-4122-b872-7786031b457f",
+          "doc_count": 19756
+        },
+        {
+          "key": "77b762ba-7cda-4617-97d7-e78df7f6dfab",
+          "doc_count": 19665
+        },
+        {
+          "key": "9e1958fb-1dc4-4375-ae35-67ba7f9c7afe",
+          "doc_count": 19660
+        },
+        {
+          "key": "48f5d475-7381-4d06-88eb-119796b9d189",
+          "doc_count": 19451
+        },
+        {
+          "key": "f630e3ea-697f-404a-8683-b86712c26c43",
+          "doc_count": 19168
+        },
+        {
+          "key": "e9b69a0a-497d-4201-b114-51519a4dfef9",
+          "doc_count": 19118
+        },
+        {
+          "key": "d100843b-d592-4024-8d15-fb1d8e218acd",
+          "doc_count": 19101
+        },
+        {
+          "key": "4ef6540c-e6cf-4678-bc43-b57435354de0",
+          "doc_count": 19067
+        },
+        {
+          "key": "1b6bb28e-e443-4cd3-910a-c6c43849c2cd",
+          "doc_count": 18944
+        },
+        {
+          "key": "a2a17035-1e6c-46df-9178-a610df825336",
+          "doc_count": 18851
+        },
+        {
+          "key": "1f5a1b81-e361-4d65-ab1c-6fb7e30c9910",
+          "doc_count": 18565
+        },
+        {
+          "key": "8e5fffb5-0b22-472d-8386-de291d17d513",
+          "doc_count": 18376
+        },
+        {
+          "key": "cb65cf5e-07b8-4d53-a91a-7dce9b8ccf80",
+          "doc_count": 18304
+        },
+        {
+          "key": "50cfe20a-9100-4710-89f9-a97bc3aa53d7",
+          "doc_count": 18060
+        },
+        {
+          "key": "92dd8c8e-c048-4f0a-9b5d-2ee627d2f553",
+          "doc_count": 17946
+        },
+        {
+          "key": "65007e62-740c-4302-ba20-260fe68da291",
+          "doc_count": 17883
+        },
+        {
+          "key": "79488fda-8310-42cd-b98e-8c3c2dd7d415",
+          "doc_count": 17834
+        },
+        {
+          "key": "c9dad611-5e60-4456-934e-75b0e0842ddd",
+          "doc_count": 17782
+        },
+        {
+          "key": "437826f3-69f9-43d9-b3c3-c0de0e26cd88",
+          "doc_count": 17715
+        },
+        {
+          "key": "bf9066a2-2c5f-4cf2-821a-1a68b4df5b1b",
+          "doc_count": 17648
+        },
+        {
+          "key": "aac5fd7f-8043-4aa8-811f-e50de70d96f3",
+          "doc_count": 17478
+        },
+        {
+          "key": "f33e9494-7b3c-4ac6-a735-59693b5a9638",
+          "doc_count": 17427
+        },
+        {
+          "key": "821c1855-6817-40ee-8732-7f472d238513",
+          "doc_count": 17079
+        },
+        {
+          "key": "a062eb42-d5c6-4332-8c88-64b4ac1af892",
+          "doc_count": 17036
+        },
+        {
+          "key": "2b45c778-b10c-496b-b8cb-1e414da59ccf",
+          "doc_count": 16711
+        },
+        {
+          "key": "c3134980-bf5c-49b8-a289-790d45f02c86",
+          "doc_count": 16504
+        },
+        {
+          "key": "7ae4d15d-62e2-459b-842a-446f921b9d3f",
+          "doc_count": 16477
+        },
+        {
+          "key": "4fed055b-3c46-4ec4-b76d-84d43df9258b",
+          "doc_count": 16341
+        },
+        {
+          "key": "8295ea14-c4fd-499b-bc68-2907ed36badc",
+          "doc_count": 16217
+        },
+        {
+          "key": "c5eeb223-0515-423a-a51a-151426c8f60d",
+          "doc_count": 16149
+        },
+        {
+          "key": "b30a7dd2-d974-4073-bdd0-cb4ea5402bae",
+          "doc_count": 15961
+        },
+        {
+          "key": "1e798b2d-7f97-49b0-a864-79c968af91d3",
+          "doc_count": 15664
+        },
+        {
+          "key": "53af19e1-9cb3-4834-8974-62adc640491c",
+          "doc_count": 15560
+        },
+        {
+          "key": "ad4e4ea0-2ac9-4030-b4bd-bf4206e79bcc",
+          "doc_count": 15339
+        },
+        {
+          "key": "6ae7221e-2085-46cf-9ad0-353269e95bc8",
+          "doc_count": 15175
+        },
+        {
+          "key": "cd177f63-761b-44f6-866e-ee19d2ac134e",
+          "doc_count": 14855
+        },
+        {
+          "key": "0038ce2e-43bb-4f70-8dd6-dca34efd3fca",
+          "doc_count": 14808
+        },
+        {
+          "key": "50b0bbe4-f075-4427-8dfc-fcc469dd3e78",
+          "doc_count": 14583
+        },
+        {
+          "key": "92e4e092-6dcb-46bc-85a0-dea8310aba45",
+          "doc_count": 14534
+        },
+        {
+          "key": "837d99c6-3045-4ba3-8951-643ddb3d6676",
+          "doc_count": 14434
+        },
+        {
+          "key": "bbf5f8ed-f33f-40ba-9d0d-1c24dfec4193",
+          "doc_count": 13613
+        },
+        {
+          "key": "a4378725-7967-47bc-aada-0220e02e1f96",
+          "doc_count": 13552
+        },
+        {
+          "key": "c9bff84f-8de4-43e6-b195-f515f187a68a",
+          "doc_count": 13487
+        },
+        {
+          "key": "662b1aa5-9c19-4eb9-9766-1da78a117456",
+          "doc_count": 13461
+        },
+        {
+          "key": "e3c0918d-ec6e-4ecd-a1db-15ec6880dade",
+          "doc_count": 13426
+        },
+        {
+          "key": "5a9ae910-9e4b-488b-af8e-88074fabc3a4",
+          "doc_count": 13374
+        },
+        {
+          "key": "e23109b4-e143-437c-b329-3dff7cb35488",
+          "doc_count": 13082
+        },
+        {
+          "key": "87017793-00dc-4f5d-b95b-09e7d17327cc",
+          "doc_count": 12983
+        },
+        {
+          "key": "341611f4-8b65-4655-b244-9be91a1109cd",
+          "doc_count": 12978
+        },
+        {
+          "key": "c3f05887-ffa9-44c4-b1af-e38fea5557bf",
+          "doc_count": 12961
+        },
+        {
+          "key": "e4b33221-1e2c-405c-ac02-a39d93f9a69b",
+          "doc_count": 12914
+        },
+        {
+          "key": "bd7cfd55-bf55-46fc-878d-e6e11f574ccd",
+          "doc_count": 12632
+        },
+        {
+          "key": "13510466-6232-4313-9e46-ea197b82750c",
+          "doc_count": 12631
+        },
+        {
+          "key": "86b2bfc9-ca99-4250-b93a-f86f3777236d",
+          "doc_count": 12457
+        },
+        {
+          "key": "91c5eec8-0cdc-4be2-9a99-a15ae5ec3edc",
+          "doc_count": 12373
+        },
+        {
+          "key": "063825dc-b8c3-4962-aea4-9994bcc09bc8",
+          "doc_count": 12238
+        },
+        {
+          "key": "139f2c47-4051-4c44-b95a-45fd20b1a8b9",
+          "doc_count": 12151
+        },
+        {
+          "key": "3c367a2d-eec0-4ef1-b3bc-4cbebb320c5a",
+          "doc_count": 11895
+        },
+        {
+          "key": "b5e5c781-765f-4981-af2a-c19c250e2cf0",
+          "doc_count": 11662
+        },
+        {
+          "key": "93e97f6c-0ab6-41a7-9b58-7e230a80ec1e",
+          "doc_count": 11634
+        },
+        {
+          "key": "2532cbd0-2752-4211-b249-4a9811a280f2",
+          "doc_count": 11614
+        },
+        {
+          "key": "04fe30b4-c1e5-4482-addb-67a4c2cd39ef",
+          "doc_count": 11602
+        },
+        {
+          "key": "cd46dc32-5e36-414b-a8d7-dea9df1f9106",
+          "doc_count": 11272
+        },
+        {
+          "key": "4d89070b-5dea-4a12-8a09-3f65ba33dba1",
+          "doc_count": 10956
+        },
+        {
+          "key": "1ad40bde-8a2a-46bb-9252-0cdc53df5683",
+          "doc_count": 10874
+        },
+        {
+          "key": "3ac8f738-bc3e-43e4-8358-00a32594954d",
+          "doc_count": 10763
+        },
+        {
+          "key": "5082e6c8-8f5b-4bf6-a930-e3e6de7bf6fb",
+          "doc_count": 10677
+        },
+        {
+          "key": "f89ada44-88df-46f0-bc61-cc46d9c84673",
+          "doc_count": 10668
+        },
+        {
+          "key": "3e86e072-2597-4849-87d5-565afe40f988",
+          "doc_count": 10594
+        },
+        {
+          "key": "6d09cfc1-a17c-4067-b1a0-557b8e5334ea",
+          "doc_count": 10542
+        },
+        {
+          "key": "ab4b6a2b-a90a-44ce-95a1-2c44c911fcc6",
+          "doc_count": 10504
+        },
+        {
+          "key": "a2a7754b-2346-496d-b681-eb754ef32b9e",
+          "doc_count": 10384
+        },
+        {
+          "key": "12018be6-3795-43a3-a073-a2b9d60c0af3",
+          "doc_count": 10183
+        },
+        {
+          "key": "bfa3c276-a3a9-48cd-8d4a-4ac42f4fe10a",
+          "doc_count": 10134
+        },
+        {
+          "key": "06c35934-1b75-4196-838d-29d509951bf9",
+          "doc_count": 10044
+        },
+        {
+          "key": "81dc7cdb-66be-4683-ae79-068a784378b1",
+          "doc_count": 10033
+        },
+        {
+          "key": "c94a06a5-df24-4546-adba-4f7940661826",
+          "doc_count": 9963
+        },
+        {
+          "key": "7cc1fb18-45c1-499f-8476-682daa14a4a3",
+          "doc_count": 9890
+        },
+        {
+          "key": "79aa7602-a963-44f3-82dd-e141a387adb8",
+          "doc_count": 9861
+        },
+        {
+          "key": "15e04168-22cc-4283-9042-247ab053c7ca",
+          "doc_count": 9804
+        },
+        {
+          "key": "dddf9315-7819-4289-b587-6be72e4894d2",
+          "doc_count": 9761
+        },
+        {
+          "key": "252a0a12-f114-4fb5-aa9a-678c523d6dcd",
+          "doc_count": 9535
+        },
+        {
+          "key": "e701ecce-f9ab-445f-afcb-24f279efbc9c",
+          "doc_count": 9475
+        },
+        {
+          "key": "3c6f1ea5-f2e7-4203-9cfe-74ec2fb1b035",
+          "doc_count": 9426
+        },
+        {
+          "key": "c004cf67-eafc-49f9-99bd-b8198e2234ed",
+          "doc_count": 9370
+        },
+        {
+          "key": "abe3903e-ceba-4864-aa5d-bd985c70fa21",
+          "doc_count": 9205
+        },
+        {
+          "key": "3a5b5c9b-b241-4883-904a-b167a7edb41a",
+          "doc_count": 9155
+        },
+        {
+          "key": "90739622-5232-4048-8121-9af9ec69604f",
+          "doc_count": 9154
+        },
+        {
+          "key": "5889291d-9105-4740-a30f-2d9d2469c264",
+          "doc_count": 9100
+        },
+        {
+          "key": "f0599190-e5b7-42ed-bec8-810905f50c34",
+          "doc_count": 8900
+        },
+        {
+          "key": "ec248223-f277-4c02-b1fa-60056b5a689a",
+          "doc_count": 8865
+        },
+        {
+          "key": "9d2a4189-6048-46e9-bac4-e5ef566334bb",
+          "doc_count": 8857
+        },
+        {
+          "key": "dbb2acdc-a808-4deb-9dc2-542d70368a3f",
+          "doc_count": 8797
+        },
+        {
+          "key": "0272afc1-36ee-4899-8c28-dde9d8a211d9",
+          "doc_count": 8788
+        },
+        {
+          "key": "414a5bf5-061e-4e47-8410-0f76a04f7d1d",
+          "doc_count": 8715
+        },
+        {
+          "key": "5ffc8bc6-e366-4157-b1ba-00859f1048a4",
+          "doc_count": 8701
+        },
+        {
+          "key": "f08c31ea-0e90-4cc1-b471-dfd0584ae7cf",
+          "doc_count": 8470
+        },
+        {
+          "key": "9756b9a4-c070-4359-8a07-2383b09d0d04",
+          "doc_count": 8361
+        },
+        {
+          "key": "bdf65f9c-a730-4083-bd8d-a2def3037637",
+          "doc_count": 8345
+        },
+        {
+          "key": "ef04e127-bb7d-4bf0-82d3-767d43108f81",
+          "doc_count": 8289
+        },
+        {
+          "key": "e7db896a-c95b-4a18-99a4-866fff238ca5",
+          "doc_count": 8046
+        },
+        {
+          "key": "331b6d1b-842e-4c63-aa23-75ef275d8a9f",
+          "doc_count": 8010
+        },
+        {
+          "key": "81d00e23-92aa-45d7-b289-5cf045ddfbf4",
+          "doc_count": 7958
+        },
+        {
+          "key": "cfe5c00e-bec3-4120-a8eb-62c5353f3e80",
+          "doc_count": 7903
+        },
+        {
+          "key": "cf60ed8a-2c79-4b85-a259-15a8e216dae4",
+          "doc_count": 7897
+        },
+        {
+          "key": "665f34ed-bfa3-4b25-a838-3b97f4dce586",
+          "doc_count": 7829
+        },
+        {
+          "key": "7e44229a-e8fa-4570-ada1-0cd7843a66d7",
+          "doc_count": 7747
+        },
+        {
+          "key": "6539877e-82dc-485c-ad3d-038f383d5431",
+          "doc_count": 7721
+        },
+        {
+          "key": "eaa5f19e-ff6f-4d09-8b55-4a6810e77a6c",
+          "doc_count": 7647
+        },
+        {
+          "key": "4960f30c-c1c7-490e-966a-61ad02969e38",
+          "doc_count": 7577
+        },
+        {
+          "key": "540e18dc-09aa-4790-8b47-8d18ae86fabc",
+          "doc_count": 7567
+        },
+        {
+          "key": "364b1f8d-5975-48d9-bba1-c97ab172986c",
+          "doc_count": 7551
+        },
+        {
+          "key": "1ffce054-8e3e-4209-9ff4-c26fa6c24c2f",
+          "doc_count": 7491
+        },
+        {
+          "key": "e77108de-88dd-4931-8085-0ea59d7ca4ee",
+          "doc_count": 7378
+        },
+        {
+          "key": "3501e0a6-1420-45b9-bbf9-77349e79e9d7",
+          "doc_count": 7307
+        },
+        {
+          "key": "c7ae0ade-c23e-4fe6-a3d4-79bd973374c2",
+          "doc_count": 7276
+        },
+        {
+          "key": "75e3aff5-b3d0-45c3-835c-5ffde192c63f",
+          "doc_count": 7170
+        },
+        {
+          "key": "5fd5a403-8e94-4865-8c77-ee92cb4a95f2",
+          "doc_count": 7150
+        },
+        {
+          "key": "4f436daa-01d5-4be6-b5c3-fdd255677536",
+          "doc_count": 6994
+        },
+        {
+          "key": "e80fe2bb-547d-4e98-84ce-01176379e3a8",
+          "doc_count": 6843
+        },
+        {
+          "key": "482990c6-da88-4d99-8cf4-ccd27ee82f44",
+          "doc_count": 6836
+        },
+        {
+          "key": "d6c6e57a-4ccb-4707-b87d-c91d01d6aa42",
+          "doc_count": 6814
+        },
+        {
+          "key": "d840624f-42d5-40d9-9daa-2260f85feb54",
+          "doc_count": 6806
+        },
+        {
+          "key": "a83151ae-e1db-4166-9dde-438f6544dca9",
+          "doc_count": 6732
+        },
+        {
+          "key": "ea9de87b-7231-4a05-809f-4b658ea4173d",
+          "doc_count": 6722
+        },
+        {
+          "key": "cd7b335e-6f5c-4259-ba45-5e334a719464",
+          "doc_count": 6667
+        },
+        {
+          "key": "73236de8-c2cc-458c-b0c3-743c7b57db3a",
+          "doc_count": 6634
+        },
+        {
+          "key": "b00cf471-6bbe-4f94-846e-288900398b65",
+          "doc_count": 6626
+        },
+        {
+          "key": "69037495-438d-4dba-bf0f-4878073766f1",
+          "doc_count": 6610
+        },
+        {
+          "key": "b4bcc255-4acf-4966-b9b3-af9dd4e458d1",
+          "doc_count": 6576
+        },
+        {
+          "key": "5ab5f23d-292e-4bea-ba06-12db0f8a8c86",
+          "doc_count": 6530
+        },
+        {
+          "key": "7ed2ce52-26e5-4847-9563-955ae3e97455",
+          "doc_count": 6526
+        },
+        {
+          "key": "c38b867b-05f3-4733-802e-d8d2d3324f84",
+          "doc_count": 6400
+        },
+        {
+          "key": "959c0dc4-fcf3-477e-af63-c00a005dbc0a",
+          "doc_count": 6384
+        },
+        {
+          "key": "beb74dc2-22ea-49e4-b1e3-bedb8e06e8f2",
+          "doc_count": 6365
+        },
+        {
+          "key": "b1ed65bb-f27e-4695-a0f5-7ca52fc0c3e6",
+          "doc_count": 6275
+        },
+        {
+          "key": "2c662e9e-cdc6-4bbf-93a5-1566ceca1af3",
+          "doc_count": 6268
+        },
+        {
+          "key": "5486b66d-2082-433d-9223-bd789ebca29c",
+          "doc_count": 6172
+        },
+        {
+          "key": "d5a1b706-c624-43df-afcf-9cea7094e75b",
+          "doc_count": 6164
+        },
+        {
+          "key": "e5cb850f-de98-45ce-9872-95262732809f",
+          "doc_count": 6015
+        },
+        {
+          "key": "8eabbc48-2b30-419d-bd8f-eece9185eca1",
+          "doc_count": 6001
+        },
+        {
+          "key": "55e724a4-336a-4315-99e7-01bf0c94f222",
+          "doc_count": 5924
+        },
+        {
+          "key": "1eca069b-09e0-406d-9625-cb9c52e1e5cc",
+          "doc_count": 5917
+        },
+        {
+          "key": "954ec5e0-4fcd-414d-8ad2-46b4b75cfc74",
+          "doc_count": 5902
+        },
+        {
+          "key": "d5c32031-231f-4213-b0f1-2dc4bbf711a0",
+          "doc_count": 5891
+        },
+        {
+          "key": "22436fe4-5049-4266-9849-335dd3f161aa",
+          "doc_count": 5863
+        },
+        {
+          "key": "c1122f57-9ab9-4552-9393-7d56b0bbe852",
+          "doc_count": 5797
+        },
+        {
+          "key": "8bcb95b2-ab5c-4368-8ead-14588eeb9c98",
+          "doc_count": 5756
+        },
+        {
+          "key": "6f470382-cb0b-4634-a796-2248bfa97fdc",
+          "doc_count": 5696
+        },
+        {
+          "key": "44328ef7-fc7f-4ff6-b51b-ed9049857e11",
+          "doc_count": 5680
+        },
+        {
+          "key": "9368e302-f8e7-4714-aed4-db2faa861e5c",
+          "doc_count": 5642
+        },
+        {
+          "key": "67893f3c-c409-41c6-a8f2-47956739a911",
+          "doc_count": 5541
+        },
+        {
+          "key": "ec135c9b-ff89-4f28-aa18-88b16d932d94",
+          "doc_count": 5441
+        },
+        {
+          "key": "5af1bae4-35c0-4ab7-9d08-08bbe22ca003",
+          "doc_count": 5428
+        },
+        {
+          "key": "347579f4-d44a-4c8e-a578-09c2a8132573",
+          "doc_count": 5391
+        },
+        {
+          "key": "a5fdee09-34c4-48bc-99ff-a503c93a9d7e",
+          "doc_count": 5227
+        },
+        {
+          "key": "66427724-af1d-43f8-bc00-cb744e55ac2c",
+          "doc_count": 5222
+        },
+        {
+          "key": "fd14095c-3658-4e00-8cec-729a89459e92",
+          "doc_count": 5138
+        },
+        {
+          "key": "7cea906d-ae65-420c-a6f7-a9a3ad64fb93",
+          "doc_count": 5121
+        },
+        {
+          "key": "589ee0cf-456c-4d9c-8e7e-3adc3cec0e09",
+          "doc_count": 5111
+        },
+        {
+          "key": "de5203b1-5a44-4010-948c-b7d33f46397a",
+          "doc_count": 5099
+        },
+        {
+          "key": "f5d395b8-c3c9-43df-b4ff-63d65c6a971e",
+          "doc_count": 5037
+        },
+        {
+          "key": "6cab4420-11e4-4b55-85ac-6ecfdda70184",
+          "doc_count": 5023
+        },
+        {
+          "key": "43c69d2a-0fd2-4d34-a1ef-50d0f9c01353",
+          "doc_count": 5020
+        },
+        {
+          "key": "d14d21fe-da24-47e5-81fb-4bfe962ce828",
+          "doc_count": 5003
+        },
+        {
+          "key": "a4babe52-5740-44e4-9ea2-acef4797f127",
+          "doc_count": 4970
+        },
+        {
+          "key": "2f740a87-8049-435d-9d06-1c393c9c11b7",
+          "doc_count": 4851
+        },
+        {
+          "key": "196c4f1c-53f9-480f-a012-dc0522629047",
+          "doc_count": 4660
+        },
+        {
+          "key": "282fe9c2-d6cb-4325-b3b5-b70ab1d22bbb",
+          "doc_count": 4611
+        },
+        {
+          "key": "fe04dab1-5a3d-4c28-a450-012658e982d8",
+          "doc_count": 4570
+        },
+        {
+          "key": "9b34b218-efb2-43b9-9b9e-dac3c470a9f9",
+          "doc_count": 4552
+        },
+        {
+          "key": "b1beb057-bc34-49a9-b784-2a50af226712",
+          "doc_count": 4442
+        },
+        {
+          "key": "25cd5e12-7830-4f46-bf6d-9b6deb706f44",
+          "doc_count": 4339
+        },
+        {
+          "key": "295a8445-346f-4ea2-b0cf-4a3863c72cdb",
+          "doc_count": 4301
+        },
+        {
+          "key": "6e922c92-b37d-4c46-8982-19d945ff8fd1",
+          "doc_count": 4272
+        },
+        {
+          "key": "23b85d9d-4669-40db-901f-aaad686fe0b8",
+          "doc_count": 4241
+        },
+        {
+          "key": "2b03a9d6-3575-43ea-8f43-38cbe0ee72e6",
+          "doc_count": 4231
+        },
+        {
+          "key": "9e046dad-2b23-4f95-8eaf-c0346de2556e",
+          "doc_count": 4226
+        },
+        {
+          "key": "69d150df-eba4-4ab3-9156-71cb0db41830",
+          "doc_count": 4207
+        },
+        {
+          "key": "c5d42fed-eed0-4e14-9625-f8a9c0ff6bb1",
+          "doc_count": 4196
+        },
+        {
+          "key": "497d74c2-d07f-4325-ac9c-8e80bcb53f61",
+          "doc_count": 4187
+        },
+        {
+          "key": "4bec11d1-f8c3-43a7-9e70-ee0256fcedaf",
+          "doc_count": 4187
+        },
+        {
+          "key": "4790a6a0-ce11-4cd8-8cad-4b2032a55c1b",
+          "doc_count": 4168
+        },
+        {
+          "key": "fc628e53-5fdf-4436-9782-bf637d812b48",
+          "doc_count": 4153
+        },
+        {
+          "key": "eeb4872b-7fb4-4ecd-8ce5-82e194f04735",
+          "doc_count": 4138
+        },
+        {
+          "key": "7370af7d-07b5-4fc6-9eca-0204b4d6e33e",
+          "doc_count": 4122
+        },
+        {
+          "key": "093030d9-a124-42a8-8cf3-8c6904fefbe7",
+          "doc_count": 4116
+        },
+        {
+          "key": "6f510e69-96b2-4817-bab7-3a36c8250c79",
+          "doc_count": 4074
+        },
+        {
+          "key": "2bbafa00-3162-4e8e-947c-64a13b8d3fef",
+          "doc_count": 4069
+        },
+        {
+          "key": "11170c5e-033a-4410-aed1-3dee2458bc43",
+          "doc_count": 4063
+        },
+        {
+          "key": "0e5201c0-bad2-4e28-9322-5c5dca8862c8",
+          "doc_count": 4010
+        },
+        {
+          "key": "9c963109-9898-4953-a351-d5ee36d6115b",
+          "doc_count": 4010
+        },
+        {
+          "key": "6ac89a16-4604-4a78-9047-dcc57e5c0130",
+          "doc_count": 3961
+        },
+        {
+          "key": "d6f12b28-bb9f-44f9-9000-08f644658bf8",
+          "doc_count": 3955
+        },
+        {
+          "key": "833306f7-91b6-4ff7-bc16-0e406334d991",
+          "doc_count": 3949
+        },
+        {
+          "key": "677f57a9-9a0d-4e69-8622-96aa1e6392c2",
+          "doc_count": 3921
+        },
+        {
+          "key": "9fab87bf-c5a7-4296-acdc-f22859cfe620",
+          "doc_count": 3898
+        },
+        {
+          "key": "d1b25dcd-472e-4902-b53c-3b164269e049",
+          "doc_count": 3879
+        },
+        {
+          "key": "9d9b81f1-3a9a-4515-b741-a145293f1fef",
+          "doc_count": 3849
+        },
+        {
+          "key": "2d4658e3-0d1a-43fc-97ff-b4813dd1f86e",
+          "doc_count": 3831
+        },
+        {
+          "key": "b8972f6b-c67f-45c0-b348-954866e04a0f",
+          "doc_count": 3777
+        },
+        {
+          "key": "560ba8f5-0dab-46f6-985d-7b37397344cd",
+          "doc_count": 3755
+        },
+        {
+          "key": "49153f74-2969-4a6a-a145-309fcb970308",
+          "doc_count": 3748
+        },
+        {
+          "key": "64b54f96-91f0-4442-b6de-173aa1a5c31b",
+          "doc_count": 3740
+        },
+        {
+          "key": "196bb137-2f82-40d5-b294-e730af29749f",
+          "doc_count": 3738
+        },
+        {
+          "key": "09a76937-b01a-4f4a-aefd-825876453015",
+          "doc_count": 3678
+        },
+        {
+          "key": "a50e98bd-13e9-41fe-a5cc-aee4f240628b",
+          "doc_count": 3674
+        },
+        {
+          "key": "66e00116-15fa-4149-a94a-eb91b98b622c",
+          "doc_count": 3632
+        },
+        {
+          "key": "1f8c7572-5cda-44be-9a78-0658217fc279",
+          "doc_count": 3622
+        },
+        {
+          "key": "6b6c13d9-7789-4da0-99d7-6786322e2612",
+          "doc_count": 3597
+        },
+        {
+          "key": "a2bc3d61-3c37-4aca-b47d-c3413f7e3b87",
+          "doc_count": 3591
+        },
+        {
+          "key": "4c9d08ce-71c1-47b8-a572-2d40e5984c49",
+          "doc_count": 3564
+        },
+        {
+          "key": "34cad268-8226-4280-b637-dde38c82a29e",
+          "doc_count": 3514
+        },
+        {
+          "key": "b880344e-22b2-4540-a56a-1de5f5601a20",
+          "doc_count": 3480
+        },
+        {
+          "key": "ff111763-e72d-4f24-8914-b5b2dd94908c",
+          "doc_count": 3478
+        },
+        {
+          "key": "55b17f44-8c6b-4dc5-a31d-d9955b425790",
+          "doc_count": 3458
+        },
+        {
+          "key": "0e0e9bbc-1dea-4de4-95ae-aecc90844bbf",
+          "doc_count": 3338
+        },
+        {
+          "key": "9a09745d-4449-46a2-b8b3-60f3c0d25e83",
+          "doc_count": 3334
+        },
+        {
+          "key": "b40e13f7-a79a-4265-93d9-3b4878dfc988",
+          "doc_count": 3303
+        },
+        {
+          "key": "4900d7ce-9442-4305-9889-c9cbbb953eaa",
+          "doc_count": 3296
+        },
+        {
+          "key": "2292f5d5-d39f-4944-be72-fa5dd62f581c",
+          "doc_count": 3287
+        },
+        {
+          "key": "7026b70a-7245-42bd-8162-81ae9a6cfbcb",
+          "doc_count": 3262
+        },
+        {
+          "key": "bf897c17-06cc-48c1-a7cc-f41b45166880",
+          "doc_count": 3244
+        },
+        {
+          "key": "8728ef71-fdcc-4027-8139-38b2c0628fba",
+          "doc_count": 3205
+        },
+        {
+          "key": "df516dc6-6ef0-426d-94e3-8a2bbb0439a5",
+          "doc_count": 3174
+        },
+        {
+          "key": "e85a9948-9c9e-451d-9485-b2b4cb7b73d5",
+          "doc_count": 3161
+        },
+        {
+          "key": "ef637c01-c551-4d47-8a48-4442b8ad5ecd",
+          "doc_count": 3152
+        },
+        {
+          "key": "79be41bc-8142-485a-9d57-d6195f9a7c81",
+          "doc_count": 3137
+        },
+        {
+          "key": "fcbcb214-cd62-4453-af56-b4b49161a261",
+          "doc_count": 3137
+        },
+        {
+          "key": "fc40fabd-0a70-48fa-b142-79990cd259a5",
+          "doc_count": 3107
+        },
+        {
+          "key": "d1983d53-434a-436e-a698-3a2745eb61dc",
+          "doc_count": 3090
+        },
+        {
+          "key": "0bfd2d69-2a35-4291-9e73-bd311463bd15",
+          "doc_count": 3076
+        },
+        {
+          "key": "6d4b658a-90b4-4639-8b06-b7f07637f6aa",
+          "doc_count": 3062
+        },
+        {
+          "key": "b4d4e884-a2ef-4967-b4cb-2072fc465eaf",
+          "doc_count": 3043
+        },
+        {
+          "key": "b20588fd-61f4-4765-8025-30c81a5f4250",
+          "doc_count": 2975
+        },
+        {
+          "key": "47ac1531-5213-4848-a32d-5bb396ab9348",
+          "doc_count": 2966
+        },
+        {
+          "key": "d81c6ad6-fb8f-4c31-bba3-f2b65f780893",
+          "doc_count": 2962
+        },
+        {
+          "key": "2e3a8e5c-eef9-462d-a690-3a91fe111e13",
+          "doc_count": 2959
+        },
+        {
+          "key": "9fa0a48c-7dd2-4372-a768-9aea3cbd35bb",
+          "doc_count": 2919
+        },
+        {
+          "key": "5277e72c-9e53-4c98-85f1-ee413bc473cd",
+          "doc_count": 2909
+        },
+        {
+          "key": "9f3bbc7b-c682-4f66-88b3-48eef3a38f38",
+          "doc_count": 2865
+        },
+        {
+          "key": "39289378-eed8-442c-ba0b-fce8b1679d8f",
+          "doc_count": 2856
+        },
+        {
+          "key": "333ac26a-30bc-4e0c-a6ef-c57a40f6bd99",
+          "doc_count": 2830
+        },
+        {
+          "key": "8783e947-93cf-4b60-b387-d10642b0eee0",
+          "doc_count": 2829
+        },
+        {
+          "key": "19daf0a7-5e37-41e6-97f8-4494553c358c",
+          "doc_count": 2822
+        },
+        {
+          "key": "5e8863ea-56ec-40f3-8075-d42b35d12e72",
+          "doc_count": 2789
+        },
+        {
+          "key": "59734d15-8edb-41a4-b3f2-f9bd3407460b",
+          "doc_count": 2778
+        },
+        {
+          "key": "d08a71aa-fe87-4bf5-ac68-8e7497bf585c",
+          "doc_count": 2745
+        },
+        {
+          "key": "40d35f62-cf89-488a-bad3-66e66d38c10c",
+          "doc_count": 2733
+        },
+        {
+          "key": "ef30a918-b583-41f1-9ac4-4a37591b515a",
+          "doc_count": 2692
+        },
+        {
+          "key": "cc11b4e3-823d-4490-95b2-afe6a1f3a9d2",
+          "doc_count": 2679
+        },
+        {
+          "key": "7c927849-94ed-4034-90e9-af34ac0cb47c",
+          "doc_count": 2664
+        },
+        {
+          "key": "2eb8ff2f-4826-4fc3-be68-22d805bcae88",
+          "doc_count": 2658
+        },
+        {
+          "key": "33bac15d-b1d0-42a1-8801-86149887eeef",
+          "doc_count": 2639
+        },
+        {
+          "key": "1aa66130-6668-4c4b-8383-a51b8e8389ec",
+          "doc_count": 2506
+        },
+        {
+          "key": "96588aed-3b7a-4179-b92b-2159427f4fcb",
+          "doc_count": 2479
+        },
+        {
+          "key": "5ddcbd44-1802-46b0-bae5-11126409c03d",
+          "doc_count": 2432
+        },
+        {
+          "key": "b5234343-b0f1-472a-9db7-dfa78affd402",
+          "doc_count": 2396
+        },
+        {
+          "key": "7232e59b-b0e1-49cd-9632-b8ae1f49f828",
+          "doc_count": 2390
+        },
+        {
+          "key": "0dabd609-2505-4492-8b7a-3f8301d8d5e1",
+          "doc_count": 2381
+        },
+        {
+          "key": "e38af226-7109-4f99-a6f1-9fd3bec5638d",
+          "doc_count": 2364
+        },
+        {
+          "key": "0072bf11-a354-4998-8730-c0cb4cfc9517",
+          "doc_count": 2351
+        },
+        {
+          "key": "d315c4a3-0bee-49d1-8d03-726358937cde",
+          "doc_count": 2308
+        },
+        {
+          "key": "9354db6c-4019-4351-a822-cb87b1b73a44",
+          "doc_count": 2247
+        },
+        {
+          "key": "e73fedf0-90ee-4c6d-88dd-49399878fc54",
+          "doc_count": 2227
+        },
+        {
+          "key": "3a0d8092-c577-4775-a586-1542574edc53",
+          "doc_count": 2188
+        },
+        {
+          "key": "18c215c3-c02f-47e9-bb66-196c33c8f672",
+          "doc_count": 2056
+        },
+        {
+          "key": "b985f284-eac5-4efe-8a7c-c726cdf7cf33",
+          "doc_count": 2055
+        },
+        {
+          "key": "82541f90-fe8e-4d66-84d8-4fe515dc5533",
+          "doc_count": 2035
+        },
+        {
+          "key": "3ad82604-c4b3-4fd0-b03e-d8f874062146",
+          "doc_count": 2009
+        },
+        {
+          "key": "db4bb0df-8539-4617-ab5f-eb118aa3126b",
+          "doc_count": 2002
+        },
+        {
+          "key": "8157bc94-5fba-4bf6-98bd-9ba653b595e8",
+          "doc_count": 1963
+        },
+        {
+          "key": "994b60a2-88f1-49ec-a6da-27d56dfa6f16",
+          "doc_count": 1958
+        },
+        {
+          "key": "fb97dfb4-72be-4dc1-9f5a-2faea75341b4",
+          "doc_count": 1883
+        },
+        {
+          "key": "30ab9c2a-0b54-4c04-84ca-bc7abdd90b52",
+          "doc_count": 1876
+        },
+        {
+          "key": "f9a33279-d6ba-41c7-a511-ef6adfcb6e20",
+          "doc_count": 1831
+        },
+        {
+          "key": "a0ec3ce6-fc8a-48b7-9105-cecf27602e37",
+          "doc_count": 1812
+        },
+        {
+          "key": "5d7869be-8526-43d8-af53-f16a15ebadb5",
+          "doc_count": 1808
+        },
+        {
+          "key": "401fec56-515d-4fa8-87d1-507e742f4f6f",
+          "doc_count": 1802
+        },
+        {
+          "key": "045aa661-f985-4203-80ff-98daafdfe377",
+          "doc_count": 1792
+        },
+        {
+          "key": "09b18522-5643-478f-86e9-d2e34440d43e",
+          "doc_count": 1782
+        },
+        {
+          "key": "8e4ff036-d38e-455f-a0fe-4ac50823f4fb",
+          "doc_count": 1742
+        },
+        {
+          "key": "2e65e24b-b7e2-40a4-a40c-09edafc1e3f4",
+          "doc_count": 1687
+        },
+        {
+          "key": "241d64f1-480a-48ae-8ec2-cd12af4a16e9",
+          "doc_count": 1685
+        },
+        {
+          "key": "7e43ea77-d2e5-4bdc-a4f7-a4792866f53f",
+          "doc_count": 1664
+        },
+        {
+          "key": "ff0d1543-247c-4039-a8ff-cf4fc224c449",
+          "doc_count": 1663
+        },
+        {
+          "key": "87c45c90-ba1d-409e-a9d7-9baf5a5cbb1c",
+          "doc_count": 1631
+        },
+        {
+          "key": "0e2f3962-e905-48f2-a1c6-19d16e2bd5ba",
+          "doc_count": 1630
+        },
+        {
+          "key": "7340c0df-8829-4197-9dc7-0328b8e7f5dd",
+          "doc_count": 1590
+        },
+        {
+          "key": "1e86442f-35a5-4e7b-9a38-4599e4d3b510",
+          "doc_count": 1582
+        },
+        {
+          "key": "f3327705-8d69-4d9c-88b7-584a08c74653",
+          "doc_count": 1579
+        },
+        {
+          "key": "e506c5e0-99b6-4e97-b7b4-4536cb80209b",
+          "doc_count": 1536
+        },
+        {
+          "key": "a545560f-a02a-4b8a-af4c-ed09f1f05df7",
+          "doc_count": 1485
+        },
+        {
+          "key": "5aac25d2-bcfb-4084-a700-584311ea539d",
+          "doc_count": 1480
+        },
+        {
+          "key": "ba77d411-4179-4dbd-b6c1-39b8a71ae795",
+          "doc_count": 1469
+        },
+        {
+          "key": "2c2cc29c-3572-4568-a129-c8cbec34ccbe",
+          "doc_count": 1458
+        },
+        {
+          "key": "3d2b5be0-7c1d-4693-9226-94bc0061123b",
+          "doc_count": 1417
+        },
+        {
+          "key": "56879e73-bf9d-4bd9-a7a4-4f2f940d0f62",
+          "doc_count": 1408
+        },
+        {
+          "key": "82c60e09-2939-4896-9ce9-5c63fe19cac9",
+          "doc_count": 1381
+        },
+        {
+          "key": "f5c38252-89f1-4753-af3a-da8818fe3a86",
+          "doc_count": 1325
+        },
+        {
+          "key": "99e84c7d-dd3c-40d9-9526-54f4342cda95",
+          "doc_count": 1287
+        },
+        {
+          "key": "feb74628-8724-466f-8c8c-b3d3b72f2417",
+          "doc_count": 1274
+        },
+        {
+          "key": "3bbf3659-4b21-40b7-b74f-f17a60097154",
+          "doc_count": 1267
+        },
+        {
+          "key": "08bfaeb8-abb4-4b33-b0e7-ed1242377bbd",
+          "doc_count": 1241
+        },
+        {
+          "key": "a4b888a2-94bf-4680-b912-84964a236c82",
+          "doc_count": 1209
+        },
+        {
+          "key": "9a861ebe-f8d7-4eb1-a2c8-3006f07cfec2",
+          "doc_count": 1205
+        },
+        {
+          "key": "ea9d9c05-11b3-4514-898e-66bd8560ec5b",
+          "doc_count": 1202
+        },
+        {
+          "key": "0a410c4a-cd4f-4bd8-b6ba-a0c2baa37622",
+          "doc_count": 1185
+        },
+        {
+          "key": "442246b3-6610-45e6-b2bf-c11ee15917b8",
+          "doc_count": 1184
+        },
+        {
+          "key": "1da2a87d-4fc7-4233-b127-59cb8d1ca5ee",
+          "doc_count": 1167
+        },
+        {
+          "key": "50b4c365-5472-4fe8-8825-b1fa0ac57fb3",
+          "doc_count": 1132
+        },
+        {
+          "key": "3ff3bf5c-7aba-40c3-80b2-1b00ea1abdd5",
+          "doc_count": 1123
+        },
+        {
+          "key": "2d853a6d-50ec-4931-8e91-48fc2491fdee",
+          "doc_count": 1122
+        },
+        {
+          "key": "b12b08da-3d05-4406-a051-0139a33ecf35",
+          "doc_count": 1118
+        },
+        {
+          "key": "76015dea-c909-4e6d-a8e1-3bf35763571e",
+          "doc_count": 1100
+        },
+        {
+          "key": "15a1cc29-b66c-4633-ad9c-c2c094b19902",
+          "doc_count": 1090
+        },
+        {
+          "key": "dd783e7e-36d8-4fcd-b7fe-9a481d785560",
+          "doc_count": 1086
+        },
+        {
+          "key": "1e6c8187-1521-4501-b205-ac8f513d5e04",
+          "doc_count": 1068
+        },
+        {
+          "key": "4aecf17c-154a-42fb-a3c0-f5e621c791e6",
+          "doc_count": 1054
+        },
+        {
+          "key": "50ca2a08-0e76-4f56-9976-d344dd201a9b",
+          "doc_count": 1053
+        },
+        {
+          "key": "8cd3a748-7f59-40e9-9cf3-3951e1e6430d",
+          "doc_count": 1053
+        },
+        {
+          "key": "bfb53140-79c1-4625-81aa-3f37de7c0c2f",
+          "doc_count": 1026
+        },
+        {
+          "key": "e8a10a16-86af-42b2-be40-9d6a1b21859a",
+          "doc_count": 986
+        },
+        {
+          "key": "af60ac71-fbfb-4648-95fb-0eb5fe24765b",
+          "doc_count": 984
+        },
+        {
+          "key": "93341fe7-38f8-4ef2-8dfc-ae550aa522dc",
+          "doc_count": 976
+        },
+        {
+          "key": "b3976394-a174-4ceb-8d64-3a435d66bde6",
+          "doc_count": 972
+        },
+        {
+          "key": "96a6898e-1fb6-4c49-a1f2-afb96058dbf8",
+          "doc_count": 967
+        },
+        {
+          "key": "d601bd5e-4f4c-4637-9196-4bd821dbd2e2",
+          "doc_count": 928
+        },
+        {
+          "key": "f4666aa7-93f0-41f7-83c2-497af7a06887",
+          "doc_count": 885
+        },
+        {
+          "key": "75c7a013-8dab-4f9c-ae6d-3a7cc24b67ce",
+          "doc_count": 882
+        },
+        {
+          "key": "da46ceaf-6084-48da-9e53-4d1ae2a51ddf",
+          "doc_count": 865
+        },
+        {
+          "key": "886f3b02-e2f2-4c49-9ace-df25bf5d091a",
+          "doc_count": 856
+        },
+        {
+          "key": "c882214e-8ba4-482b-9998-070b5547dc54",
+          "doc_count": 853
+        },
+        {
+          "key": "4efa66cf-8adb-414b-b78c-8e651d20f84d",
+          "doc_count": 852
+        },
+        {
+          "key": "49db9725-7bdc-4c38-8548-c32994e811c1",
+          "doc_count": 838
+        },
+        {
+          "key": "c3a7b339-122e-4fe9-8851-371b1fdf584e",
+          "doc_count": 803
+        },
+        {
+          "key": "41350373-fc6f-4dd9-b908-27805fff9155",
+          "doc_count": 800
+        },
+        {
+          "key": "f266a75c-3529-4868-8669-9f98822e033f",
+          "doc_count": 795
+        },
+        {
+          "key": "2b89de41-42bd-46c6-ab61-d386f855f7fb",
+          "doc_count": 790
+        },
+        {
+          "key": "b764863c-de93-4d7c-b0cf-1bb57166141d",
+          "doc_count": 765
+        },
+        {
+          "key": "2936c837-ad9f-40d8-bea0-58b2a635c637",
+          "doc_count": 747
+        },
+        {
+          "key": "781b461a-2788-4fa6-b3df-bbed9447f5a3",
+          "doc_count": 741
+        },
+        {
+          "key": "b027383d-6705-4d06-8514-db6ef16efdb5",
+          "doc_count": 736
+        },
+        {
+          "key": "3c919328-94fd-4657-b81d-21f4707253ed",
+          "doc_count": 697
+        },
+        {
+          "key": "0c9378fa-3ccb-4342-be2e-5b5080691dd1",
+          "doc_count": 691
+        },
+        {
+          "key": "a5fe6f13-2121-41dd-a036-dae15546ad91",
+          "doc_count": 661
+        },
+        {
+          "key": "c359c2e5-cd20-4057-9179-35a7a5b5da72",
+          "doc_count": 648
+        },
+        {
+          "key": "ad5c4ec7-ed56-4d3e-881a-963af217d334",
+          "doc_count": 627
+        },
+        {
+          "key": "c96ca51c-908e-41cc-ae10-ac1fb72ca3d9",
+          "doc_count": 624
+        },
+        {
+          "key": "fb4cc282-eba5-4156-b7c7-df41e0581b68",
+          "doc_count": 619
+        },
+        {
+          "key": "932e8ecc-fb16-4ce1-9863-e0e586e3ab34",
+          "doc_count": 610
+        },
+        {
+          "key": "6659b6dd-d487-4b72-b0c8-ae65942a6f15",
+          "doc_count": 594
+        },
+        {
+          "key": "2e03b83d-d2b9-4a8e-90b5-42b5b1301a92",
+          "doc_count": 587
+        },
+        {
+          "key": "4cdf5c2f-1a44-4fd5-bdd8-de08c8a660e2",
+          "doc_count": 566
+        },
+        {
+          "key": "e7bc6545-f14f-4fc4-9902-1aa38040f184",
+          "doc_count": 561
+        },
+        {
+          "key": "8456dc3d-99e2-407c-ab55-4746d382496b",
+          "doc_count": 552
+        },
+        {
+          "key": "aa977d4a-0dd6-4441-87d4-5efb60435a0b",
+          "doc_count": 544
+        },
+        {
+          "key": "539721d9-f5f8-489b-a816-abc28b2748e8",
+          "doc_count": 523
+        },
+        {
+          "key": "abb0a03c-4dcb-4f6f-a31d-55268f63d44c",
+          "doc_count": 515
+        },
+        {
+          "key": "27b2b46f-4cae-4ffa-870d-b17e51d627f2",
+          "doc_count": 504
+        },
+        {
+          "key": "2ee56f8c-db1d-43aa-bfb7-3fb2a19601df",
+          "doc_count": 500
+        },
+        {
+          "key": "1c8ec291-8067-4b48-848b-410c2c768420",
+          "doc_count": 470
+        },
+        {
+          "key": "f4f833ea-0abf-4059-948e-132c64dda1be",
+          "doc_count": 456
+        },
+        {
+          "key": "41e1a09b-bd55-4d20-a480-5d8187f7afca",
+          "doc_count": 450
+        },
+        {
+          "key": "e2a12ef3-cf03-4ce4-8aff-802ccf2aec1d",
+          "doc_count": 440
+        },
+        {
+          "key": "b7a79601-c07b-46d5-bd09-d4472b0d9431",
+          "doc_count": 427
+        },
+        {
+          "key": "f3a5ec1a-49dd-4a52-8bd8-67cacae7a7ac",
+          "doc_count": 426
+        },
+        {
+          "key": "4efa0623-a625-4949-aea4-7cb60a99b6f8",
+          "doc_count": 411
+        },
+        {
+          "key": "47e638be-2983-4d22-b05d-260dd5881e9c",
+          "doc_count": 409
+        },
+        {
+          "key": "8dd13cdf-1425-497d-a4ff-bb5dadfe21a8",
+          "doc_count": 403
+        },
+        {
+          "key": "6aca6f67-a2e9-440d-a503-9501db6e6f36",
+          "doc_count": 397
+        },
+        {
+          "key": "9aa11cc8-6c2d-4202-b30b-c8454338bbd2",
+          "doc_count": 394
+        },
+        {
+          "key": "1ae056ac-8834-43a8-ad44-d1148b6e075f",
+          "doc_count": 358
+        },
+        {
+          "key": "0df55e93-0fce-4ba6-a344-1d9918b60816",
+          "doc_count": 346
+        },
+        {
+          "key": "00df4fe2-0025-45ec-814a-36777155e077",
+          "doc_count": 328
+        },
+        {
+          "key": "f271128e-2e79-430b-81a4-a92ec7c969b8",
+          "doc_count": 326
+        },
+        {
+          "key": "4f5fc75f-f983-4ef8-9723-ba375615d926",
+          "doc_count": 324
+        },
+        {
+          "key": "314f66a9-2b8f-4085-b10c-0f083ce2f1eb",
+          "doc_count": 307
+        },
+        {
+          "key": "d3412433-4df9-4828-89e0-73956898f749",
+          "doc_count": 305
+        },
+        {
+          "key": "07c47dd3-a0a9-434a-b144-71c32996f278",
+          "doc_count": 304
+        },
+        {
+          "key": "3451a762-d117-430e-968c-dd747ed53887",
+          "doc_count": 298
+        },
+        {
+          "key": "85ae9fb4-de87-41ce-abb3-44fda2fb24a8",
+          "doc_count": 292
+        },
+        {
+          "key": "d0769c31-e4f1-42b1-a21f-cd6bf2257edb",
+          "doc_count": 291
+        },
+        {
+          "key": "d9d38b3f-5173-4051-98a6-2efad16fc8da",
+          "doc_count": 285
+        },
+        {
+          "key": "a7463c8a-27f0-485e-b794-fb78d94beda7",
+          "doc_count": 277
+        },
+        {
+          "key": "697b5707-b86f-43c5-a114-93a3fc602719",
+          "doc_count": 276
+        },
+        {
+          "key": "fd36e434-8c4d-4d97-a15d-e4d55f312d73",
+          "doc_count": 270
+        },
+        {
+          "key": "e27dc54d-8114-4927-b400-694caab9872e",
+          "doc_count": 261
+        },
+        {
+          "key": "71e55d91-4c0c-4a13-9421-c732348b0a47",
+          "doc_count": 253
+        },
+        {
+          "key": "639ae683-0a66-4a59-9c09-36304bf11424",
+          "doc_count": 245
+        },
+        {
+          "key": "a5d9992f-ebbb-457c-b56a-b6cd0429e2d6",
+          "doc_count": 245
+        },
+        {
+          "key": "b3d53973-5bac-432a-90d3-7956baa09c5d",
+          "doc_count": 237
+        },
+        {
+          "key": "57b1a2a3-78ab-4e69-a77e-a8fd4394ee5a",
+          "doc_count": 221
+        },
+        {
+          "key": "011880b9-7697-4626-946f-258a68f754cb",
+          "doc_count": 201
+        },
+        {
+          "key": "7fcdca8e-7469-480c-8516-cce4e24c37c9",
+          "doc_count": 193
+        },
+        {
+          "key": "433d3c37-8dde-42e4-a344-2cb6605c5da2",
+          "doc_count": 190
+        },
+        {
+          "key": "25e4ea2d-74ef-4251-b461-6ceb3c812bf1",
+          "doc_count": 187
+        },
+        {
+          "key": "03eac319-23c7-429e-9fa4-480640007d62",
+          "doc_count": 184
+        },
+        {
+          "key": "997c4dda-0465-40c0-af8d-67f8f90dea3b",
+          "doc_count": 182
+        },
+        {
+          "key": "e2c129bc-e45b-43d1-ab52-86e52093080b",
+          "doc_count": 175
+        },
+        {
+          "key": "67dfbfc8-bfc8-4a69-a63c-0918539e4dee",
+          "doc_count": 173
+        },
+        {
+          "key": "f3d1fbbb-93d5-432e-8808-ebc08c42ef6d",
+          "doc_count": 172
+        },
+        {
+          "key": "9b62118d-9b90-46b1-854d-06a5a9a22a90",
+          "doc_count": 171
+        },
+        {
+          "key": "9764480a-6e4a-4800-9bb7-b6fb73bccc50",
+          "doc_count": 169
+        },
+        {
+          "key": "1d14acd1-20ef-4a55-8206-f04c8a75ea3e",
+          "doc_count": 168
+        },
+        {
+          "key": "b761d317-a36e-4a05-a5f4-bd3e3963daf6",
+          "doc_count": 164
+        },
+        {
+          "key": "4c46db9d-74d7-4e45-9ed2-0da40ec6b44f",
+          "doc_count": 161
+        },
+        {
+          "key": "87fee729-2a4e-4d23-ad8a-5e03e1ab7c1a",
+          "doc_count": 161
+        },
+        {
+          "key": "e6b4d68a-59b5-4b74-a5ce-daadd930d3ca",
+          "doc_count": 159
+        },
+        {
+          "key": "c6e89321-fc23-4cba-ad79-be3e52edfb6d",
+          "doc_count": 144
+        },
+        {
+          "key": "c19c539d-2f8c-4a99-b956-15921ec345ed",
+          "doc_count": 138
+        },
+        {
+          "key": "b3f10d7b-6763-4f79-9789-f6abc68b9720",
+          "doc_count": 137
+        },
+        {
+          "key": "6acaebd6-e8d2-454a-8f50-e7a6734b8c79",
+          "doc_count": 136
+        },
+        {
+          "key": "4bf197cb-6fbc-4b22-82d0-849fffb5906e",
+          "doc_count": 134
+        },
+        {
+          "key": "07389fe4-c6dc-4e6c-87d2-345e2d183050",
+          "doc_count": 131
+        },
+        {
+          "key": "8a54c5fa-2900-4859-a2d6-1b7faedafac4",
+          "doc_count": 130
+        },
+        {
+          "key": "ec8f29eb-6d25-4a48-841c-49d6217761a4",
+          "doc_count": 129
+        },
+        {
+          "key": "fbac84f2-8db7-4af5-96b1-9d8885370c10",
+          "doc_count": 127
+        },
+        {
+          "key": "f8944362-0f02-4ccb-bbaf-3149b2de8e22",
+          "doc_count": 118
+        },
+        {
+          "key": "21ea1ef6-4a2a-4ff2-a18b-5c0f297fc1cf",
+          "doc_count": 108
+        },
+        {
+          "key": "b3d3a357-9fa6-453c-9f02-d86a1bbc762a",
+          "doc_count": 106
+        },
+        {
+          "key": "95773ebb-2f5f-43f0-a652-bfd8d5f4707a",
+          "doc_count": 105
+        },
+        {
+          "key": "bcbae485-1286-4452-bbc9-bcb38c6c3573",
+          "doc_count": 94
+        },
+        {
+          "key": "974f7564-a7fb-409a-bb67-35b7cafec327",
+          "doc_count": 84
+        },
+        {
+          "key": "ba4b4a05-f01f-4b16-b36a-83bf997a8722",
+          "doc_count": 84
+        },
+        {
+          "key": "94dd2cee-ed7d-4f98-894f-efafeac92b5b",
+          "doc_count": 82
+        },
+        {
+          "key": "4fecde59-9f59-44eb-ab6f-4a50b4ed85cf",
+          "doc_count": 76
+        },
+        {
+          "key": "2e746628-f895-4367-ae31-62e81e0b6b98",
+          "doc_count": 70
+        },
+        {
+          "key": "2148b4f7-a770-4bca-b276-da70ae948690",
+          "doc_count": 69
+        },
+        {
+          "key": "5302ea7f-1c6f-4fc9-8c20-97dd38c0c783",
+          "doc_count": 48
+        },
+        {
+          "key": "86b1f54d-ac01-4c5e-8ed8-09da2689c7a9",
+          "doc_count": 47
+        },
+        {
+          "key": "0e0d4dba-9c5d-4dbf-9ac8-09114c56ec03",
+          "doc_count": 44
+        },
+        {
+          "key": "17cea35c-721f-4d9b-b67f-d29250064d25",
+          "doc_count": 43
+        },
+        {
+          "key": "bc41afff-4d56-421e-bc87-45e18b4fe64a",
+          "doc_count": 43
+        },
+        {
+          "key": "473400bf-fe83-4bd6-9f69-c4608f4cdf4f",
+          "doc_count": 41
+        },
+        {
+          "key": "bdaa6842-3055-465e-82f6-da577e987cde",
+          "doc_count": 40
+        },
+        {
+          "key": "513dd822-f211-42c3-9af2-ee3c798cd1b8",
+          "doc_count": 36
+        },
+        {
+          "key": "6f6bf083-d27a-417d-9205-e5a70c2b7a0d",
+          "doc_count": 36
+        },
+        {
+          "key": "3617a6a3-d384-48de-948d-2d1e1c54e090",
+          "doc_count": 29
+        },
+        {
+          "key": "2c00d087-1df6-4744-807d-056be36eed0d",
+          "doc_count": 28
+        },
+        {
+          "key": "adae5c6c-72f3-4cd8-a00b-3ea71d516abc",
+          "doc_count": 27
+        },
+        {
+          "key": "1fc07b28-43f5-49d1-badf-63005e1c3e9a",
+          "doc_count": 26
+        },
+        {
+          "key": "2c84db50-bab1-40a6-a9ef-405f3ffcec7e",
+          "doc_count": 26
+        },
+        {
+          "key": "ab820732-0844-4323-ba14-c58c24f3fc7e",
+          "doc_count": 26
+        },
+        {
+          "key": "fb7db48e-1599-420e-8f10-1f20fe1c6aa3",
+          "doc_count": 24
+        },
+        {
+          "key": "656d1c9a-cbb7-4dde-ac24-62323af5b831",
+          "doc_count": 22
+        },
+        {
+          "key": "7400877a-13b8-423d-9074-5371a8234157",
+          "doc_count": 21
+        },
+        {
+          "key": "a4c4e0ee-38dd-47fd-9b06-ce4cc011e111",
+          "doc_count": 21
+        },
+        {
+          "key": "76aab8f5-69d4-4ce9-b0c9-837b64a2dd06",
+          "doc_count": 20
+        },
+        {
+          "key": "80daac2f-e496-4c65-b196-6be7a9c4c98e",
+          "doc_count": 20
+        },
+        {
+          "key": "cb4882a8-19d3-41a1-9373-c1a868b5ac9b",
+          "doc_count": 20
+        },
+        {
+          "key": "061dfaff-0c45-459e-ac56-738fe4cbe213",
+          "doc_count": 19
+        },
+        {
+          "key": "88271bd3-1985-4fa7-9e33-f82cc24dfad3",
+          "doc_count": 18
+        },
+        {
+          "key": "a8add96d-651c-488e-8ca3-ed3f85c7a117",
+          "doc_count": 18
+        },
+        {
+          "key": "4d9103e7-fe58-4dc5-9fa8-e739949fd3f3",
+          "doc_count": 17
+        },
+        {
+          "key": "62c35d43-f15c-451d-a8be-1b9c6928b8bd",
+          "doc_count": 17
+        },
+        {
+          "key": "f93c403b-d0f0-4be1-8a4b-ed9aa3b513e3",
+          "doc_count": 17
+        },
+        {
+          "key": "72059315-e131-42ba-b7c6-489415e297b9",
+          "doc_count": 16
+        },
+        {
+          "key": "879d475f-4b76-4d18-8cf6-a7e5a6d44926",
+          "doc_count": 15
+        },
+        {
+          "key": "90d6f994-d652-49d0-b6e6-924c65c4c079",
+          "doc_count": 12
+        },
+        {
+          "key": "b1c7a275-21f6-4b66-895d-d497359b34a1",
+          "doc_count": 11
+        },
+        {
+          "key": "c16e25c8-1e93-4571-881f-b757d3e48700",
+          "doc_count": 11
+        },
+        {
+          "key": "e1c7bc41-50a4-4723-b8b3-f970844ffb65",
+          "doc_count": 11
+        },
+        {
+          "key": "8f62e9b0-96e5-4d64-8008-b2b8692050db",
+          "doc_count": 10
+        },
+        {
+          "key": "a8cafd75-ca3b-42c6-8b8e-52aafa15753b",
+          "doc_count": 10
+        },
+        {
+          "key": "0c15e83e-79ee-4ee3-86e3-e5f98a51dc11",
+          "doc_count": 9
+        },
+        {
+          "key": "372d25cd-e4c6-4c58-8d3f-abe16887c805",
+          "doc_count": 9
+        },
+        {
+          "key": "5bd3bf29-b78d-4bf3-bbd7-bbfb4eaf36a1",
+          "doc_count": 9
+        },
+        {
+          "key": "a8d88237-2f62-4ad5-b1f7-ab13ace304df",
+          "doc_count": 9
+        },
+        {
+          "key": "5f681b65-9a7e-4b79-8a17-fc95cc26b837",
+          "doc_count": 6
+        },
+        {
+          "key": "6226705f-4867-464d-9fab-4e81ecee731f",
+          "doc_count": 6
+        },
+        {
+          "key": "73b2abe8-93ea-4343-bc37-35693035dea0",
+          "doc_count": 5
+        },
+        {
+          "key": "84006c59-fead-4b84-b3b5-cedf28f67ea9",
+          "doc_count": 5
+        },
+        {
+          "key": "bf1a26f8-6e89-4b95-b512-16430cccb6df",
+          "doc_count": 4
+        },
+        {
+          "key": "a3b54f92-360f-49a9-ae3b-9f5361549ef9",
+          "doc_count": 3
+        },
+        {
+          "key": "e5f377de-c662-4eec-a4d4-b41b18441f3a",
+          "doc_count": 3
+        },
+        {
+          "key": "3c6099e4-3a0c-44c8-942a-f44860aea12b",
+          "doc_count": 2
+        },
+        {
+          "key": "41800344-33b3-4201-b9d2-cabbbf564fbc",
+          "doc_count": 2
+        },
+        {
+          "key": "48e1b8c1-91aa-4b87-8ca0-de1f81232eaf",
+          "doc_count": 2
+        },
+        {
+          "key": "53feaa83-e3b6-4ad3-8597-293b153e7548",
+          "doc_count": 2
+        },
+        {
+          "key": "a73b61c5-812c-453b-b12b-5c65929e947a",
+          "doc_count": 2
+        },
+        {
+          "key": "abf5b4f3-ed39-4bb9-acd6-9ee50acac0ad",
+          "doc_count": 2
+        },
+        {
+          "key": "c2dcb184-6c90-4aa3-9ebb-33b2d53837b9",
+          "doc_count": 2
+        },
+        {
+          "key": "c7883ffb-d381-4748-9694-e5abdaa46dbc",
+          "doc_count": 2
+        },
+        {
+          "key": "d07e7b8a-2222-477f-a7f3-f098bbfdaf54",
+          "doc_count": 2
+        },
+        {
+          "key": "de67ccab-7d04-43b9-8083-81e45f628505",
+          "doc_count": 2
+        },
+        {
+          "key": "0395f3c4-0277-43b6-a36d-e07720588790",
+          "doc_count": 1
+        },
+        {
+          "key": "0da18fe6-2e2a-43fc-9d2a-ffb2cefc05c0",
+          "doc_count": 1
+        },
+        {
+          "key": "237d30ca-7675-4840-b4fd-96771fabf518",
+          "doc_count": 1
+        },
+        {
+          "key": "53064db5-a272-46f9-85d2-d1b78e9a3293",
+          "doc_count": 1
+        },
+        {
+          "key": "54ae6783-dbb5-403a-b0e6-11a3b07d491a",
+          "doc_count": 1
+        },
+        {
+          "key": "74ba1d92-d9a5-486e-8e52-bb44d51e1788",
+          "doc_count": 1
+        },
+        {
+          "key": "8a9e3b42-e6e8-4485-b304-3cbf6d709a6c",
+          "doc_count": 1
+        },
+        {
+          "key": "a9bb4417-af3e-46e7-a2e0-167d61b49d10",
+          "doc_count": 1
+        }
+      ]
+    },
+    "max_dm": {
+      "value": 1674657431736,
+      "value_as_string": "2023-01-25T14:37:11.736Z"
+    }
+  }
+}

--- a/__tests__/mock/search-50d74577b6d63ecd6d453e6485f3179a.json
+++ b/__tests__/mock/search-50d74577b6d63ecd6d453e6485f3179a.json
@@ -1,0 +1,1197 @@
+{
+  "timed_out": false,
+  "_shards": {
+    "total": 48,
+    "successful": 48,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1955,
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "84006c59-fead-4b84-b3b5-cedf28f67ea9",
+        "_score": 1,
+        "_source": {
+          "publisher": "089a51fa-5f81-48e7-a1b7-9bc539555f29",
+          "uuid": "84006c59-fead-4b84-b3b5-cedf28f67ea9",
+          "dqs": -1,
+          "archivelink": "http://xbiod.osu.edu/ipt/archive.do?r=ucfc",
+          "rights": "no license, assume public domain",
+          "contacts": [
+            {
+              "first_name": "Hojun",
+              "last_name": "Song",
+              "role": "Curator, Asst. Professor",
+              "email": "song@ucf.edu"
+            },
+            {
+              "first_name": "Norman",
+              "last_name": "Johnson",
+              "role": "Director, Professor",
+              "email": "johnson.2@osu.edu"
+            },
+            {
+              "first_name": "Sandor",
+              "last_name": "Kelly",
+              "role": "Collection Manager",
+              "email": "sandor.kelly@ucf.edu"
+            },
+            {
+              "first_name": "Hojun",
+              "last_name": "Song",
+              "role": "Curator, Asst. Professor",
+              "email": "song@ucf.edu"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "089a51fa-5f81-48e7-a1b7-9bc539555f29",
+            "eml_link": "http://xbiod.osu.edu/ipt/eml.do?r=ucfc",
+            "contacts": [
+              {
+                "first_name": "Hojun",
+                "last_name": "Song",
+                "role": "Curator, Asst. Professor",
+                "email": "song@ucf.edu"
+              },
+              {
+                "first_name": "Norman",
+                "last_name": "Johnson",
+                "role": "Director, Professor",
+                "email": "johnson.2@osu.edu"
+              },
+              {
+                "first_name": "Sandor",
+                "last_name": "Kelly",
+                "role": "Collection Manager",
+                "email": "sandor.kelly@ucf.edu"
+              },
+              {
+                "first_name": "Hojun",
+                "last_name": "Song",
+                "role": "Curator, Asst. Professor",
+                "email": "song@ucf.edu"
+              }
+            ],
+            "collection_name": "Stuart M. Fullerton Collection of Arthropods (UCFC), University of Central Florida",
+            "idigbio:uuid": "84006c59-fead-4b84-b3b5-cedf28f67ea9",
+            "idigbio:etag": "41e6af7fc888b9ef73a8e01384ad73abed6f84a8",
+            "update": "2018-08-29T08:25:24",
+            "ingest": true,
+            "institution_web_address": "http://bugcloset.cos.ucf.edu",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "262f8270-f9c2-4bc6-a562-8ed71c0790e6"
+            ],
+            "link": "http://xbiod.osu.edu/ipt/archive.do?r=ucfc",
+            "idigbio:dateModified": "2018-08-29T09:25:42.776340",
+            "collection_description": "Vouchered occurrence records for arthropods, primarily insects, from the Stuart M. Fullerton Collection of Arthropods at the University of Central Florida.",
+            "id": "262f8270-f9c2-4bc6-a562-8ed71c0790e6",
+            "other_guids": [],
+            "data_rights": "No license, assume Public Domain"
+          },
+          "etag": "41e6af7fc888b9ef73a8e01384ad73abed6f84a8",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "http://xbiod.osu.edu/ipt/eml.do?r=ucfc",
+          "recordids": [
+            "262f8270-f9c2-4bc6-a562-8ed71c0790e6"
+          ],
+          "data": {
+            "eml_link": "http://xbiod.osu.edu/ipt/eml.do?r=ucfc",
+            "contacts": [
+              {
+                "first_name": "Hojun",
+                "last_name": "Song",
+                "role": "Curator, Asst. Professor",
+                "email": "song@ucf.edu"
+              },
+              {
+                "first_name": "Norman",
+                "last_name": "Johnson",
+                "role": "Director, Professor",
+                "email": "johnson.2@osu.edu"
+              },
+              {
+                "first_name": "Sandor",
+                "last_name": "Kelly",
+                "role": "Collection Manager",
+                "email": "sandor.kelly@ucf.edu"
+              },
+              {
+                "first_name": "Hojun",
+                "last_name": "Song",
+                "role": "Curator, Asst. Professor",
+                "email": "song@ucf.edu"
+              }
+            ],
+            "collection_name": "Stuart M. Fullerton Collection of Arthropods (UCFC), University of Central Florida",
+            "update": "2018-08-29T08:25:24",
+            "ingest": true,
+            "data_rights": "No license, assume Public Domain",
+            "link": "http://xbiod.osu.edu/ipt/archive.do?r=ucfc",
+            "collection_description": "Vouchered occurrence records for arthropods, primarily insects, from the Stuart M. Fullerton Collection of Arthropods at the University of Central Florida.",
+            "other_guids": [],
+            "institution_web_address": "http://bugcloset.cos.ucf.edu",
+            "id": "262f8270-f9c2-4bc6-a562-8ed71c0790e6"
+          },
+          "datemodified": "2018-08-29T09:25:42.776340+00:00",
+          "name": "stuart m. fullerton collection of arthropods (ucfc), university of central florida"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "9475a9e1-cd56-4f5c-8d21-4206b088231b",
+        "_score": 1,
+        "_source": {
+          "publisher": "26281097-694b-483d-ae22-676a2a448bf1",
+          "uuid": "9475a9e1-cd56-4f5c-8d21-4206b088231b",
+          "dqs": -1,
+          "archivelink": "http://danbif.au.dk/ipt/archive.do?r=macroarthropods_nuupkangerlua2013_greenland",
+          "rights": "cc4 by",
+          "contacts": [
+            {
+              "first_name": "Toke Thomas",
+              "last_name": "Høye",
+              "role": "Senior scientist",
+              "email": "tth@bios.au.dk"
+            },
+            {
+              "first_name": "Toke Thomas",
+              "last_name": "Høye",
+              "role": "Senior scientist",
+              "email": "tth@bios.au.dk"
+            },
+            {
+              "first_name": "Isabel",
+              "last_name": "Calabuig",
+              "role": "Node manager, Data curator",
+              "email": "icalabuig@snm.ku.dk"
+            },
+            {
+              "first_name": "Toke Thomas",
+              "last_name": "Høye",
+              "role": "Senior scientist",
+              "email": "tth@bios.au.dk"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "26281097-694b-483d-ae22-676a2a448bf1",
+            "eml_link": "http://danbif.au.dk/ipt/eml.do?r=macroarthropods_nuupkangerlua2013_greenland",
+            "contacts": [
+              {
+                "first_name": "Toke Thomas",
+                "last_name": "Høye",
+                "role": "Senior scientist",
+                "email": "tth@bios.au.dk"
+              },
+              {
+                "first_name": "Toke Thomas",
+                "last_name": "Høye",
+                "role": "Senior scientist",
+                "email": "tth@bios.au.dk"
+              },
+              {
+                "first_name": "Isabel",
+                "last_name": "Calabuig",
+                "role": "Node manager, Data curator",
+                "email": "icalabuig@snm.ku.dk"
+              },
+              {
+                "first_name": "Toke Thomas",
+                "last_name": "Høye",
+                "role": "Senior scientist",
+                "email": "tth@bios.au.dk"
+              }
+            ],
+            "collection_name": "Macroarthropods, Godthåbsfjorden (Nuup Kangerlua) 2013, Greenland",
+            "idigbio:uuid": "9475a9e1-cd56-4f5c-8d21-4206b088231b",
+            "idigbio:etag": "2b558403c4bcd68517331e6d2d19d73d0ad465b4",
+            "update": "2017-08-09T08:49:56",
+            "ingest": true,
+            "institution_web_address": "",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "59d25ddf-355d-47d7-b8a1-c1e2819014c7"
+            ],
+            "link": "http://danbif.au.dk/ipt/archive.do?r=macroarthropods_nuupkangerlua2013_greenland",
+            "idigbio:dateModified": "2017-08-09T09:05:46.761969",
+            "collection_description": "Pitfall trap data set collected by Toke Thomas Høye, Rikke Reisner Hansen, and Oskar Liset Pryds Hansen",
+            "id": "59d25ddf-355d-47d7-b8a1-c1e2819014c7",
+            "other_guids": [],
+            "data_rights": "CC4 BY"
+          },
+          "etag": "2b558403c4bcd68517331e6d2d19d73d0ad465b4",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "http://danbif.au.dk/ipt/eml.do?r=macroarthropods_nuupkangerlua2013_greenland",
+          "recordids": [
+            "59d25ddf-355d-47d7-b8a1-c1e2819014c7"
+          ],
+          "data": {
+            "eml_link": "http://danbif.au.dk/ipt/eml.do?r=macroarthropods_nuupkangerlua2013_greenland",
+            "contacts": [
+              {
+                "first_name": "Toke Thomas",
+                "last_name": "Høye",
+                "role": "Senior scientist",
+                "email": "tth@bios.au.dk"
+              },
+              {
+                "first_name": "Toke Thomas",
+                "last_name": "Høye",
+                "role": "Senior scientist",
+                "email": "tth@bios.au.dk"
+              },
+              {
+                "first_name": "Isabel",
+                "last_name": "Calabuig",
+                "role": "Node manager, Data curator",
+                "email": "icalabuig@snm.ku.dk"
+              },
+              {
+                "first_name": "Toke Thomas",
+                "last_name": "Høye",
+                "role": "Senior scientist",
+                "email": "tth@bios.au.dk"
+              }
+            ],
+            "collection_name": "Macroarthropods, Godthåbsfjorden (Nuup Kangerlua) 2013, Greenland",
+            "update": "2017-08-09T08:49:56",
+            "ingest": true,
+            "data_rights": "CC4 BY",
+            "link": "http://danbif.au.dk/ipt/archive.do?r=macroarthropods_nuupkangerlua2013_greenland",
+            "collection_description": "Pitfall trap data set collected by Toke Thomas Høye, Rikke Reisner Hansen, and Oskar Liset Pryds Hansen",
+            "other_guids": [],
+            "institution_web_address": "",
+            "id": "59d25ddf-355d-47d7-b8a1-c1e2819014c7"
+          },
+          "datemodified": "2017-08-09T09:05:46.761969+00:00",
+          "name": "macroarthropods, godthåbsfjorden (nuup kangerlua) 2013, greenland"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "d2e46893-099f-45eb-9a76-d2a66f43bec8",
+        "_score": 1,
+        "_source": {
+          "publisher": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+          "uuid": "d2e46893-099f-45eb-9a76-d2a66f43bec8",
+          "dqs": -1,
+          "archivelink": "https://www.snib.mx/iptconabio/archive.do?r=snib-hc022",
+          "rights": "cc4 by",
+          "contacts": [
+            {
+              "first_name": "Francisco Xavier",
+              "last_name": "González Cózatl",
+              "role": "Responsable"
+            },
+            {
+              "first_name": "CONABIO",
+              "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            },
+            {
+              "first_name": "Patricia",
+              "last_name": "Ramos Rivera",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-HC022",
+            "contacts": [
+              {
+                "first_name": "Francisco Xavier",
+                "last_name": "González Cózatl",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Computarización de la colección de mamíferos del Centro de Educación Ambiental e Investigación Sierra de Huautla (CEAMISH) de la Universidad Autónoma del Estado de Morelos (UAEM)",
+            "idigbio:uuid": "d2e46893-099f-45eb-9a76-d2a66f43bec8",
+            "idigbio:etag": "587c955722ea3dcfe8475f08f1e1519c07c8bb1b",
+            "update": "2021-07-16T23:04:11",
+            "ingest": true,
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=HC&Numero=22",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "f0d7eb48-a312-4643-a1bb-1ba9370497ec"
+            ],
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-HC022",
+            "idigbio:dateModified": "2021-07-27T02:26:40.506165",
+            "collection_description": "La Colección de Mamíferos del CEAMISH (CMC) se inició en el año 2000 con la incorporación de ejemplares colectados en proyectos financiados por el CONACYT, la Universidad Autónoma del Estado de Morelos y tres instituciones extranjeras.  La CMC fue formalmente registrada ante la SEMARNAT en el año del 2005.  Cuenta con 2,424 ejemplares pertenecientes a 7 ordenes, 17 familias, 48 géneros y 81 especies, principalmente del orden Rodentia.  La mayoría de los ejemplares provienen de localidades de bosque mesófilo y selva baja caducifolia de México.  Actualmente, 1,166 ejemplares están catalogados formalmente con identificaciones hasta el nivel de especie,  353 ejemplares están en proceso de identificación y 35 más acaban de ingresar y están en el proceso de catalogación.  Afortunadamente, cerca del 95% de los ejemplares están referenciados con coordenadas geográficas.  Para más del 75% de estos ejemplares se preserva muestras de tejido congelado o en alcohol para estudios moleculares.  Además, se cuenta con muestras de sangre de 45% de los ejemplares para determinar la presencia de virus tales como el arenavirus y el hantavirus.  Sin embargo, debido a que la CMC ha tenido limitaciones de financiamiento, infraestructura, y ha carecido de personal de apoyo de tiempo competo asociado a la misma, aún falta computarizar mucha de la información asociada a los ejemplares.  Además, es necesario completar el proceso de curación de más del 50% de los ejemplares que integran la CMC.  En este sentido, la presente propuesta tiene como objetivo solicitar recursos para computarizar la información asociada a los ejemplares de la CMC, y  completar el proceso de curación del material biológico depositado en la CMC, procurando que éste quede resguardado en gabinetes adecuados para su protección. Reino: 1\nFilo: 1\nClase: 1\nOrden: 7\nFamilia: 17\nGénero: 49\nEspecie: 99",
+            "id": "f0d7eb48-a312-4643-a1bb-1ba9370497ec",
+            "other_guids": [],
+            "data_rights": "CC4 BY"
+          },
+          "etag": "587c955722ea3dcfe8475f08f1e1519c07c8bb1b",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "https://www.snib.mx/iptconabio/eml.do?r=snib-hc022",
+          "recordids": [
+            "f0d7eb48-a312-4643-a1bb-1ba9370497ec"
+          ],
+          "data": {
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-HC022",
+            "contacts": [
+              {
+                "first_name": "Francisco Xavier",
+                "last_name": "González Cózatl",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Computarización de la colección de mamíferos del Centro de Educación Ambiental e Investigación Sierra de Huautla (CEAMISH) de la Universidad Autónoma del Estado de Morelos (UAEM)",
+            "update": "2021-07-16T23:04:11",
+            "ingest": true,
+            "data_rights": "CC4 BY",
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-HC022",
+            "collection_description": "La Colección de Mamíferos del CEAMISH (CMC) se inició en el año 2000 con la incorporación de ejemplares colectados en proyectos financiados por el CONACYT, la Universidad Autónoma del Estado de Morelos y tres instituciones extranjeras.  La CMC fue formalmente registrada ante la SEMARNAT en el año del 2005.  Cuenta con 2,424 ejemplares pertenecientes a 7 ordenes, 17 familias, 48 géneros y 81 especies, principalmente del orden Rodentia.  La mayoría de los ejemplares provienen de localidades de bosque mesófilo y selva baja caducifolia de México.  Actualmente, 1,166 ejemplares están catalogados formalmente con identificaciones hasta el nivel de especie,  353 ejemplares están en proceso de identificación y 35 más acaban de ingresar y están en el proceso de catalogación.  Afortunadamente, cerca del 95% de los ejemplares están referenciados con coordenadas geográficas.  Para más del 75% de estos ejemplares se preserva muestras de tejido congelado o en alcohol para estudios moleculares.  Además, se cuenta con muestras de sangre de 45% de los ejemplares para determinar la presencia de virus tales como el arenavirus y el hantavirus.  Sin embargo, debido a que la CMC ha tenido limitaciones de financiamiento, infraestructura, y ha carecido de personal de apoyo de tiempo competo asociado a la misma, aún falta computarizar mucha de la información asociada a los ejemplares.  Además, es necesario completar el proceso de curación de más del 50% de los ejemplares que integran la CMC.  En este sentido, la presente propuesta tiene como objetivo solicitar recursos para computarizar la información asociada a los ejemplares de la CMC, y  completar el proceso de curación del material biológico depositado en la CMC, procurando que éste quede resguardado en gabinetes adecuados para su protección. Reino: 1\nFilo: 1\nClase: 1\nOrden: 7\nFamilia: 17\nGénero: 49\nEspecie: 99",
+            "other_guids": [],
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=HC&Numero=22",
+            "id": "f0d7eb48-a312-4643-a1bb-1ba9370497ec"
+          },
+          "datemodified": "2021-07-27T02:26:40.506165+00:00",
+          "name": "computarización de la colección de mamíferos del centro de educación ambiental e investigación sierra de huautla (ceamish) de la universidad autónoma del estado de morelos (uaem)"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "9a0d6dc0-689f-4327-8cf3-1c530443f49a",
+        "_score": 1,
+        "_source": {
+          "publisher": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+          "uuid": "9a0d6dc0-689f-4327-8cf3-1c530443f49a",
+          "dqs": -1,
+          "archivelink": "https://www.snib.mx/iptconabio/archive.do?r=snib-l070",
+          "rights": "cc4 by",
+          "contacts": [
+            {
+              "first_name": "José Alberto",
+              "last_name": "Ocaña Luna",
+              "role": "Responsable"
+            },
+            {
+              "first_name": "CONABIO",
+              "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            },
+            {
+              "first_name": "Patricia",
+              "last_name": "Ramos Rivera",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-L070",
+            "contacts": [
+              {
+                "first_name": "José Alberto",
+                "last_name": "Ocaña Luna",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Diversidad del ictioplancton en las lagunas Madre y Almagre, Tamaulipas, y laguna de Tampamachoco, Veracruz",
+            "idigbio:uuid": "9a0d6dc0-689f-4327-8cf3-1c530443f49a",
+            "idigbio:etag": "7ba2765075772838bb6b8a206377dc7c88b59a74",
+            "update": "2021-07-16T23:12:16",
+            "ingest": true,
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=L&Numero=70",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "d22863c3-aff9-4f91-b727-dc3ece083694"
+            ],
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-L070",
+            "idigbio:dateModified": "2021-07-27T02:27:01.694180",
+            "collection_description": "Este proyecto tiene como objetivo principal conocer la diversidad y variación espacio-temporal del ictioplancton en tres sistemas lagunares: Laguna Madre y Laguna Almagre, Tamaulipas (lagunas adyacentes a la región prioritaria para la conservación No. 67) y Laguna de Tampamachoco, Veracruz (región prioritaria para la conservación No. 106). Actualmente se tiene cubierta la parte central de la Laguna Madre y la Laguna de Tampamachoco costituyendo alrededor del 75% del total de regiones comprometidas a la CONABIO en el presente proyecto, provenientes de 74 muestras de las cuales se extrajeron un total de 7,721 organismos que corresponde a 434 registros. En el sur de la Laguna Madre y la Laguna Almagre  se planea realizar cuatro colectas (agosto y noviembre,1997; febrero y mayo 1998) en 17 estaciones, con lo cual se espera obtener durante esta fase de proyecto alrededor de 126 registros y 2,500-3,000 ejemplares. Este proyecto se desarrollará en el Laboratorio de Ecología  de la Escuela Nacional de Ciencias Biológicas del IPN, bajo la  responsabilidad de un profesor-investigador de esta escuela, con la participación de un investigador del Instituto de Geografía y con estudiantes de posgrado de la Facultad de Ciencias de la UNAM. Reino: 1\nFilo: 1\nClase: 1\nOrden: 17\nFamilia: 22\nGénero: 41\nEspecie: 49",
+            "id": "d22863c3-aff9-4f91-b727-dc3ece083694",
+            "other_guids": [],
+            "data_rights": "CC4 BY"
+          },
+          "etag": "7ba2765075772838bb6b8a206377dc7c88b59a74",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "https://www.snib.mx/iptconabio/eml.do?r=snib-l070",
+          "recordids": [
+            "d22863c3-aff9-4f91-b727-dc3ece083694"
+          ],
+          "data": {
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-L070",
+            "contacts": [
+              {
+                "first_name": "José Alberto",
+                "last_name": "Ocaña Luna",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Diversidad del ictioplancton en las lagunas Madre y Almagre, Tamaulipas, y laguna de Tampamachoco, Veracruz",
+            "update": "2021-07-16T23:12:16",
+            "ingest": true,
+            "data_rights": "CC4 BY",
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-L070",
+            "collection_description": "Este proyecto tiene como objetivo principal conocer la diversidad y variación espacio-temporal del ictioplancton en tres sistemas lagunares: Laguna Madre y Laguna Almagre, Tamaulipas (lagunas adyacentes a la región prioritaria para la conservación No. 67) y Laguna de Tampamachoco, Veracruz (región prioritaria para la conservación No. 106). Actualmente se tiene cubierta la parte central de la Laguna Madre y la Laguna de Tampamachoco costituyendo alrededor del 75% del total de regiones comprometidas a la CONABIO en el presente proyecto, provenientes de 74 muestras de las cuales se extrajeron un total de 7,721 organismos que corresponde a 434 registros. En el sur de la Laguna Madre y la Laguna Almagre  se planea realizar cuatro colectas (agosto y noviembre,1997; febrero y mayo 1998) en 17 estaciones, con lo cual se espera obtener durante esta fase de proyecto alrededor de 126 registros y 2,500-3,000 ejemplares. Este proyecto se desarrollará en el Laboratorio de Ecología  de la Escuela Nacional de Ciencias Biológicas del IPN, bajo la  responsabilidad de un profesor-investigador de esta escuela, con la participación de un investigador del Instituto de Geografía y con estudiantes de posgrado de la Facultad de Ciencias de la UNAM. Reino: 1\nFilo: 1\nClase: 1\nOrden: 17\nFamilia: 22\nGénero: 41\nEspecie: 49",
+            "other_guids": [],
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=L&Numero=70",
+            "id": "d22863c3-aff9-4f91-b727-dc3ece083694"
+          },
+          "datemodified": "2021-07-27T02:27:01.694180+00:00",
+          "name": "diversidad del ictioplancton en las lagunas madre y almagre, tamaulipas, y laguna de tampamachoco, veracruz"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "03e291b1-e74e-489a-8ec9-d23ff481c13c",
+        "_score": 1,
+        "_source": {
+          "publisher": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+          "uuid": "03e291b1-e74e-489a-8ec9-d23ff481c13c",
+          "dqs": -1,
+          "archivelink": "https://www.snib.mx/iptconabio/archive.do?r=snib-l074",
+          "rights": "cc4 by",
+          "contacts": [
+            {
+              "first_name": "Teresa",
+              "last_name": "Terrazas Salgado",
+              "role": "Responsable"
+            },
+            {
+              "first_name": "CONABIO",
+              "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            },
+            {
+              "first_name": "Patricia",
+              "last_name": "Ramos Rivera",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-L074",
+            "contacts": [
+              {
+                "first_name": "Teresa",
+                "last_name": "Terrazas Salgado",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Filogenia de las cactáceas columnares (Pachycereeae) con base en caracteres anatómico-morfológicos",
+            "idigbio:uuid": "03e291b1-e74e-489a-8ec9-d23ff481c13c",
+            "idigbio:etag": "f5fb6529a68f8a63d0403822cf3ea65e0d915ef7",
+            "update": "2021-07-16T23:12:15",
+            "ingest": true,
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=L&Numero=74",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "80863c34-f762-11e1-a439-00145eb45e9a"
+            ],
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-L074",
+            "idigbio:dateModified": "2021-07-27T02:26:52.812930",
+            "collection_description": "La tribu Pachycereeae sensu Barthlott y Hunt contiene 10 géneros y 60 especies. El mayor número de especies de esta tribu son endémicas a México, además de ser elementos dominantes de algunas comunidades vegetales del país. La tribu fue dividida por Gibson y Horak en dos subtribus con base en caracteres anatómicos, morfológicos y fitioquímicos, no obstante la monofilia de algunos géneros se ha cuestionado en trabajos más recientes. Por otra parte un análisis riguroso (cladistico) con base en caracteres anatómicos y morfológicos no se ha realizado y la información existente a la fecha es parcial y difícil de re-analizarse, en especial para los caracteres anatómicos. Con base en lo anterior se plantea analizar la información anatómica-morfológica  de los miembros de este tribu a través del método de cladismo. Este proyecto pretende con base en colectas de campo: 1) generar información anivel anatómico para las especies de Pachycereeae y 2) generar/sintetizar información ya disponible de los caracteres morfológicos para las especies de dicha tribu y con ambos conjuntos de postular hipótesis de relaciones filogenéticas. Reino: 1\nFilo: 1\nClase: 1\nOrden: 1\nFamilia: 1\nGénero: 10\nEspecie: 48",
+            "id": "80863c34-f762-11e1-a439-00145eb45e9a",
+            "other_guids": [],
+            "data_rights": "CC4 BY"
+          },
+          "etag": "f5fb6529a68f8a63d0403822cf3ea65e0d915ef7",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "https://www.snib.mx/iptconabio/eml.do?r=snib-l074",
+          "recordids": [
+            "80863c34-f762-11e1-a439-00145eb45e9a"
+          ],
+          "data": {
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-L074",
+            "contacts": [
+              {
+                "first_name": "Teresa",
+                "last_name": "Terrazas Salgado",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Filogenia de las cactáceas columnares (Pachycereeae) con base en caracteres anatómico-morfológicos",
+            "update": "2021-07-16T23:12:15",
+            "ingest": true,
+            "data_rights": "CC4 BY",
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-L074",
+            "collection_description": "La tribu Pachycereeae sensu Barthlott y Hunt contiene 10 géneros y 60 especies. El mayor número de especies de esta tribu son endémicas a México, además de ser elementos dominantes de algunas comunidades vegetales del país. La tribu fue dividida por Gibson y Horak en dos subtribus con base en caracteres anatómicos, morfológicos y fitioquímicos, no obstante la monofilia de algunos géneros se ha cuestionado en trabajos más recientes. Por otra parte un análisis riguroso (cladistico) con base en caracteres anatómicos y morfológicos no se ha realizado y la información existente a la fecha es parcial y difícil de re-analizarse, en especial para los caracteres anatómicos. Con base en lo anterior se plantea analizar la información anatómica-morfológica  de los miembros de este tribu a través del método de cladismo. Este proyecto pretende con base en colectas de campo: 1) generar información anivel anatómico para las especies de Pachycereeae y 2) generar/sintetizar información ya disponible de los caracteres morfológicos para las especies de dicha tribu y con ambos conjuntos de postular hipótesis de relaciones filogenéticas. Reino: 1\nFilo: 1\nClase: 1\nOrden: 1\nFamilia: 1\nGénero: 10\nEspecie: 48",
+            "other_guids": [],
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=L&Numero=74",
+            "id": "80863c34-f762-11e1-a439-00145eb45e9a"
+          },
+          "datemodified": "2021-07-27T02:26:52.812930+00:00",
+          "name": "filogenia de las cactáceas columnares (pachycereeae) con base en caracteres anatómico-morfológicos"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "080f57e4-505c-4e56-bfad-d1861609f146",
+        "_score": 1,
+        "_source": {
+          "publisher": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+          "uuid": "080f57e4-505c-4e56-bfad-d1861609f146",
+          "dqs": -1,
+          "archivelink": "https://www.snib.mx/iptconabio/archive.do?r=snib-h285",
+          "rights": "cc4 by",
+          "contacts": [
+            {
+              "first_name": "Clementina de los Angeles",
+              "last_name": "Equihua Zamora",
+              "role": "Responsable"
+            },
+            {
+              "first_name": "CONABIO",
+              "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            },
+            {
+              "first_name": "Patricia",
+              "last_name": "Ramos Rivera",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-H285",
+            "contacts": [
+              {
+                "first_name": "Clementina de los Angeles",
+                "last_name": "Equihua Zamora",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Brioflora de la Reserva de Montes Azules, Chis.: Diversidad, Biogeografía y Depauperación por Actividad Humana",
+            "idigbio:uuid": "080f57e4-505c-4e56-bfad-d1861609f146",
+            "idigbio:etag": "c0a9d8febe4be588695f74fa11939781e40d309b",
+            "update": "2021-07-16T23:08:28",
+            "ingest": true,
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=H&Numero=285",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "80bfa122-f762-11e1-a439-00145eb45e9a"
+            ],
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-H285",
+            "idigbio:dateModified": "2021-07-27T02:27:14.791596",
+            "collection_description": "Los musgos y hepáticas (en conjunto denominados briofitas) constituyen el segundo grupo en diversidad del reino vegetal (Mishler, 1988 y Buck y Thiers, 1989).  Al igual que las angiospermas, es de esperar mayor diversidad en las briofloras tropicales que las de regiones templadas, y aún así, Delgadillo y Equihua (1990) solamente citan dos trabajos que dedican su investigación al estado de Chiapas. Ambos estudios están enfocados a la parte central y los altos de Chiapas. Chiapas es uno de los estados más diversos de nuestro país (Breedlove, 1973 y Flores-Villela y Gerez, 1988) y donde se ubica uno de los límites septentrionales de bosque húmedo tropical (Medellín, et al., 1992).  La zona Lacandona, específicamente la Reserva de Montes Azules, ha sido muy poco estudiada (Delgadillo, 1993).  Este es el primer trabajo formal sobre briofitas en la zona y abarcará tanto la adquisición de información elemental sobre la brioflora de la zona, como análisis básicos sobre su ecología y distribución geográfica. Se han realizado cuatro visitas a la Reserva de Montes Azules y a zonas aledañas incluidas en la selva Lacandona: la región de Ixcán, alrededores de la estación Chajul, zona del río Tzendales, alrededores de los poblados de Nahá, Lacanhá y Nuevo Chapultepec.  Durante estas visitas se han colectado un total de 994 ejemplares y se están procesando 623 previamente colectados.  Hasta el momento se han determinado 60% de los ejemplares distribuidos en 170 especies.  Dentro de estas especies se han encontrado 14 nuevos registros para el país: nueve de hepáticas epífilas (Pócs y Equihua en prep.) y 5 de musgos (Equihua y García-Ávila, en prep).  Al finalizar este proyecto, se depositarán los ejemplares en el herbario nacional (MEXU). También se han realizado colectas en cuadrantes en los diferentes tipos de perturbación más frecuentes en la zona: acahuales y cacaotales, para comparar la diversidad con sitios sin perturbar (Equihua y Gradstein, en prep.). Al finalizar este estudió se publicará un listado florístico, un estudio biogeográfico y un estudio comparativo del efecto de la perturbación humana sobre las comunidades de briofitas. Reino: 1\nFilo: 3\nClase: 4\nOrden: 17\nFamilia: 48\nGénero: 134\nEspecie: 227\nEpitetoinfraespecifico: 7",
+            "id": "80bfa122-f762-11e1-a439-00145eb45e9a",
+            "other_guids": [],
+            "data_rights": "CC4 BY"
+          },
+          "etag": "c0a9d8febe4be588695f74fa11939781e40d309b",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "https://www.snib.mx/iptconabio/eml.do?r=snib-h285",
+          "recordids": [
+            "80bfa122-f762-11e1-a439-00145eb45e9a"
+          ],
+          "data": {
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-H285",
+            "contacts": [
+              {
+                "first_name": "Clementina de los Angeles",
+                "last_name": "Equihua Zamora",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Brioflora de la Reserva de Montes Azules, Chis.: Diversidad, Biogeografía y Depauperación por Actividad Humana",
+            "update": "2021-07-16T23:08:28",
+            "ingest": true,
+            "data_rights": "CC4 BY",
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-H285",
+            "collection_description": "Los musgos y hepáticas (en conjunto denominados briofitas) constituyen el segundo grupo en diversidad del reino vegetal (Mishler, 1988 y Buck y Thiers, 1989).  Al igual que las angiospermas, es de esperar mayor diversidad en las briofloras tropicales que las de regiones templadas, y aún así, Delgadillo y Equihua (1990) solamente citan dos trabajos que dedican su investigación al estado de Chiapas. Ambos estudios están enfocados a la parte central y los altos de Chiapas. Chiapas es uno de los estados más diversos de nuestro país (Breedlove, 1973 y Flores-Villela y Gerez, 1988) y donde se ubica uno de los límites septentrionales de bosque húmedo tropical (Medellín, et al., 1992).  La zona Lacandona, específicamente la Reserva de Montes Azules, ha sido muy poco estudiada (Delgadillo, 1993).  Este es el primer trabajo formal sobre briofitas en la zona y abarcará tanto la adquisición de información elemental sobre la brioflora de la zona, como análisis básicos sobre su ecología y distribución geográfica. Se han realizado cuatro visitas a la Reserva de Montes Azules y a zonas aledañas incluidas en la selva Lacandona: la región de Ixcán, alrededores de la estación Chajul, zona del río Tzendales, alrededores de los poblados de Nahá, Lacanhá y Nuevo Chapultepec.  Durante estas visitas se han colectado un total de 994 ejemplares y se están procesando 623 previamente colectados.  Hasta el momento se han determinado 60% de los ejemplares distribuidos en 170 especies.  Dentro de estas especies se han encontrado 14 nuevos registros para el país: nueve de hepáticas epífilas (Pócs y Equihua en prep.) y 5 de musgos (Equihua y García-Ávila, en prep).  Al finalizar este proyecto, se depositarán los ejemplares en el herbario nacional (MEXU). También se han realizado colectas en cuadrantes en los diferentes tipos de perturbación más frecuentes en la zona: acahuales y cacaotales, para comparar la diversidad con sitios sin perturbar (Equihua y Gradstein, en prep.). Al finalizar este estudió se publicará un listado florístico, un estudio biogeográfico y un estudio comparativo del efecto de la perturbación humana sobre las comunidades de briofitas. Reino: 1\nFilo: 3\nClase: 4\nOrden: 17\nFamilia: 48\nGénero: 134\nEspecie: 227\nEpitetoinfraespecifico: 7",
+            "other_guids": [],
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=H&Numero=285",
+            "id": "80bfa122-f762-11e1-a439-00145eb45e9a"
+          },
+          "datemodified": "2021-07-27T02:27:14.791596+00:00",
+          "name": "brioflora de la reserva de montes azules, chis.: diversidad, biogeografía y depauperación por actividad humana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "a9223e1d-7a81-4311-800e-211c5a1b8205",
+        "_score": 1,
+        "_source": {
+          "publisher": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+          "uuid": "a9223e1d-7a81-4311-800e-211c5a1b8205",
+          "dqs": -1,
+          "archivelink": "https://www.snib.mx/iptconabio/archive.do?r=snib-j063",
+          "rights": "cc4 by",
+          "contacts": [
+            {
+              "first_name": "Diego David",
+              "last_name": "Reygadas Prado",
+              "role": "Responsable"
+            },
+            {
+              "first_name": "CONABIO",
+              "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            },
+            {
+              "first_name": "Patricia",
+              "last_name": "Ramos Rivera",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-J063",
+            "contacts": [
+              {
+                "first_name": "Diego David",
+                "last_name": "Reygadas Prado",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Sistema de apoyo a la toma de decisiones para la reforestación rural en México",
+            "idigbio:uuid": "a9223e1d-7a81-4311-800e-211c5a1b8205",
+            "idigbio:etag": "34be2144b0279bd5c958018446e78f94dfb96f94",
+            "update": "2021-07-16T23:06:42",
+            "ingest": true,
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=J&Numero=63",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "80a89392-f762-11e1-a439-00145eb45e9a"
+            ],
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-J063",
+            "idigbio:dateModified": "2021-07-27T02:27:29.693139",
+            "collection_description": "La reforestación es la acción más directa e inmediata que apoya la recuperación de las áreas degradadas en México y a la conservación de aquellas susceptibles de afectación y pérdida de la cobertura vegetal y biodiversidad asociada. Se ha dado un impulso importante a los programas de reforestación a nivel nacional en los últimos años, de hecho se tiene programada una meta de 1,700 millones de plantas para el presente sexenio, aunque el enfoque que se ha dado a las plantaciones no se puede decir que refleja esta directriz de manera adecuada ya que la reforestación se ha dirigido en un alto porcentaje hacia las áreas urbanas y con especies exóticas. Es importante que el enfoque que se de a los trabajos futuros de reforestación se dirijan a especies nativas y en las áreas rurales de nuestro país dentro de las cuales los problemas ecológicos, económicos y sociales en conjunto requieren de una solución a corto plazo. En este contexto, este proyecto considera el empleo de herramientas como las bases de datos relacionales y los sistemas de información geográfica para conjuntar y analizar la información ecológica,, social y económica relacionada con la reforestación rural en México, a fin de proporcionar elementos de apoyo a la toma de decisiones que conlleven al desarrollo sustentable de las comunidades que habitan las áreas rurales de nuestro país. Reino: 1\nFilo: 1\nClase: 2\nOrden: 38\nFamilia: 85\nGénero: 262\nSubgénero: 7\nEspecie: 435\nEpitetoinfraespecifico: 5",
+            "id": "80a89392-f762-11e1-a439-00145eb45e9a",
+            "other_guids": [],
+            "data_rights": "CC4 BY"
+          },
+          "etag": "34be2144b0279bd5c958018446e78f94dfb96f94",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "https://www.snib.mx/iptconabio/eml.do?r=snib-j063",
+          "recordids": [
+            "80a89392-f762-11e1-a439-00145eb45e9a"
+          ],
+          "data": {
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-J063",
+            "contacts": [
+              {
+                "first_name": "Diego David",
+                "last_name": "Reygadas Prado",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Sistema de apoyo a la toma de decisiones para la reforestación rural en México",
+            "update": "2021-07-16T23:06:42",
+            "ingest": true,
+            "data_rights": "CC4 BY",
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-J063",
+            "collection_description": "La reforestación es la acción más directa e inmediata que apoya la recuperación de las áreas degradadas en México y a la conservación de aquellas susceptibles de afectación y pérdida de la cobertura vegetal y biodiversidad asociada. Se ha dado un impulso importante a los programas de reforestación a nivel nacional en los últimos años, de hecho se tiene programada una meta de 1,700 millones de plantas para el presente sexenio, aunque el enfoque que se ha dado a las plantaciones no se puede decir que refleja esta directriz de manera adecuada ya que la reforestación se ha dirigido en un alto porcentaje hacia las áreas urbanas y con especies exóticas. Es importante que el enfoque que se de a los trabajos futuros de reforestación se dirijan a especies nativas y en las áreas rurales de nuestro país dentro de las cuales los problemas ecológicos, económicos y sociales en conjunto requieren de una solución a corto plazo. En este contexto, este proyecto considera el empleo de herramientas como las bases de datos relacionales y los sistemas de información geográfica para conjuntar y analizar la información ecológica,, social y económica relacionada con la reforestación rural en México, a fin de proporcionar elementos de apoyo a la toma de decisiones que conlleven al desarrollo sustentable de las comunidades que habitan las áreas rurales de nuestro país. Reino: 1\nFilo: 1\nClase: 2\nOrden: 38\nFamilia: 85\nGénero: 262\nSubgénero: 7\nEspecie: 435\nEpitetoinfraespecifico: 5",
+            "other_guids": [],
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=J&Numero=63",
+            "id": "80a89392-f762-11e1-a439-00145eb45e9a"
+          },
+          "datemodified": "2021-07-27T02:27:29.693139+00:00",
+          "name": "sistema de apoyo a la toma de decisiones para la reforestación rural en méxico"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "ea3c3b03-0ed5-42fc-b192-7328459ea04a",
+        "_score": 1,
+        "_source": {
+          "publisher": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+          "uuid": "ea3c3b03-0ed5-42fc-b192-7328459ea04a",
+          "dqs": -1,
+          "archivelink": "https://www.snib.mx/iptconabio/archive.do?r=snib-u048",
+          "rights": "cc4 by",
+          "contacts": [
+            {
+              "first_name": "Enrique",
+              "last_name": "Guízar Nolazco",
+              "role": "Responsable"
+            },
+            {
+              "first_name": "CONABIO",
+              "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            },
+            {
+              "first_name": "Patricia",
+              "last_name": "Ramos Rivera",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-U048",
+            "contacts": [
+              {
+                "first_name": "Enrique",
+                "last_name": "Guízar Nolazco",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Banco de datos florísticos del Herbario CHAP",
+            "idigbio:uuid": "ea3c3b03-0ed5-42fc-b192-7328459ea04a",
+            "idigbio:etag": "ba0e2b66042b2ad2cad1d209ba0196a424b8288c",
+            "update": "2021-07-16T23:06:13",
+            "ingest": true,
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=U&Numero=48",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "9d300300-333d-4ac3-abcb-04d4b369e556"
+            ],
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-U048",
+            "idigbio:dateModified": "2021-07-27T02:26:58.291460",
+            "collection_description": "La colección científica del Herbario CHAP es la más antigua, cuantiosa e importante de la Universidad Autónoma Chapingo, esta constituida por aproximadamente 50,800 ejemplares debidamente registrados, pertenecientes a las diferentes formas biológicas de las plantas fanerógamas, así como de los diferentes tipos de vegetación existentes en México. Reviste importancia porque posee una de las colecciones más completas del grupo de las gimnospermas mexicanas y en general de la flora dendrológica. Contiene colecciones importantes entre las que destacan las de Pennington y Sarukhán del trópico cálido-húmedo, las colectas de Zsolt Debreczy e Iztvan Rácz correspondientes a las coníferas colectadas en México como parte del proyecto internacional Atlas Dendrológico, además de estar representadas las siguientes regiones: Sierra Nevada del Eje Neovolcánico, Noroeste de Chihuahua y Durango, cuenca alta del Balsas y las Mixtecas Poblana-Oaxaqueña. Reino: 1\nFilo: 1\nClase: 3\nOrden: 68\nFamilia: 267\nGénero: 1975\nSubgénero: 23\nEspecie: 8814\nEpitetoinfraespecifico: 465",
+            "id": "9d300300-333d-4ac3-abcb-04d4b369e556",
+            "other_guids": [],
+            "data_rights": "CC4 BY"
+          },
+          "etag": "ba0e2b66042b2ad2cad1d209ba0196a424b8288c",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "https://www.snib.mx/iptconabio/eml.do?r=snib-u048",
+          "recordids": [
+            "9d300300-333d-4ac3-abcb-04d4b369e556"
+          ],
+          "data": {
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-U048",
+            "contacts": [
+              {
+                "first_name": "Enrique",
+                "last_name": "Guízar Nolazco",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Banco de datos florísticos del Herbario CHAP",
+            "update": "2021-07-16T23:06:13",
+            "ingest": true,
+            "data_rights": "CC4 BY",
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-U048",
+            "collection_description": "La colección científica del Herbario CHAP es la más antigua, cuantiosa e importante de la Universidad Autónoma Chapingo, esta constituida por aproximadamente 50,800 ejemplares debidamente registrados, pertenecientes a las diferentes formas biológicas de las plantas fanerógamas, así como de los diferentes tipos de vegetación existentes en México. Reviste importancia porque posee una de las colecciones más completas del grupo de las gimnospermas mexicanas y en general de la flora dendrológica. Contiene colecciones importantes entre las que destacan las de Pennington y Sarukhán del trópico cálido-húmedo, las colectas de Zsolt Debreczy e Iztvan Rácz correspondientes a las coníferas colectadas en México como parte del proyecto internacional Atlas Dendrológico, además de estar representadas las siguientes regiones: Sierra Nevada del Eje Neovolcánico, Noroeste de Chihuahua y Durango, cuenca alta del Balsas y las Mixtecas Poblana-Oaxaqueña. Reino: 1\nFilo: 1\nClase: 3\nOrden: 68\nFamilia: 267\nGénero: 1975\nSubgénero: 23\nEspecie: 8814\nEpitetoinfraespecifico: 465",
+            "other_guids": [],
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=U&Numero=48",
+            "id": "9d300300-333d-4ac3-abcb-04d4b369e556"
+          },
+          "datemodified": "2021-07-27T02:26:58.291460+00:00",
+          "name": "banco de datos florísticos del herbario chap"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "8cae9490-b1c1-4199-a44e-3a1396666072",
+        "_score": 1,
+        "_source": {
+          "publisher": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+          "uuid": "8cae9490-b1c1-4199-a44e-3a1396666072",
+          "dqs": -1,
+          "archivelink": "https://www.snib.mx/iptconabio/archive.do?r=snib-ej008-ej0080809f-crustaceos",
+          "rights": "cc4 by",
+          "contacts": [
+            {
+              "first_name": "Ma del Carmen",
+              "last_name": "Franco Gordo",
+              "role": "Responsable"
+            },
+            {
+              "first_name": "CONABIO",
+              "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            },
+            {
+              "first_name": "Patricia",
+              "last_name": "Ramos Rivera",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-EJ008-EJ0080809F-crustaceos",
+            "contacts": [
+              {
+                "first_name": "Ma del Carmen",
+                "last_name": "Franco Gordo",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Base de datos y colección de distintos grupos del zooplancton de regiones marinas prioritarias de Jalisco y Colima en el Pacífico mexicano (Crustáceos)",
+            "idigbio:uuid": "8cae9490-b1c1-4199-a44e-3a1396666072",
+            "idigbio:etag": "590a9a50a0f250f3fefb8ce3af574564c2f6931d",
+            "update": "2021-07-16T23:12:33",
+            "ingest": true,
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=EJ&Numero=8",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "17f76205-c629-41d8-afc6-8959f90c8ab3"
+            ],
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-EJ008-EJ0080809F-crustaceos",
+            "idigbio:dateModified": "2021-07-27T02:27:10.942999",
+            "collection_description": "Nuestro conocimiento de la fauna zooplanctónica, en toda la costa mexicana, es aún escaso, y los pocos estudios que existen son aislados y no secuenciales. Es por eso que en este proyecto se pretende estudiar y difundir los datos de varios grupos del zooplancton   que fueron recolectados desde el año 1988 (medusas),  1990 (copépodos,  eufáusidos)  y otros colectados de manera sistemática durante 1995-1998  (larvas de peces y quetognatos), conforman cerca de 70 sitios georeferenciados, ubicadas en tres Áreas Marinas Prioritarias del Jalisco y Colima.   Se creará una base de datos en versión BIOTICA con la información de los organismos encontrados y los datos de los sitios de recolección.   Se creará una colección de referencia con por lo menos un ejemplar de cada una de las distintas especies identificadas. Se calcula obtener un mínimo de 100 especies de larvas de peces, 20 especies de medusas, 40 especies de  copépodos,  5 especies de eufaúsidos y 11 especies de quetognatos, más de 10, 000 registros curatoriales y 6100  ejemplares a partir de 50 localidades georreferenciadas y más de 300  muestras analizadas.\nPalabras clave: colección, larvas de peces, copépodos, medusas, quetognatos, eufáusidos Reino: 1\nFilo: 1\nClase: 2\nOrden: 4\nFamilia: 18\nGénero: 25\nEspecie: 48",
+            "id": "17f76205-c629-41d8-afc6-8959f90c8ab3",
+            "other_guids": [],
+            "data_rights": "CC4 BY"
+          },
+          "etag": "590a9a50a0f250f3fefb8ce3af574564c2f6931d",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "https://www.snib.mx/iptconabio/eml.do?r=snib-ej008-ej0080809f-crustaceos",
+          "recordids": [
+            "17f76205-c629-41d8-afc6-8959f90c8ab3"
+          ],
+          "data": {
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-EJ008-EJ0080809F-crustaceos",
+            "contacts": [
+              {
+                "first_name": "Ma del Carmen",
+                "last_name": "Franco Gordo",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Base de datos y colección de distintos grupos del zooplancton de regiones marinas prioritarias de Jalisco y Colima en el Pacífico mexicano (Crustáceos)",
+            "update": "2021-07-16T23:12:33",
+            "ingest": true,
+            "data_rights": "CC4 BY",
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-EJ008-EJ0080809F-crustaceos",
+            "collection_description": "Nuestro conocimiento de la fauna zooplanctónica, en toda la costa mexicana, es aún escaso, y los pocos estudios que existen son aislados y no secuenciales. Es por eso que en este proyecto se pretende estudiar y difundir los datos de varios grupos del zooplancton   que fueron recolectados desde el año 1988 (medusas),  1990 (copépodos,  eufáusidos)  y otros colectados de manera sistemática durante 1995-1998  (larvas de peces y quetognatos), conforman cerca de 70 sitios georeferenciados, ubicadas en tres Áreas Marinas Prioritarias del Jalisco y Colima.   Se creará una base de datos en versión BIOTICA con la información de los organismos encontrados y los datos de los sitios de recolección.   Se creará una colección de referencia con por lo menos un ejemplar de cada una de las distintas especies identificadas. Se calcula obtener un mínimo de 100 especies de larvas de peces, 20 especies de medusas, 40 especies de  copépodos,  5 especies de eufaúsidos y 11 especies de quetognatos, más de 10, 000 registros curatoriales y 6100  ejemplares a partir de 50 localidades georreferenciadas y más de 300  muestras analizadas.\nPalabras clave: colección, larvas de peces, copépodos, medusas, quetognatos, eufáusidos Reino: 1\nFilo: 1\nClase: 2\nOrden: 4\nFamilia: 18\nGénero: 25\nEspecie: 48",
+            "other_guids": [],
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=EJ&Numero=8",
+            "id": "17f76205-c629-41d8-afc6-8959f90c8ab3"
+          },
+          "datemodified": "2021-07-27T02:27:10.942999+00:00",
+          "name": "base de datos y colección de distintos grupos del zooplancton de regiones marinas prioritarias de jalisco y colima en el pacífico mexicano (crustáceos)"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "8dc14464-57b3-423e-8cb0-950ab8f36b6f",
+        "_score": 1,
+        "_source": {
+          "publisher": "4e1beef9-d7c0-4ac0-87df-065bc5a55361",
+          "uuid": "8dc14464-57b3-423e-8cb0-950ab8f36b6f",
+          "dqs": -1,
+          "archivelink": "http://bryophyteportal.org/portal/collections/datasets/dwc/cas_dwc-a.zip",
+          "rights": "cc3 by-nc",
+          "contacts": [
+            {
+              "email": "egbot@asu.edu"
+            },
+            {
+              "first_name": "Debra Trock, Collections Manager, Herbarium",
+              "email": "dtrock@calacademy.org"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "4e1beef9-d7c0-4ac0-87df-065bc5a55361",
+            "eml_link": "http://bryophyteportal.org/portal/collections/datasets/dwc/CAS_DwC-A.eml",
+            "contacts": [
+              {
+                "email": "egbot@asu.edu"
+              },
+              {
+                "first_name": "Debra Trock, Collections Manager, Herbarium",
+                "email": "dtrock@calacademy.org"
+              }
+            ],
+            "collection_name": "California Academy of Sciences",
+            "idigbio:uuid": "8dc14464-57b3-423e-8cb0-950ab8f36b6f",
+            "idigbio:etag": "4e9fb98c216afc7ffc4647b7af09be98f397a627",
+            "update": "2015-09-28T21:12:12",
+            "ingest": true,
+            "institution_web_address": "http://research.calacademy.org/botany/collections",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "http://bryophyteportal.org/portal/webservices/dwc/d56640e5-4356-4610-8d1e-d5567c193937"
+            ],
+            "link": "http://bryophyteportal.org/portal/collections/datasets/dwc/CAS_DwC-A.zip",
+            "idigbio:dateModified": "2015-09-29T00:21:36.226368",
+            "collection_description": "The herbarium of the California Academy of Sciences (CAS) is the largest collection of vascular plants in the western U.S. It is the sixth largest collection in the United States. Together with the Herbarium of the University of California at Berkeley (UC) the San Francisco Bay area is regarded as a National Resource Center for systematic botany. These two major collections have an informal agreement to avoid duplication, thus providing botanists with a rich and varied resource for research.",
+            "id": "http://bryophyteportal.org/portal/webservices/dwc/d56640e5-4356-4610-8d1e-d5567c193937",
+            "other_guids": [],
+            "logo_url": "http://bryophyteportal.org/portal/images/collicons/CAS.jpg",
+            "data_rights": "CC3 BY-NC"
+          },
+          "etag": "4e9fb98c216afc7ffc4647b7af09be98f397a627",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "http://bryophyteportal.org/portal/collections/datasets/dwc/cas_dwc-a.eml",
+          "logourl": "http://bryophyteportal.org/portal/images/collicons/cas.jpg",
+          "recordids": [
+            "http://bryophyteportal.org/portal/webservices/dwc/d56640e5-4356-4610-8d1e-d5567c193937"
+          ],
+          "data": {
+            "eml_link": "http://bryophyteportal.org/portal/collections/datasets/dwc/CAS_DwC-A.eml",
+            "contacts": [
+              {
+                "email": "egbot@asu.edu"
+              },
+              {
+                "first_name": "Debra Trock, Collections Manager, Herbarium",
+                "email": "dtrock@calacademy.org"
+              }
+            ],
+            "collection_name": "California Academy of Sciences",
+            "update": "2015-09-28T21:12:12",
+            "ingest": true,
+            "data_rights": "CC3 BY-NC",
+            "link": "http://bryophyteportal.org/portal/collections/datasets/dwc/CAS_DwC-A.zip",
+            "collection_description": "The herbarium of the California Academy of Sciences (CAS) is the largest collection of vascular plants in the western U.S. It is the sixth largest collection in the United States. Together with the Herbarium of the University of California at Berkeley (UC) the San Francisco Bay area is regarded as a National Resource Center for systematic botany. These two major collections have an informal agreement to avoid duplication, thus providing botanists with a rich and varied resource for research.",
+            "institution_web_address": "http://research.calacademy.org/botany/collections",
+            "other_guids": [],
+            "logo_url": "http://bryophyteportal.org/portal/images/collicons/CAS.jpg",
+            "id": "http://bryophyteportal.org/portal/webservices/dwc/d56640e5-4356-4610-8d1e-d5567c193937"
+          },
+          "datemodified": "2015-09-29T00:21:36.226368+00:00",
+          "name": "california academy of sciences"
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "top_data.contacts.email": {
+      "doc_count_error_upper_bound": 27,
+      "sum_other_doc_count": 4937,
+      "buckets": [
+        {
+          "key": "conabio.gob.mx",
+          "doc_count": 415
+        },
+        {
+          "key": "patricia.ramos",
+          "doc_count": 400
+        },
+        {
+          "key": "gmail.com",
+          "doc_count": 258
+        },
+        {
+          "key": "berkeley.edu",
+          "doc_count": 187
+        },
+        {
+          "key": "vertnet.org",
+          "doc_count": 182
+        },
+        {
+          "key": "dbloom",
+          "doc_count": 178
+        },
+        {
+          "key": "asu.edu",
+          "doc_count": 177
+        },
+        {
+          "key": "tuco",
+          "doc_count": 176
+        },
+        {
+          "key": "cria.org.br",
+          "doc_count": 119
+        },
+        {
+          "key": "splink",
+          "doc_count": 117
+        }
+      ]
+    }
+  }
+}

--- a/__tests__/mock/search-603ff02998a8ec7d1b37680457863937.json
+++ b/__tests__/mock/search-603ff02998a8ec7d1b37680457863937.json
@@ -1,0 +1,7542 @@
+{
+  "timed_out": false,
+  "_shards": {
+    "total": 48,
+    "successful": 48,
+    "failed": 0
+  },
+  "hits": {
+    "total": 137283704,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7f61e2b6-5524-40a3-a7f2-c32374f2b1b7",
+        "_score": null,
+        "_source": {
+          "uuid": "7f61e2b6-5524-40a3-a7f2-c32374f2b1b7"
+        },
+        "sort": [
+          0.6376812
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "238e680d-430c-4f6e-8f82-204a52339ee6",
+        "_score": null,
+        "_source": {
+          "uuid": "238e680d-430c-4f6e-8f82-204a52339ee6"
+        },
+        "sort": [
+          0.6376812
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6b4c4dcd-6778-4be4-b8c7-c0cc1cd5db3a",
+        "_score": null,
+        "_source": {
+          "uuid": "6b4c4dcd-6778-4be4-b8c7-c0cc1cd5db3a"
+        },
+        "sort": [
+          0.6086956
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0ac575ba-406f-4537-aa26-c34192e90910",
+        "_score": null,
+        "_source": {
+          "uuid": "0ac575ba-406f-4537-aa26-c34192e90910"
+        },
+        "sort": [
+          0.5942029
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bc3b3459-66a6-40cc-b71d-c30b0521b75a",
+        "_score": null,
+        "_source": {
+          "uuid": "bc3b3459-66a6-40cc-b71d-c30b0521b75a"
+        },
+        "sort": [
+          0.5942029
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c04897dd-2c1e-436f-a192-8d34848b360d",
+        "_score": null,
+        "_source": {
+          "uuid": "c04897dd-2c1e-436f-a192-8d34848b360d"
+        },
+        "sort": [
+          0.5942029
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8a531737-f932-48f6-854b-8fb0aee49d1e",
+        "_score": null,
+        "_source": {
+          "uuid": "8a531737-f932-48f6-854b-8fb0aee49d1e"
+        },
+        "sort": [
+          0.5942029
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a741b503-cb3d-4291-9f12-c4853fccfd66",
+        "_score": null,
+        "_source": {
+          "uuid": "a741b503-cb3d-4291-9f12-c4853fccfd66"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e6c5dffc-4ad1-4d9d-800f-5796baec1f65",
+        "_score": null,
+        "_source": {
+          "uuid": "e6c5dffc-4ad1-4d9d-800f-5796baec1f65"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e6474a5f-f29c-4228-b19d-2fb7422f5559",
+        "_score": null,
+        "_source": {
+          "uuid": "e6474a5f-f29c-4228-b19d-2fb7422f5559"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "843503da-da16-4f95-8292-68c87d4209e8",
+        "_score": null,
+        "_source": {
+          "uuid": "843503da-da16-4f95-8292-68c87d4209e8"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9181468a-5f0c-433d-a9f6-47fd7a7ae8bc",
+        "_score": null,
+        "_source": {
+          "uuid": "9181468a-5f0c-433d-a9f6-47fd7a7ae8bc"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "497415c1-b486-4e27-97dc-26e3b408eb42",
+        "_score": null,
+        "_source": {
+          "uuid": "497415c1-b486-4e27-97dc-26e3b408eb42"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "db16bf3a-550b-4204-92e4-bbc71c96c772",
+        "_score": null,
+        "_source": {
+          "uuid": "db16bf3a-550b-4204-92e4-bbc71c96c772"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "18e914df-aa7f-48d7-aa0e-643583f5cb45",
+        "_score": null,
+        "_source": {
+          "uuid": "18e914df-aa7f-48d7-aa0e-643583f5cb45"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b013cdc8-f97f-47d0-9c2b-4d419332981b",
+        "_score": null,
+        "_source": {
+          "uuid": "b013cdc8-f97f-47d0-9c2b-4d419332981b"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8b1f86b8-2a57-4f9b-a8ae-6208af69c3de",
+        "_score": null,
+        "_source": {
+          "uuid": "8b1f86b8-2a57-4f9b-a8ae-6208af69c3de"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f14ea100-141e-44bd-9bbd-fdc73a17814a",
+        "_score": null,
+        "_source": {
+          "uuid": "f14ea100-141e-44bd-9bbd-fdc73a17814a"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7510ec97-cb80-49c5-a9f8-f909a304f8ee",
+        "_score": null,
+        "_source": {
+          "uuid": "7510ec97-cb80-49c5-a9f8-f909a304f8ee"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2d12c5ec-6619-4ef4-ba5f-6b6ef15447c3",
+        "_score": null,
+        "_source": {
+          "uuid": "2d12c5ec-6619-4ef4-ba5f-6b6ef15447c3"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d884554f-d9e5-480c-bc6e-e9de2bd82cd4",
+        "_score": null,
+        "_source": {
+          "uuid": "d884554f-d9e5-480c-bc6e-e9de2bd82cd4"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4a02e435-c74b-463f-8bb8-356bcd52869e",
+        "_score": null,
+        "_source": {
+          "uuid": "4a02e435-c74b-463f-8bb8-356bcd52869e"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b32cfcb2-2e96-474c-94c3-8ff5c24ee511",
+        "_score": null,
+        "_source": {
+          "uuid": "b32cfcb2-2e96-474c-94c3-8ff5c24ee511"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5de99bab-c735-4d3c-9117-35278ba18e76",
+        "_score": null,
+        "_source": {
+          "uuid": "5de99bab-c735-4d3c-9117-35278ba18e76"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "04d07425-687d-4646-9f1e-b19c5137642d",
+        "_score": null,
+        "_source": {
+          "uuid": "04d07425-687d-4646-9f1e-b19c5137642d"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "37ac603e-c90e-4c79-9d3c-8ddfa9ec5746",
+        "_score": null,
+        "_source": {
+          "uuid": "37ac603e-c90e-4c79-9d3c-8ddfa9ec5746"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0c7670d6-f1be-4ad9-99f9-fa7237597505",
+        "_score": null,
+        "_source": {
+          "uuid": "0c7670d6-f1be-4ad9-99f9-fa7237597505"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "64c3277e-44bf-461f-85cd-40d4503d8bdc",
+        "_score": null,
+        "_source": {
+          "uuid": "64c3277e-44bf-461f-85cd-40d4503d8bdc"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b23c4138-0ee7-4780-8f35-64932782b632",
+        "_score": null,
+        "_source": {
+          "uuid": "b23c4138-0ee7-4780-8f35-64932782b632"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "62aaa67e-6e23-465d-9cc3-9511f6c25b0f",
+        "_score": null,
+        "_source": {
+          "uuid": "62aaa67e-6e23-465d-9cc3-9511f6c25b0f"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f2337a9d-0e75-4074-8742-0d11ee5851a7",
+        "_score": null,
+        "_source": {
+          "uuid": "f2337a9d-0e75-4074-8742-0d11ee5851a7"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "723100d4-7361-438d-9844-d8c6363b9542",
+        "_score": null,
+        "_source": {
+          "uuid": "723100d4-7361-438d-9844-d8c6363b9542"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4e0227e9-29eb-4d84-9b76-597116331488",
+        "_score": null,
+        "_source": {
+          "uuid": "4e0227e9-29eb-4d84-9b76-597116331488"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "534e96be-2875-43e2-86b3-7bc251fbee4f",
+        "_score": null,
+        "_source": {
+          "uuid": "534e96be-2875-43e2-86b3-7bc251fbee4f"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dd44fdd9-75d7-4b8a-8136-f5dc5a3d93af",
+        "_score": null,
+        "_source": {
+          "uuid": "dd44fdd9-75d7-4b8a-8136-f5dc5a3d93af"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8f5b2bd0-92c8-4c88-818e-144d61f21133",
+        "_score": null,
+        "_source": {
+          "uuid": "8f5b2bd0-92c8-4c88-818e-144d61f21133"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3cf2ec24-1387-4b5e-a777-c7f71227479c",
+        "_score": null,
+        "_source": {
+          "uuid": "3cf2ec24-1387-4b5e-a777-c7f71227479c"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ddd2dab6-114c-4dff-a15f-8a9618c50015",
+        "_score": null,
+        "_source": {
+          "uuid": "ddd2dab6-114c-4dff-a15f-8a9618c50015"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a0a12901-6331-4945-b962-b76d8720bacb",
+        "_score": null,
+        "_source": {
+          "uuid": "a0a12901-6331-4945-b962-b76d8720bacb"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f143b718-3979-4d48-8027-d263781bbf54",
+        "_score": null,
+        "_source": {
+          "uuid": "f143b718-3979-4d48-8027-d263781bbf54"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7bdaac8a-2a67-41b1-8250-bb7d45b39469",
+        "_score": null,
+        "_source": {
+          "uuid": "7bdaac8a-2a67-41b1-8250-bb7d45b39469"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "50ec644e-d6be-4930-8763-928c30acb86d",
+        "_score": null,
+        "_source": {
+          "uuid": "50ec644e-d6be-4930-8763-928c30acb86d"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ab5771d6-b038-4bb6-9fd6-1de2f3d4d471",
+        "_score": null,
+        "_source": {
+          "uuid": "ab5771d6-b038-4bb6-9fd6-1de2f3d4d471"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f6899449-ece8-45ff-aea9-ff509eaeebb1",
+        "_score": null,
+        "_source": {
+          "uuid": "f6899449-ece8-45ff-aea9-ff509eaeebb1"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b1ae9aed-2081-4f83-b76a-28e40af03d34",
+        "_score": null,
+        "_source": {
+          "uuid": "b1ae9aed-2081-4f83-b76a-28e40af03d34"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f146bcf0-8a3f-4d4c-a510-c16bfe578bff",
+        "_score": null,
+        "_source": {
+          "uuid": "f146bcf0-8a3f-4d4c-a510-c16bfe578bff"
+        },
+        "sort": [
+          0.5797101
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fbbf4d3a-7559-4e3f-871f-7bee766dd636",
+        "_score": null,
+        "_source": {
+          "uuid": "fbbf4d3a-7559-4e3f-871f-7bee766dd636"
+        },
+        "sort": [
+          0.5797101
+        ]
+      }
+    ]
+  },
+  "aggregations": {
+    "rs": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "a6eee223-cf3b-4079-8bb2-b77dad8cae9d",
+          "doc_count": 9147418
+        },
+        {
+          "key": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+          "doc_count": 5550404
+        },
+        {
+          "key": "fabcdc12-9d29-4bd2-912b-176e71818144",
+          "doc_count": 4993090
+        },
+        {
+          "key": "3c9420c9-c4a8-47dc-88b7-b5638ca5e716",
+          "doc_count": 4904346
+        },
+        {
+          "key": "5386d272-06c6-4027-b5d5-d588c2afe5e5",
+          "doc_count": 4899691
+        },
+        {
+          "key": "36d35b23-113e-4633-90ec-19d265a3b5f6",
+          "doc_count": 4327355
+        },
+        {
+          "key": "271a9ce9-c6d3-4b63-a722-cb0adc48863f",
+          "doc_count": 2194148
+        },
+        {
+          "key": "7450a9e3-ef95-4f9e-8260-09b498d2c5e6",
+          "doc_count": 1631069
+        },
+        {
+          "key": "5aef068f-efd3-4851-a623-f542e97350cd",
+          "doc_count": 1560995
+        },
+        {
+          "key": "568e209f-d072-4fd6-8b64-27954b0fd731",
+          "doc_count": 1384505
+        },
+        {
+          "key": "fc014977-92f7-47fd-92d7-b609c39d8212",
+          "doc_count": 1382328
+        },
+        {
+          "key": "765aa536-b79e-4794-a0d2-40a160233922",
+          "doc_count": 1154684
+        },
+        {
+          "key": "f778ecc0-8371-49d5-9ab1-9d75f0b76fad",
+          "doc_count": 1143697
+        },
+        {
+          "key": "dde625e8-cc2a-4877-9ec4-0b8a20dfded9",
+          "doc_count": 1089069
+        },
+        {
+          "key": "0583609b-202f-40d0-8021-4c019635d4c9",
+          "doc_count": 1078175
+        },
+        {
+          "key": "c55ac6d0-180d-41be-829a-e82898c5ca54",
+          "doc_count": 1030455
+        },
+        {
+          "key": "03d3b1ea-c664-4699-ac3b-420735bef8e4",
+          "doc_count": 1002170
+        },
+        {
+          "key": "d598446c-2b25-4d5d-a983-99be53001203",
+          "doc_count": 1002094
+        },
+        {
+          "key": "a3b77120-3770-46dd-ba47-6941eff848b3",
+          "doc_count": 999991
+        },
+        {
+          "key": "e6ccc2bd-9451-4802-8a51-8640d9f09793",
+          "doc_count": 982388
+        },
+        {
+          "key": "710a8a54-783c-41aa-ad9a-05544cdb4c55",
+          "doc_count": 957725
+        },
+        {
+          "key": "5975bbda-cd92-4084-8a09-ce1e28e6164f",
+          "doc_count": 933057
+        },
+        {
+          "key": "2292f5d5-d39f-4944-be72-fa5dd62f581c",
+          "doc_count": 854352
+        },
+        {
+          "key": "a6e02b78-6fc6-4cb6-bb87-8d5a443f2c2a",
+          "doc_count": 836971
+        },
+        {
+          "key": "ded380b5-1ba2-4089-8e0c-0aa1b4140785",
+          "doc_count": 792753
+        },
+        {
+          "key": "a4e6033a-d1eb-46d3-869d-7c0328f09aa7",
+          "doc_count": 791318
+        },
+        {
+          "key": "953b0329-c3e4-4816-a038-7afbd2bb2547",
+          "doc_count": 787122
+        },
+        {
+          "key": "e95396c4-1cac-4c9b-b461-5f21cd978fc6",
+          "doc_count": 771095
+        },
+        {
+          "key": "cdb6ec43-935e-4da2-8798-71e40ca6d12a",
+          "doc_count": 735476
+        },
+        {
+          "key": "6c6f34ed-58a4-4ba2-b9c7-34524f79a349",
+          "doc_count": 718880
+        },
+        {
+          "key": "c1fa848f-ec37-4cdb-930b-c38de2ae63e6",
+          "doc_count": 715410
+        },
+        {
+          "key": "62a36329-6b82-48bc-94d8-1cb9adb91ab5",
+          "doc_count": 706679
+        },
+        {
+          "key": "6bb853ab-e8ea-43b1-bd83-47318fc4c345",
+          "doc_count": 689442
+        },
+        {
+          "key": "26f7cbde-fbcb-4500-80a9-a99daa0ead9d",
+          "doc_count": 674875
+        },
+        {
+          "key": "205fa34c-2fcb-4492-b992-972b18560f6f",
+          "doc_count": 661842
+        },
+        {
+          "key": "6aad3ea3-3c10-4eb5-8c42-3e12c3429c67",
+          "doc_count": 636115
+        },
+        {
+          "key": "2d853a6d-50ec-4931-8e91-48fc2491fdee",
+          "doc_count": 595613
+        },
+        {
+          "key": "65536dcd-7bb2-44e5-af3f-4a13f08e53d0",
+          "doc_count": 578172
+        },
+        {
+          "key": "84006c59-fead-4b84-b3b5-cedf28f67ea9",
+          "doc_count": 564020
+        },
+        {
+          "key": "a3c2796f-44b2-4a43-8d1f-c81654854245",
+          "doc_count": 561820
+        },
+        {
+          "key": "137ed4cd-5172-45a5-acdb-8e1de9a64e32",
+          "doc_count": 549855
+        },
+        {
+          "key": "db6c3db9-1e6d-4def-af29-33aa0339bfa9",
+          "doc_count": 541458
+        },
+        {
+          "key": "482990c6-da88-4d99-8cf4-ccd27ee82f44",
+          "doc_count": 539910
+        },
+        {
+          "key": "66427724-af1d-43f8-bc00-cb744e55ac2c",
+          "doc_count": 526672
+        },
+        {
+          "key": "53091d18-f173-4fc0-b9d9-20a1494e2466",
+          "doc_count": 523286
+        },
+        {
+          "key": "5ab348ab-439a-4697-925c-d6abe0c09b92",
+          "doc_count": 521115
+        },
+        {
+          "key": "f9a33279-d6ba-41c7-a511-ef6adfcb6e20",
+          "doc_count": 520079
+        },
+        {
+          "key": "fc628e53-5fdf-4436-9782-bf637d812b48",
+          "doc_count": 498716
+        },
+        {
+          "key": "95ecb448-3c1f-4145-8565-4f6d51beb62c",
+          "doc_count": 483213
+        },
+        {
+          "key": "774a153b-e556-47f6-95d1-bab49e61cc58",
+          "doc_count": 480848
+        },
+        {
+          "key": "32d433aa-9e2b-4ff9-bc55-5c3e30112207",
+          "doc_count": 477604
+        },
+        {
+          "key": "3a0018d0-9b91-4671-82d2-b635177dace6",
+          "doc_count": 468858
+        },
+        {
+          "key": "4e3043a6-d48a-4a35-b5fb-f67d50cbc158",
+          "doc_count": 435675
+        },
+        {
+          "key": "02ff95c9-5a14-459f-a2e4-7f93d87a7559",
+          "doc_count": 429045
+        },
+        {
+          "key": "7c3067c3-c229-4e73-b4aa-c187997ee530",
+          "doc_count": 419063
+        },
+        {
+          "key": "2d7910d9-7f63-4bde-918a-9e0265f1c245",
+          "doc_count": 406052
+        },
+        {
+          "key": "70abba3e-5f2a-4276-87f3-261706e24453",
+          "doc_count": 395306
+        },
+        {
+          "key": "f062cb7d-c03e-4762-b1c4-49118fee1a56",
+          "doc_count": 390412
+        },
+        {
+          "key": "6b5e29d3-b462-44d8-ba38-d68af5088067",
+          "doc_count": 390145
+        },
+        {
+          "key": "eaa5f19e-ff6f-4d09-8b55-4a6810e77a6c",
+          "doc_count": 388294
+        },
+        {
+          "key": "a47eacbb-22d0-4a8b-8853-989b26fd8290",
+          "doc_count": 383909
+        },
+        {
+          "key": "e60301d9-9b40-483f-92de-065769b9d3dd",
+          "doc_count": 382994
+        },
+        {
+          "key": "9e5aede6-bee5-4a3d-a255-513771b20035",
+          "doc_count": 382180
+        },
+        {
+          "key": "8919571f-205a-4aed-b9f2-96ccd0108e4c",
+          "doc_count": 369654
+        },
+        {
+          "key": "09b18522-5643-478f-86e9-d2e34440d43e",
+          "doc_count": 351896
+        },
+        {
+          "key": "c4bb08d4-c310-4879-abee-1b3986e8e0ca",
+          "doc_count": 350791
+        },
+        {
+          "key": "7ce9b7d0-a8da-4528-bbe3-2c4f407f9cea",
+          "doc_count": 349178
+        },
+        {
+          "key": "c004cf67-eafc-49f9-99bd-b8198e2234ed",
+          "doc_count": 342631
+        },
+        {
+          "key": "1f9209f0-ecf2-4c3e-8ec5-bfacec1e5b9c",
+          "doc_count": 342276
+        },
+        {
+          "key": "0fb53db0-a7a4-4ac4-8ad3-bc4648b411e0",
+          "doc_count": 327268
+        },
+        {
+          "key": "a68df423-aae9-4f4b-8a42-a36124627a53",
+          "doc_count": 326938
+        },
+        {
+          "key": "1ba0bbad-28a7-4c50-8992-a028f79d1dc5",
+          "doc_count": 326692
+        },
+        {
+          "key": "bf1fee2d-f760-4068-b8e6-d1db63ce434c",
+          "doc_count": 325387
+        },
+        {
+          "key": "51b958bb-9d5f-48d7-9a97-e372c0c747c3",
+          "doc_count": 319757
+        },
+        {
+          "key": "87017793-00dc-4f5d-b95b-09e7d17327cc",
+          "doc_count": 312858
+        },
+        {
+          "key": "8eabbc48-2b30-419d-bd8f-eece9185eca1",
+          "doc_count": 310348
+        },
+        {
+          "key": "4523e216-ee13-4b15-a3f7-a6fd56431604",
+          "doc_count": 310121
+        },
+        {
+          "key": "d7b285d4-2643-45ee-9302-b0c3d51dda5c",
+          "doc_count": 308751
+        },
+        {
+          "key": "87c45c90-ba1d-409e-a9d7-9baf5a5cbb1c",
+          "doc_count": 303111
+        },
+        {
+          "key": "72d4c3c7-3413-4588-a803-e1a63e0d7c6c",
+          "doc_count": 299544
+        },
+        {
+          "key": "8057906f-17c9-4e25-b173-4e7fb938078b",
+          "doc_count": 298271
+        },
+        {
+          "key": "e2def7e2-1455-4856-9823-6d3738417d24",
+          "doc_count": 298221
+        },
+        {
+          "key": "1320a827-d62a-45b1-9d26-c0aa4790a422",
+          "doc_count": 294681
+        },
+        {
+          "key": "b3976394-a174-4ceb-8d64-3a435d66bde6",
+          "doc_count": 294344
+        },
+        {
+          "key": "cb790bee-26da-40ed-94e0-d179618f9bd4",
+          "doc_count": 290333
+        },
+        {
+          "key": "d4ea4495-c4b2-4d05-b524-163423f17cd7",
+          "doc_count": 290145
+        },
+        {
+          "key": "40250f4d-7aa6-4fcc-ac38-2868fa4846bd",
+          "doc_count": 283567
+        },
+        {
+          "key": "b4bcc255-4acf-4966-b9b3-af9dd4e458d1",
+          "doc_count": 282874
+        },
+        {
+          "key": "3027c437-cdb3-4072-9410-5a46ec3b1fd5",
+          "doc_count": 280658
+        },
+        {
+          "key": "92dd8c8e-c048-4f0a-9b5d-2ee627d2f553",
+          "doc_count": 280146
+        },
+        {
+          "key": "fc7b78d7-82d4-4648-8185-87a0ba209c20",
+          "doc_count": 277221
+        },
+        {
+          "key": "beab5209-9628-4d4d-851e-2bc9bb1a0105",
+          "doc_count": 275252
+        },
+        {
+          "key": "f0174bc9-0cca-450e-a941-655d80040139",
+          "doc_count": 271745
+        },
+        {
+          "key": "ba042ffa-8175-4a47-8eb1-08b4d6319ccf",
+          "doc_count": 270528
+        },
+        {
+          "key": "d82fa49b-915e-4aa8-acc6-51df3d431884",
+          "doc_count": 268227
+        },
+        {
+          "key": "5ace330b-5888-4a46-a5ac-e428535ed4f3",
+          "doc_count": 267236
+        },
+        {
+          "key": "341da8fa-d049-46ee-9be8-463043f26fa7",
+          "doc_count": 262232
+        },
+        {
+          "key": "56879e73-bf9d-4bd9-a7a4-4f2f940d0f62",
+          "doc_count": 262214
+        },
+        {
+          "key": "858a7761-82a5-47df-8e8a-dbc8806cf424",
+          "doc_count": 258923
+        },
+        {
+          "key": "7df4be6b-67e9-4c05-8cd9-f546bdcc54d0",
+          "doc_count": 258397
+        },
+        {
+          "key": "79dfdec6-3e24-489c-a7ce-85dcc52bc3f9",
+          "doc_count": 256509
+        },
+        {
+          "key": "9fc55204-8dc8-467d-b92a-e6f27d1da317",
+          "doc_count": 255092
+        },
+        {
+          "key": "a2b36fdf-50bc-44ef-a6a4-ca6dc1dc148a",
+          "doc_count": 253911
+        },
+        {
+          "key": "a7228b3f-982a-4518-a761-b19b00e14844",
+          "doc_count": 252252
+        },
+        {
+          "key": "97e4947d-fce9-4019-9f86-c0d94c820269",
+          "doc_count": 251744
+        },
+        {
+          "key": "0bfd2d69-2a35-4291-9e73-bd311463bd15",
+          "doc_count": 250677
+        },
+        {
+          "key": "d53132e6-7997-4850-8607-4fec5a3f9c3f",
+          "doc_count": 246745
+        },
+        {
+          "key": "4ac45d7e-c6e5-45ea-a0e0-aea6ebe2afcf",
+          "doc_count": 244573
+        },
+        {
+          "key": "8b0c1f4b-9de7-4521-98c2-983e0bfd33c7",
+          "doc_count": 244568
+        },
+        {
+          "key": "fcbcb214-cd62-4453-af56-b4b49161a261",
+          "doc_count": 242207
+        },
+        {
+          "key": "e5cb850f-de98-45ce-9872-95262732809f",
+          "doc_count": 238853
+        },
+        {
+          "key": "f1cf8457-237e-487a-9d13-5de7d81b9de4",
+          "doc_count": 238062
+        },
+        {
+          "key": "9e046dad-2b23-4f95-8eaf-c0346de2556e",
+          "doc_count": 236488
+        },
+        {
+          "key": "207b6c64-7b58-4d6a-816d-bc759c27eafc",
+          "doc_count": 236162
+        },
+        {
+          "key": "97058091-eb35-401b-b286-18465761f832",
+          "doc_count": 234689
+        },
+        {
+          "key": "c38b867b-05f3-4733-802e-d8d2d3324f84",
+          "doc_count": 234088
+        },
+        {
+          "key": "ea12da76-1b2e-4944-8709-1de3af1c65e2",
+          "doc_count": 230893
+        },
+        {
+          "key": "24aa66d3-86a3-44a7-b6a3-6a45edc1e6a9",
+          "doc_count": 229051
+        },
+        {
+          "key": "781fd581-7b93-471e-a025-413e4bcd8491",
+          "doc_count": 228562
+        },
+        {
+          "key": "497d74c2-d07f-4325-ac9c-8e80bcb53f61",
+          "doc_count": 228245
+        },
+        {
+          "key": "dddf9315-7819-4289-b587-6be72e4894d2",
+          "doc_count": 223860
+        },
+        {
+          "key": "f7624647-b0d7-4753-94d0-9961186562fb",
+          "doc_count": 221420
+        },
+        {
+          "key": "da67ebd9-52de-444d-b114-e23c03111ac6",
+          "doc_count": 220272
+        },
+        {
+          "key": "bd61c458-b865-4b05-9f1f-735c49066e55",
+          "doc_count": 218777
+        },
+        {
+          "key": "beb74dc2-22ea-49e4-b1e3-bedb8e06e8f2",
+          "doc_count": 216309
+        },
+        {
+          "key": "67dfbfc8-bfc8-4a69-a63c-0918539e4dee",
+          "doc_count": 214114
+        },
+        {
+          "key": "7c1a1d78-aeaa-4501-87e1-83eceb8ca8ea",
+          "doc_count": 213685
+        },
+        {
+          "key": "4a32531f-1580-499f-bd48-5b0ef4cc5722",
+          "doc_count": 212106
+        },
+        {
+          "key": "59422682-15ba-47e1-99e2-1ef69f7bdd9a",
+          "doc_count": 211505
+        },
+        {
+          "key": "62c310ac-e1ff-47bc-860d-0471a84ed0d3",
+          "doc_count": 210017
+        },
+        {
+          "key": "39023cd0-ca46-4235-a6fa-162e414d6483",
+          "doc_count": 209691
+        },
+        {
+          "key": "2f484dca-4e55-4d29-ad96-56c96573444f",
+          "doc_count": 207416
+        },
+        {
+          "key": "59efaf7d-60b5-4295-abb3-27ba42eb5231",
+          "doc_count": 206223
+        },
+        {
+          "key": "515cab85-98d0-4a23-9544-9e7b1c51f5a6",
+          "doc_count": 205967
+        },
+        {
+          "key": "348f4784-4786-45be-8d0f-85f2b189eba8",
+          "doc_count": 204725
+        },
+        {
+          "key": "bc13ff8e-6f31-4f3d-b47a-38e3ce8a2194",
+          "doc_count": 203850
+        },
+        {
+          "key": "d2217bca-3a93-4407-bb56-087afa000cbc",
+          "doc_count": 203767
+        },
+        {
+          "key": "c9bff84f-8de4-43e6-b195-f515f187a68a",
+          "doc_count": 203203
+        },
+        {
+          "key": "9c5fea92-a28b-4b6e-94b5-9c939f7369a2",
+          "doc_count": 200878
+        },
+        {
+          "key": "b6ec6203-09db-4d6e-8cba-ee4bebd2934c",
+          "doc_count": 200630
+        },
+        {
+          "key": "d6ac6bcc-5473-46ae-a2b9-ca1813bc2438",
+          "doc_count": 199278
+        },
+        {
+          "key": "cb65cf5e-07b8-4d53-a91a-7dce9b8ccf80",
+          "doc_count": 196972
+        },
+        {
+          "key": "f3ee2661-268a-48dc-b931-b9429d5674f4",
+          "doc_count": 196583
+        },
+        {
+          "key": "3a5b5c9b-b241-4883-904a-b167a7edb41a",
+          "doc_count": 196261
+        },
+        {
+          "key": "d06a16c6-f540-40a8-9e92-876ad1955d03",
+          "doc_count": 194346
+        },
+        {
+          "key": "19daf0a7-5e37-41e6-97f8-4494553c358c",
+          "doc_count": 194186
+        },
+        {
+          "key": "25e4ea2d-74ef-4251-b461-6ceb3c812bf1",
+          "doc_count": 190683
+        },
+        {
+          "key": "459bd81e-63b9-47d2-9818-dceb6657bea0",
+          "doc_count": 189283
+        },
+        {
+          "key": "0fd6e726-6828-4f62-ba8d-6ec316fe0b52",
+          "doc_count": 188170
+        },
+        {
+          "key": "b3d38693-5f9b-484d-aca3-6cefcc5b08e0",
+          "doc_count": 187017
+        },
+        {
+          "key": "215eeaf0-0a88-409e-a75d-aec98b7c41eb",
+          "doc_count": 186686
+        },
+        {
+          "key": "01017cef-5065-48b2-9db8-3e428971d702",
+          "doc_count": 186097
+        },
+        {
+          "key": "bc41afff-4d56-421e-bc87-45e18b4fe64a",
+          "doc_count": 185149
+        },
+        {
+          "key": "5e893602-84ca-4c8c-bac1-99111c777582",
+          "doc_count": 179486
+        },
+        {
+          "key": "703b5bdc-4581-47e3-b4b6-e6f32d0eec54",
+          "doc_count": 176538
+        },
+        {
+          "key": "bd7cfd55-bf55-46fc-878d-e6e11f574ccd",
+          "doc_count": 175626
+        },
+        {
+          "key": "4830ffb8-669a-4717-bec8-2f2374f52120",
+          "doc_count": 173867
+        },
+        {
+          "key": "01dfe0f4-24fe-447e-9f8f-1db7f8394b89",
+          "doc_count": 172237
+        },
+        {
+          "key": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "doc_count": 172098
+        },
+        {
+          "key": "045aa661-f985-4203-80ff-98daafdfe377",
+          "doc_count": 170040
+        },
+        {
+          "key": "45544aa4-8762-4bf0-bfc6-890d08dc6ead",
+          "doc_count": 169844
+        },
+        {
+          "key": "3f508496-c860-4701-93e4-84e940c8395e",
+          "doc_count": 169117
+        },
+        {
+          "key": "fb4a4330-9124-4013-a0e1-af42ee20cd16",
+          "doc_count": 168799
+        },
+        {
+          "key": "f8866892-56a0-4f46-9583-6719d42d81de",
+          "doc_count": 168534
+        },
+        {
+          "key": "5ea005e8-626f-47de-afee-972e976cc3a7",
+          "doc_count": 168316
+        },
+        {
+          "key": "53feaa83-e3b6-4ad3-8597-293b153e7548",
+          "doc_count": 168092
+        },
+        {
+          "key": "ab4b6a2b-a90a-44ce-95a1-2c44c911fcc6",
+          "doc_count": 167430
+        },
+        {
+          "key": "1527b668-b797-42be-94d3-0058e1393e94",
+          "doc_count": 162770
+        },
+        {
+          "key": "275a8cea-1c34-4580-a030-4f58e680605c",
+          "doc_count": 162318
+        },
+        {
+          "key": "a8ac06c9-efb5-4337-9bdb-bee3b490772c",
+          "doc_count": 162150
+        },
+        {
+          "key": "0dab1fc7-ca99-456b-9985-76edbac003e0",
+          "doc_count": 162064
+        },
+        {
+          "key": "67b5d248-4a1e-4861-bc2a-3ac7f379acde",
+          "doc_count": 161140
+        },
+        {
+          "key": "6cc31636-c3e5-4887-bbee-2e56621771c4",
+          "doc_count": 159080
+        },
+        {
+          "key": "2e6b6643-ebc7-4a80-a7ea-f4dd7b9c42e7",
+          "doc_count": 158171
+        },
+        {
+          "key": "6258d160-a7aa-4937-bce3-3538eebd374f",
+          "doc_count": 157313
+        },
+        {
+          "key": "d7540872-1c53-48ac-a617-2d0739eadcbd",
+          "doc_count": 152346
+        },
+        {
+          "key": "8fc08919-1137-42e4-9fa5-9e64f1e5757b",
+          "doc_count": 152124
+        },
+        {
+          "key": "d38fd1e8-bc15-46b2-92d5-5f3df98cff53",
+          "doc_count": 151334
+        },
+        {
+          "key": "58402fe3-37c1-4d15-9e07-0ff1c4c9fb11",
+          "doc_count": 150988
+        },
+        {
+          "key": "2ccbe8d3-c688-4c20-bf24-68a5ef486519",
+          "doc_count": 149811
+        },
+        {
+          "key": "b5f4526b-f4fb-4d90-8ce0-975e0cda8ff6",
+          "doc_count": 147669
+        },
+        {
+          "key": "11d3ad3b-38de-4709-8544-ec3c26d96607",
+          "doc_count": 146747
+        },
+        {
+          "key": "77e7e6bd-7822-4b84-a46b-39a06abdac2e",
+          "doc_count": 145394
+        },
+        {
+          "key": "abbf4722-c63b-492f-b183-cb45ad9f5211",
+          "doc_count": 144765
+        },
+        {
+          "key": "7b0809fb-fd62-4733-8f40-74ceb04cbcac",
+          "doc_count": 142757
+        },
+        {
+          "key": "b4d4e884-a2ef-4967-b4cb-2072fc465eaf",
+          "doc_count": 142592
+        },
+        {
+          "key": "edf395ee-e4ec-4b31-82cf-d57066b1159f",
+          "doc_count": 142363
+        },
+        {
+          "key": "17ff84d1-e3e9-43d1-a746-745ef8d339d0",
+          "doc_count": 141860
+        },
+        {
+          "key": "15a68005-43c2-4706-8a10-af419af9201d",
+          "doc_count": 141197
+        },
+        {
+          "key": "b9ab58cf-785e-44a7-a873-1966e14a6715",
+          "doc_count": 140521
+        },
+        {
+          "key": "253f90be-3b94-469c-820c-cb727b85bdd4",
+          "doc_count": 139087
+        },
+        {
+          "key": "e9b69a0a-497d-4201-b114-51519a4dfef9",
+          "doc_count": 138755
+        },
+        {
+          "key": "589ad4bd-a0aa-4949-bb92-0533ba7edaf2",
+          "doc_count": 137692
+        },
+        {
+          "key": "948a3370-bdb4-46cb-a047-c777a76ae420",
+          "doc_count": 137348
+        },
+        {
+          "key": "9151bc4c-8505-4b22-a16b-9dbf337535fa",
+          "doc_count": 135830
+        },
+        {
+          "key": "2c00c297-9ebd-498a-b701-d3ebde4b49f3",
+          "doc_count": 134110
+        },
+        {
+          "key": "b40e13f7-a79a-4265-93d9-3b4878dfc988",
+          "doc_count": 133466
+        },
+        {
+          "key": "ccd17772-d220-4088-8fa3-df3729f14df4",
+          "doc_count": 132304
+        },
+        {
+          "key": "e881a3e2-f7ba-43c8-ae9a-11fcbfd741bb",
+          "doc_count": 132214
+        },
+        {
+          "key": "96662fa9-ff60-495b-912a-284f3b98ed72",
+          "doc_count": 129753
+        },
+        {
+          "key": "2d94a3ac-f505-49ec-98e7-3b7dc48344dd",
+          "doc_count": 128085
+        },
+        {
+          "key": "e48bb88f-9594-461e-8230-522a3a5572fe",
+          "doc_count": 127280
+        },
+        {
+          "key": "a7020dbf-35fc-46e8-a441-c0a6b957193c",
+          "doc_count": 126880
+        },
+        {
+          "key": "a8d88237-2f62-4ad5-b1f7-ab13ace304df",
+          "doc_count": 126703
+        },
+        {
+          "key": "ce0c9488-97f0-432a-a0fa-d204230366be",
+          "doc_count": 126702
+        },
+        {
+          "key": "cf42855e-a54a-4488-a79e-beac086ba1d4",
+          "doc_count": 126338
+        },
+        {
+          "key": "3ad82604-c4b3-4fd0-b03e-d8f874062146",
+          "doc_count": 126085
+        },
+        {
+          "key": "b688c17c-3761-4ccd-a42f-88219f5fcff4",
+          "doc_count": 125864
+        },
+        {
+          "key": "3e5a9f79-297b-497d-84eb-97e0d1e5c2bf",
+          "doc_count": 125515
+        },
+        {
+          "key": "d56c787a-7da2-438b-81c5-554442f97259",
+          "doc_count": 124997
+        },
+        {
+          "key": "7c927849-94ed-4034-90e9-af34ac0cb47c",
+          "doc_count": 124009
+        },
+        {
+          "key": "2080cb77-b769-406f-a551-519858dd3f23",
+          "doc_count": 123759
+        },
+        {
+          "key": "31c140bc-e6f1-4acc-beaf-b825cf288ad9",
+          "doc_count": 121733
+        },
+        {
+          "key": "b531ea59-025d-4c29-9d23-99ae75bcd55f",
+          "doc_count": 121154
+        },
+        {
+          "key": "3c919328-94fd-4657-b81d-21f4707253ed",
+          "doc_count": 120647
+        },
+        {
+          "key": "0c94911f-6f18-40a2-a0c3-95c845bc41d7",
+          "doc_count": 120340
+        },
+        {
+          "key": "b1f0612a-bc21-424f-b9c1-3bba69ad4f54",
+          "doc_count": 119983
+        },
+        {
+          "key": "55b17f44-8c6b-4dc5-a31d-d9955b425790",
+          "doc_count": 119804
+        },
+        {
+          "key": "ec359278-df8e-4766-a1d3-4b55fd822704",
+          "doc_count": 119382
+        },
+        {
+          "key": "83ad8494-136b-485a-87d4-8ce01dd6a8de",
+          "doc_count": 118745
+        },
+        {
+          "key": "bf897c17-06cc-48c1-a7cc-f41b45166880",
+          "doc_count": 117444
+        },
+        {
+          "key": "49153f74-2969-4a6a-a145-309fcb970308",
+          "doc_count": 117350
+        },
+        {
+          "key": "f4bec217-9676-4fc0-be90-856b4b89d4d1",
+          "doc_count": 116417
+        },
+        {
+          "key": "d78d13a7-3852-4244-ba34-86ef5765fa99",
+          "doc_count": 116343
+        },
+        {
+          "key": "433646ab-571a-44f5-820e-25e0736b1113",
+          "doc_count": 115365
+        },
+        {
+          "key": "e4ff51ba-5007-4c40-9a86-e8c6f4db77b7",
+          "doc_count": 115330
+        },
+        {
+          "key": "10d835b1-1062-4236-9329-444ed81f624f",
+          "doc_count": 112530
+        },
+        {
+          "key": "1aee98c2-6623-49ae-b4af-c8afcf08150f",
+          "doc_count": 111242
+        },
+        {
+          "key": "e3c3f4db-e4f3-4198-9c43-4d518d5893a3",
+          "doc_count": 110350
+        },
+        {
+          "key": "0bc60df1-a162-4173-9a73-c51e09031843",
+          "doc_count": 110311
+        },
+        {
+          "key": "aca26f37-3ec8-4e9e-b927-50b4944a0096",
+          "doc_count": 110029
+        },
+        {
+          "key": "e6642584-cbe8-4d3d-806d-6a4242515742",
+          "doc_count": 108856
+        },
+        {
+          "key": "1ea148f3-17d9-4af8-b49f-bb17affe24d8",
+          "doc_count": 108384
+        },
+        {
+          "key": "387ae47b-8641-4e3c-ae66-d1e20d93cf32",
+          "doc_count": 107792
+        },
+        {
+          "key": "c2767dde-1315-4d78-abf9-8e098dd588ab",
+          "doc_count": 107621
+        },
+        {
+          "key": "cd46dc32-5e36-414b-a8d7-dea9df1f9106",
+          "doc_count": 107301
+        },
+        {
+          "key": "6ca0f584-8a74-42c6-9fdc-041502bc0a33",
+          "doc_count": 106550
+        },
+        {
+          "key": "71bf994a-3af5-484d-983b-b146aa1512d1",
+          "doc_count": 105648
+        },
+        {
+          "key": "d0769c31-e4f1-42b1-a21f-cd6bf2257edb",
+          "doc_count": 104916
+        },
+        {
+          "key": "8195c379-b0aa-42ac-839b-b436e23d750a",
+          "doc_count": 103638
+        },
+        {
+          "key": "f00b6a32-5337-406b-a850-17f5d78470ad",
+          "doc_count": 103143
+        },
+        {
+          "key": "87fee729-2a4e-4d23-ad8a-5e03e1ab7c1a",
+          "doc_count": 102032
+        },
+        {
+          "key": "237d30ca-7675-4840-b4fd-96771fabf518",
+          "doc_count": 101919
+        },
+        {
+          "key": "639ae683-0a66-4a59-9c09-36304bf11424",
+          "doc_count": 101503
+        },
+        {
+          "key": "e1e0f2cc-a50c-40d4-9031-c2d90a826247",
+          "doc_count": 101342
+        },
+        {
+          "key": "5626f61a-822e-4692-b432-51f53d053e4d",
+          "doc_count": 101064
+        },
+        {
+          "key": "82541f90-fe8e-4d66-84d8-4fe515dc5533",
+          "doc_count": 100754
+        },
+        {
+          "key": "ff111763-e72d-4f24-8914-b5b2dd94908c",
+          "doc_count": 100366
+        },
+        {
+          "key": "7311c4ac-7cf6-4160-a55c-4a4c7cd0cf89",
+          "doc_count": 100247
+        },
+        {
+          "key": "35c43eda-1f4a-4713-bb69-e3fbe1bf792f",
+          "doc_count": 99961
+        },
+        {
+          "key": "b8cbed64-5126-46bd-97aa-43627743aba7",
+          "doc_count": 99592
+        },
+        {
+          "key": "88271bd3-1985-4fa7-9e33-f82cc24dfad3",
+          "doc_count": 99568
+        },
+        {
+          "key": "1a44dfa0-6a54-4584-8c57-d98669d7f033",
+          "doc_count": 98985
+        },
+        {
+          "key": "d0c73947-fce1-4914-abf0-280584f89510",
+          "doc_count": 98523
+        },
+        {
+          "key": "4790a6a0-ce11-4cd8-8cad-4b2032a55c1b",
+          "doc_count": 97797
+        },
+        {
+          "key": "7ae4d15d-62e2-459b-842a-446f921b9d3f",
+          "doc_count": 97582
+        },
+        {
+          "key": "5082e6c8-8f5b-4bf6-a930-e3e6de7bf6fb",
+          "doc_count": 97321
+        },
+        {
+          "key": "1bb2a80e-271f-46a8-bbfc-ba56d3e6292a",
+          "doc_count": 96941
+        },
+        {
+          "key": "8e58cd34-3cbb-46f7-9c25-527251881a6f",
+          "doc_count": 96937
+        },
+        {
+          "key": "d621e959-2633-4ec1-a2a2-5d97cd818b47",
+          "doc_count": 96898
+        },
+        {
+          "key": "d478c23a-1993-443d-85ea-308870606626",
+          "doc_count": 96726
+        },
+        {
+          "key": "6b546055-ecf5-40dd-a091-67fe6f9531f4",
+          "doc_count": 95779
+        },
+        {
+          "key": "0ed8a17e-149b-4cbe-8383-7676da92ea1c",
+          "doc_count": 95437
+        },
+        {
+          "key": "1ebb0c8e-31f2-4564-b75d-65196bee4f09",
+          "doc_count": 95273
+        },
+        {
+          "key": "995cc7f1-69c3-4317-ab77-28fd48f1e535",
+          "doc_count": 94942
+        },
+        {
+          "key": "c569e530-7322-40b8-9b66-1e0ed96fefcb",
+          "doc_count": 94693
+        },
+        {
+          "key": "88595487-6d33-4980-ba54-bcf427c9466e",
+          "doc_count": 93710
+        },
+        {
+          "key": "ec6cef7d-d8aa-43b4-b352-908f172a378e",
+          "doc_count": 92911
+        },
+        {
+          "key": "ea44c7c9-9cca-4fae-9a0a-84f1b95f21cf",
+          "doc_count": 92758
+        },
+        {
+          "key": "b667cef4-96fe-42e8-a9fa-6298aa80bb14",
+          "doc_count": 92575
+        },
+        {
+          "key": "7370af7d-07b5-4fc6-9eca-0204b4d6e33e",
+          "doc_count": 92562
+        },
+        {
+          "key": "f84d528a-7d08-467e-b532-ace707316f1d",
+          "doc_count": 92393
+        },
+        {
+          "key": "d8862887-ff5c-4caa-9d61-f1958887ebc1",
+          "doc_count": 91995
+        },
+        {
+          "key": "4fecde59-9f59-44eb-ab6f-4a50b4ed85cf",
+          "doc_count": 91253
+        },
+        {
+          "key": "d29b9265-07e6-4e73-8f72-fc42d3d83fb1",
+          "doc_count": 91131
+        },
+        {
+          "key": "6075f4b7-4242-4886-be7d-391614fffe41",
+          "doc_count": 89982
+        },
+        {
+          "key": "20360fae-574a-4d63-b9f6-47b1cc07fd22",
+          "doc_count": 88733
+        },
+        {
+          "key": "02fceae6-c71c-4db9-8b2f-e235ced6624a",
+          "doc_count": 88240
+        },
+        {
+          "key": "46c11153-2154-495d-89d2-7cdef6425cdb",
+          "doc_count": 87691
+        },
+        {
+          "key": "14f8f83f-7a0c-458c-b6d5-6da7dc8eaa0a",
+          "doc_count": 87345
+        },
+        {
+          "key": "7644703a-ce24-4f7b-b800-66ddf8812f86",
+          "doc_count": 86801
+        },
+        {
+          "key": "35830c1e-429e-4006-a153-78984a3e0ee2",
+          "doc_count": 85979
+        },
+        {
+          "key": "ddef79ec-043c-4027-9876-c4a298feff6d",
+          "doc_count": 85750
+        },
+        {
+          "key": "61a1c0ce-8327-4e2a-9766-449751a49b7a",
+          "doc_count": 84356
+        },
+        {
+          "key": "b2b294ed-1742-4479-b0c8-a8891fccd7eb",
+          "doc_count": 84315
+        },
+        {
+          "key": "71b8ffab-444e-43f9-9a9c-5c42b0eaa5eb",
+          "doc_count": 84309
+        },
+        {
+          "key": "eb526a6d-7f7b-49d9-9341-4e20e065059e",
+          "doc_count": 84255
+        },
+        {
+          "key": "e647814d-6975-4b34-b8c4-e79b7ca83085",
+          "doc_count": 83656
+        },
+        {
+          "key": "264c48ec-8636-451f-a7e0-74131bc6f84c",
+          "doc_count": 83411
+        },
+        {
+          "key": "9e66257f-21a9-491a-ac23-06b7b62ceeb7",
+          "doc_count": 82915
+        },
+        {
+          "key": "623a6f8e-794b-44e6-b0f2-1cbf2e58ef5c",
+          "doc_count": 82855
+        },
+        {
+          "key": "e36691ec-c4f8-4bec-b331-b48ffa82ff49",
+          "doc_count": 82638
+        },
+        {
+          "key": "e15b02ba-9593-4771-b584-bcc2b7868ce9",
+          "doc_count": 81889
+        },
+        {
+          "key": "e3063807-1c2e-4eed-b5b9-170e26e8b565",
+          "doc_count": 81745
+        },
+        {
+          "key": "540b0fd9-6b39-4217-9e9a-5f452fb6318d",
+          "doc_count": 81478
+        },
+        {
+          "key": "e7301984-8b46-4932-b670-21c231ae4c01",
+          "doc_count": 81240
+        },
+        {
+          "key": "ba54ba45-caac-4708-a389-ac94642976f8",
+          "doc_count": 81125
+        },
+        {
+          "key": "5e29dbcc-ce45-4f05-9bb0-212baffa8932",
+          "doc_count": 80369
+        },
+        {
+          "key": "a2bc3d61-3c37-4aca-b47d-c3413f7e3b87",
+          "doc_count": 80274
+        },
+        {
+          "key": "ff89320d-e232-4edd-9cdd-4b6acc672ad3",
+          "doc_count": 80086
+        },
+        {
+          "key": "0220907a-0463-4ae0-8a0b-77f5e80fff40",
+          "doc_count": 79688
+        },
+        {
+          "key": "244ee82a-438c-4e77-a2ce-4e2af9ddbe4d",
+          "doc_count": 79635
+        },
+        {
+          "key": "e185415c-15c4-4612-89f3-27cfebbca0d9",
+          "doc_count": 79178
+        },
+        {
+          "key": "3998ec8d-4aae-46db-9370-179c19b69356",
+          "doc_count": 78615
+        },
+        {
+          "key": "14312086-24f8-453a-be6f-d7a0c796a116",
+          "doc_count": 78575
+        },
+        {
+          "key": "6539877e-82dc-485c-ad3d-038f383d5431",
+          "doc_count": 78375
+        },
+        {
+          "key": "5835f642-2560-4e3e-9c25-741a12cc3fe8",
+          "doc_count": 78349
+        },
+        {
+          "key": "844875a9-9927-48a5-90b4-76c5f227f145",
+          "doc_count": 78144
+        },
+        {
+          "key": "b26fa674-6300-4ea0-a8e3-fc0ce32b5226",
+          "doc_count": 77865
+        },
+        {
+          "key": "beecd160-a96c-46fc-bdce-7dcb7024d473",
+          "doc_count": 77464
+        },
+        {
+          "key": "69037495-438d-4dba-bf0f-4878073766f1",
+          "doc_count": 77067
+        },
+        {
+          "key": "c3f05887-ffa9-44c4-b1af-e38fea5557bf",
+          "doc_count": 76987
+        },
+        {
+          "key": "f1a78c0f-449c-45fa-9472-0b92cc2a58da",
+          "doc_count": 76497
+        },
+        {
+          "key": "605bb19b-7564-4e6d-a5df-8ec841d68ba0",
+          "doc_count": 76380
+        },
+        {
+          "key": "f145327c-e4aa-4a00-9b2f-8cec8416e605",
+          "doc_count": 76325
+        },
+        {
+          "key": "5f105976-5a5f-4a72-850d-2059a80f7c10",
+          "doc_count": 75870
+        },
+        {
+          "key": "04d9b721-259c-4d6b-b48f-2e23edf66c9f",
+          "doc_count": 75731
+        },
+        {
+          "key": "df22987f-d20d-41db-b8eb-8b5f5fca6df0",
+          "doc_count": 75686
+        },
+        {
+          "key": "8ec76c75-a673-4682-bfde-00a18bc12794",
+          "doc_count": 75080
+        },
+        {
+          "key": "dd232f5c-7f53-48ec-9bb7-7205702c3dc8",
+          "doc_count": 74946
+        },
+        {
+          "key": "e5f57bb0-07ec-4405-90b6-dc89647a1cb5",
+          "doc_count": 74419
+        },
+        {
+          "key": "02266d50-00a1-4933-bfa3-97abbdb4870a",
+          "doc_count": 74118
+        },
+        {
+          "key": "652ea450-af13-4334-96ff-3136d0188778",
+          "doc_count": 74109
+        },
+        {
+          "key": "ee9d38ef-c1db-44de-b8f2-62acb7049370",
+          "doc_count": 73748
+        },
+        {
+          "key": "0e162e0a-bf3e-4710-9357-44258ca12abb",
+          "doc_count": 73624
+        },
+        {
+          "key": "41b119de-f745-482d-be42-a0155bc76e5d",
+          "doc_count": 72416
+        },
+        {
+          "key": "cab6d230-499b-4a21-9cc2-2750e14e92f8",
+          "doc_count": 71715
+        },
+        {
+          "key": "5ee6f92f-c65c-4888-98e3-f152b3ceb184",
+          "doc_count": 71336
+        },
+        {
+          "key": "5a660a44-afdd-45ac-8c48-1a6c570ce0b5",
+          "doc_count": 71068
+        },
+        {
+          "key": "84c24d87-e4ad-4165-8e86-5ae1a249c196",
+          "doc_count": 70447
+        },
+        {
+          "key": "d9dac6f3-c7bc-48fc-a917-4fc9e4d6da32",
+          "doc_count": 70229
+        },
+        {
+          "key": "95773ebb-2f5f-43f0-a652-bfd8d5f4707a",
+          "doc_count": 69846
+        },
+        {
+          "key": "17fc477d-727e-4dde-99d6-ac440e937d14",
+          "doc_count": 69438
+        },
+        {
+          "key": "ba4b4a05-f01f-4b16-b36a-83bf997a8722",
+          "doc_count": 69004
+        },
+        {
+          "key": "76fd34da-4892-4821-858d-98fe9e28ba8b",
+          "doc_count": 68983
+        },
+        {
+          "key": "e38af226-7109-4f99-a6f1-9fd3bec5638d",
+          "doc_count": 68393
+        },
+        {
+          "key": "35879d2c-063f-4046-9ac6-eda6410e21a9",
+          "doc_count": 68260
+        },
+        {
+          "key": "d0d1c390-e662-4980-97e3-ae0039a06de8",
+          "doc_count": 67885
+        },
+        {
+          "key": "05c029de-734c-450a-a41a-56061b7ebb18",
+          "doc_count": 67668
+        },
+        {
+          "key": "9354db6c-4019-4351-a822-cb87b1b73a44",
+          "doc_count": 67502
+        },
+        {
+          "key": "0a0f5c81-bf4d-492b-b459-08bd987a0c9a",
+          "doc_count": 66530
+        },
+        {
+          "key": "91c5eec8-0cdc-4be2-9a99-a15ae5ec3edc",
+          "doc_count": 66480
+        },
+        {
+          "key": "4ed5b2e2-8b45-4b5a-a38f-df7c6e51030e",
+          "doc_count": 66116
+        },
+        {
+          "key": "a8413649-05d9-46da-b137-1317a709453f",
+          "doc_count": 65917
+        },
+        {
+          "key": "9ea3f46b-f7b9-4b2e-8d4e-a052fbe69de9",
+          "doc_count": 65706
+        },
+        {
+          "key": "28a8561d-4699-4c90-823b-686d6207d675",
+          "doc_count": 65586
+        },
+        {
+          "key": "05498053-5a06-45d5-bf6c-dbea1c42cb2b",
+          "doc_count": 64876
+        },
+        {
+          "key": "1ae056ac-8834-43a8-ad44-d1148b6e075f",
+          "doc_count": 64870
+        },
+        {
+          "key": "ef77ec72-6537-41ab-a418-17f9a58e6e73",
+          "doc_count": 64731
+        },
+        {
+          "key": "5f513dff-ccd8-4578-ad0b-5e6cf035e4d1",
+          "doc_count": 64431
+        },
+        {
+          "key": "b88033dd-5dbb-4377-b374-2210f32ece16",
+          "doc_count": 64371
+        },
+        {
+          "key": "7809d96b-7edf-4ef7-9f12-59967e9a01a6",
+          "doc_count": 63725
+        },
+        {
+          "key": "e6d3c1da-a02f-43a2-a5ef-6a035298b933",
+          "doc_count": 63426
+        },
+        {
+          "key": "6aa085c5-7abf-4995-a3fc-91c49ad65b79",
+          "doc_count": 63415
+        },
+        {
+          "key": "c2e06358-1f9f-463c-843f-446c0a37fbd0",
+          "doc_count": 63027
+        },
+        {
+          "key": "9eccfde2-7da0-444c-999c-aa0d28043a56",
+          "doc_count": 62813
+        },
+        {
+          "key": "4d9103e7-fe58-4dc5-9fa8-e739949fd3f3",
+          "doc_count": 62403
+        },
+        {
+          "key": "e33a1faa-5175-45bc-89b8-3ec9cdd63cfb",
+          "doc_count": 62177
+        },
+        {
+          "key": "63dee426-7b24-4217-a5fc-76428f3aa74f",
+          "doc_count": 62125
+        },
+        {
+          "key": "cf60ed8a-2c79-4b85-a259-15a8e216dae4",
+          "doc_count": 61540
+        },
+        {
+          "key": "d1f70494-b5d9-4c84-973d-e34445b7552b",
+          "doc_count": 61485
+        },
+        {
+          "key": "697ed841-1462-46ed-9679-c0c35779e255",
+          "doc_count": 61258
+        },
+        {
+          "key": "cf641fbf-fa31-481a-993b-9204f2ee1884",
+          "doc_count": 61215
+        },
+        {
+          "key": "373cd7de-bc99-4e1e-b7e3-b2cf4fed73d3",
+          "doc_count": 61113
+        },
+        {
+          "key": "cb33cf97-2a7b-4b45-9b73-5aca568332a6",
+          "doc_count": 60952
+        },
+        {
+          "key": "2cf2843f-567c-45c1-a328-cc210af76fc1",
+          "doc_count": 60856
+        },
+        {
+          "key": "471835cc-feb6-4d05-a8d1-62ce71399326",
+          "doc_count": 60840
+        },
+        {
+          "key": "9ef17d55-0498-44cf-9da4-dde3e3acb570",
+          "doc_count": 60813
+        },
+        {
+          "key": "0377a9ab-eea0-4580-8c6a-a33c88647122",
+          "doc_count": 60333
+        },
+        {
+          "key": "c481fbc6-4bd7-4c50-8537-ba1993d4eb88",
+          "doc_count": 60042
+        },
+        {
+          "key": "6b6c13d9-7789-4da0-99d7-6786322e2612",
+          "doc_count": 59978
+        },
+        {
+          "key": "5f6fcfc2-598c-42e8-abb3-50ca9c2446e2",
+          "doc_count": 59816
+        },
+        {
+          "key": "a4c4e0ee-38dd-47fd-9b06-ce4cc011e111",
+          "doc_count": 59669
+        },
+        {
+          "key": "7fcdca8e-7469-480c-8516-cce4e24c37c9",
+          "doc_count": 59236
+        },
+        {
+          "key": "ab56632e-dbf5-493f-bcb1-0b77bcdfebfd",
+          "doc_count": 58475
+        },
+        {
+          "key": "ec4acc26-ff1b-4131-a1df-a950fe31bb0e",
+          "doc_count": 58455
+        },
+        {
+          "key": "09a3fcf2-55a1-488f-aa42-f103bdce0536",
+          "doc_count": 58214
+        },
+        {
+          "key": "e9633eea-971a-48c6-b6f9-a98c5c12ec10",
+          "doc_count": 58112
+        },
+        {
+          "key": "e6eba8cd-fa2c-4ba2-bec0-6841e7633695",
+          "doc_count": 57981
+        },
+        {
+          "key": "ca4e7ee9-06f5-4f93-830c-507a6598ec25",
+          "doc_count": 57775
+        },
+        {
+          "key": "637d0f2f-a0b4-4f33-a1ad-bd0ab18b620d",
+          "doc_count": 57669
+        },
+        {
+          "key": "21ea1ef6-4a2a-4ff2-a18b-5c0f297fc1cf",
+          "doc_count": 57526
+        },
+        {
+          "key": "78ee1a12-9e8a-4d9c-84de-e2dfce4e1447",
+          "doc_count": 57286
+        },
+        {
+          "key": "bcbae485-1286-4452-bbc9-bcb38c6c3573",
+          "doc_count": 57127
+        },
+        {
+          "key": "e506c5e0-99b6-4e97-b7b4-4536cb80209b",
+          "doc_count": 56800
+        },
+        {
+          "key": "41b166d5-ce08-4efe-99fc-6df77d8fe29e",
+          "doc_count": 56727
+        },
+        {
+          "key": "b5b79eb9-c270-4427-9cd6-43bd6c4b73ab",
+          "doc_count": 56535
+        },
+        {
+          "key": "d3dbe69e-8e8a-4849-9fb1-1bf5c3786f70",
+          "doc_count": 56490
+        },
+        {
+          "key": "e5b0c46a-5eb6-4b94-9d4c-fb1000f534b0",
+          "doc_count": 56138
+        },
+        {
+          "key": "667c2736-bcd3-4a6a-abf4-db5d2dc815c4",
+          "doc_count": 56029
+        },
+        {
+          "key": "5e2f4c81-8c8a-45f3-a220-851f85f86b40",
+          "doc_count": 55882
+        },
+        {
+          "key": "8456dc3d-99e2-407c-ab55-4746d382496b",
+          "doc_count": 55821
+        },
+        {
+          "key": "e3f5ac40-ec34-4423-9aa8-d660a65864af",
+          "doc_count": 55816
+        },
+        {
+          "key": "36be338b-cfb2-47e4-a1fc-b3f7a1aaaf22",
+          "doc_count": 55807
+        },
+        {
+          "key": "b985f284-eac5-4efe-8a7c-c726cdf7cf33",
+          "doc_count": 55743
+        },
+        {
+          "key": "9e89b6af-4bb5-45af-93d8-0112bd20a60d",
+          "doc_count": 55277
+        },
+        {
+          "key": "1bb33d2d-0714-4fc9-968e-b66bab1cf3d3",
+          "doc_count": 55200
+        },
+        {
+          "key": "e7ac8c4a-64bd-491b-b764-232de9b4bfe5",
+          "doc_count": 54497
+        },
+        {
+          "key": "021e2617-7532-4cef-806c-690bed32ab84",
+          "doc_count": 54246
+        },
+        {
+          "key": "c57817e7-034c-4796-ac47-2bc2191713b3",
+          "doc_count": 53907
+        },
+        {
+          "key": "82672123-feef-4b1c-9ee3-9a681204ae76",
+          "doc_count": 53732
+        },
+        {
+          "key": "9b725e43-93c9-423b-adf8-a11d08a83d13",
+          "doc_count": 53654
+        },
+        {
+          "key": "9ff03c57-ba5a-4127-9439-4bf3e838c4df",
+          "doc_count": 53637
+        },
+        {
+          "key": "2b76daad-10dc-4235-843e-dffad2424df7",
+          "doc_count": 53583
+        },
+        {
+          "key": "1e798b2d-7f97-49b0-a864-79c968af91d3",
+          "doc_count": 53452
+        },
+        {
+          "key": "3a250778-79ff-4fcd-916f-ddea77e5db77",
+          "doc_count": 53442
+        },
+        {
+          "key": "910eadc8-8131-428c-b28a-91d0e2890f1d",
+          "doc_count": 53300
+        },
+        {
+          "key": "026a4216-957a-4efb-acf1-506499ec474e",
+          "doc_count": 53165
+        },
+        {
+          "key": "8f3b62fb-56ec-49e8-9f8f-bb257348291f",
+          "doc_count": 52783
+        },
+        {
+          "key": "e80fe2bb-547d-4e98-84ce-01176379e3a8",
+          "doc_count": 52710
+        },
+        {
+          "key": "767c78b4-1c16-4cac-ad04-66333ac5a7f2",
+          "doc_count": 52275
+        },
+        {
+          "key": "c5b7dae8-b483-4742-9954-d7f9226daa34",
+          "doc_count": 52065
+        },
+        {
+          "key": "d36887a2-9f9a-44af-887a-5bb95d09a83b",
+          "doc_count": 51637
+        },
+        {
+          "key": "319636db-c2da-493c-beac-1194949e95b4",
+          "doc_count": 51513
+        },
+        {
+          "key": "005ac06a-3d9a-46ad-ac3c-062aaa5b7059",
+          "doc_count": 51496
+        },
+        {
+          "key": "2ec3b31e-c86b-4ce9-b265-77c8c3f9643c",
+          "doc_count": 51496
+        },
+        {
+          "key": "79488fda-8310-42cd-b98e-8c3c2dd7d415",
+          "doc_count": 51130
+        },
+        {
+          "key": "7057e6e2-fe83-472d-9580-6c18118cd71d",
+          "doc_count": 50944
+        },
+        {
+          "key": "5baa1d0c-cfc0-4c89-8e3e-7a49359b0caa",
+          "doc_count": 50877
+        },
+        {
+          "key": "2e03b83d-d2b9-4a8e-90b5-42b5b1301a92",
+          "doc_count": 50872
+        },
+        {
+          "key": "667a12e7-c6d8-4de0-933f-ce2f07cb7a92",
+          "doc_count": 50663
+        },
+        {
+          "key": "62254613-2696-4834-8c58-5c465f70df56",
+          "doc_count": 50654
+        },
+        {
+          "key": "511dfafa-94d1-495d-b869-c6ad91536a52",
+          "doc_count": 50566
+        },
+        {
+          "key": "b279e757-e14a-4e6f-90a6-31647349e22e",
+          "doc_count": 50419
+        },
+        {
+          "key": "311c3a01-c824-4a85-8771-fcc3f353619b",
+          "doc_count": 50407
+        },
+        {
+          "key": "531537fc-6349-4a20-ae42-540d61797086",
+          "doc_count": 50356
+        },
+        {
+          "key": "9dce915b-3de4-4a7d-a68d-e4c4c15809ce",
+          "doc_count": 50317
+        },
+        {
+          "key": "71aa2a5b-b661-450b-b863-e5e0ede82cde",
+          "doc_count": 50301
+        },
+        {
+          "key": "9401f7e8-7d41-4c57-a5da-8839be046935",
+          "doc_count": 50240
+        },
+        {
+          "key": "e73fedf0-90ee-4c6d-88dd-49399878fc54",
+          "doc_count": 49509
+        },
+        {
+          "key": "3420d3d5-f142-4db6-951c-5d37cb72ce53",
+          "doc_count": 49326
+        },
+        {
+          "key": "72b6dbee-bc4d-4e35-a32c-8df0422771fb",
+          "doc_count": 49283
+        },
+        {
+          "key": "e01c69a9-c561-4e3d-8a2e-cfeeb4d9528e",
+          "doc_count": 49262
+        },
+        {
+          "key": "f31a5f98-efd3-476a-9627-de3add582acd",
+          "doc_count": 48901
+        },
+        {
+          "key": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "doc_count": 48892
+        },
+        {
+          "key": "7f497d81-4c7e-4e06-b166-a459968b14e3",
+          "doc_count": 48887
+        },
+        {
+          "key": "be34dbd9-5d54-4837-9f49-ff423eb18e8b",
+          "doc_count": 48493
+        },
+        {
+          "key": "6659b6dd-d487-4b72-b0c8-ae65942a6f15",
+          "doc_count": 48469
+        },
+        {
+          "key": "d100843b-d592-4024-8d15-fb1d8e218acd",
+          "doc_count": 48412
+        },
+        {
+          "key": "f885076c-a7ae-4a7b-9769-3f733c6a9ecf",
+          "doc_count": 48397
+        },
+        {
+          "key": "ffafa16e-c903-4a59-8edf-b368bb6eccb3",
+          "doc_count": 47695
+        },
+        {
+          "key": "10eea9b5-e08f-4c07-adf6-561aea89ae09",
+          "doc_count": 47670
+        },
+        {
+          "key": "1701a75c-5a57-48c3-84c2-234a53f4c3e2",
+          "doc_count": 47399
+        },
+        {
+          "key": "a16dc8d8-ff4a-4d62-a684-2937fb292b8d",
+          "doc_count": 47319
+        },
+        {
+          "key": "30733214-8eb0-4894-b19d-775fe8a617cf",
+          "doc_count": 47005
+        },
+        {
+          "key": "176d536a-2691-47c4-95c1-c0d47d3abd48",
+          "doc_count": 46970
+        },
+        {
+          "key": "e27f0218-47e0-41bc-9086-9d9169096e90",
+          "doc_count": 46945
+        },
+        {
+          "key": "d08e9d4d-b6cf-4155-addb-d635ceaa8964",
+          "doc_count": 46933
+        },
+        {
+          "key": "011880b9-7697-4626-946f-258a68f754cb",
+          "doc_count": 46817
+        },
+        {
+          "key": "90e622c7-f025-4f27-8891-82f0e867155f",
+          "doc_count": 46710
+        },
+        {
+          "key": "e39f6dee-f2cf-4eff-afc9-4600cafe660c",
+          "doc_count": 46580
+        },
+        {
+          "key": "120d557c-c5be-474d-98f0-1ba00ae16b40",
+          "doc_count": 46178
+        },
+        {
+          "key": "02153e3c-902f-4d8d-8c7a-11c38b99ec0c",
+          "doc_count": 46152
+        },
+        {
+          "key": "ea3c3b03-0ed5-42fc-b192-7328459ea04a",
+          "doc_count": 46131
+        },
+        {
+          "key": "0f19f6d6-79a4-434e-ba0b-a4f49f334078",
+          "doc_count": 45876
+        },
+        {
+          "key": "cd5bc13d-ee5c-4b68-a550-37edb3e7899d",
+          "doc_count": 45760
+        },
+        {
+          "key": "8445ab25-ff89-44b0-90f8-bf0790f50afc",
+          "doc_count": 45470
+        },
+        {
+          "key": "1f2b44b8-8556-4d6e-8247-4611689551cf",
+          "doc_count": 45047
+        },
+        {
+          "key": "38c75faa-67df-46ae-bce8-331f46d46140",
+          "doc_count": 44879
+        },
+        {
+          "key": "442246b3-6610-45e6-b2bf-c11ee15917b8",
+          "doc_count": 44619
+        },
+        {
+          "key": "be31dfd1-c721-4697-8ee0-f7043c070810",
+          "doc_count": 43953
+        },
+        {
+          "key": "ae04a8bb-eb28-4671-839b-62dde372353e",
+          "doc_count": 43603
+        },
+        {
+          "key": "4e8502bf-d07a-4603-906a-726fa2240277",
+          "doc_count": 43260
+        },
+        {
+          "key": "664bd710-8791-4dba-a3b6-000a1b140951",
+          "doc_count": 43154
+        },
+        {
+          "key": "e794b292-4a94-471e-ab84-6aaef1fea1b3",
+          "doc_count": 42838
+        },
+        {
+          "key": "598cda6a-75a8-4ba3-b169-3fa4a285ed86",
+          "doc_count": 42751
+        },
+        {
+          "key": "43aa1339-67e4-4298-b7c5-3d0f201266ef",
+          "doc_count": 42498
+        },
+        {
+          "key": "6649f781-fc4a-410f-a366-208e16241942",
+          "doc_count": 42413
+        },
+        {
+          "key": "3872f27e-cf4e-40bd-b91b-ba7b723a86e5",
+          "doc_count": 42242
+        },
+        {
+          "key": "8f689b8b-5b65-4638-9555-f2a5d237a624",
+          "doc_count": 41986
+        },
+        {
+          "key": "6135420b-aac1-476e-bda5-e07ba8458662",
+          "doc_count": 41984
+        },
+        {
+          "key": "5aac25d2-bcfb-4084-a700-584311ea539d",
+          "doc_count": 41963
+        },
+        {
+          "key": "8b7ece52-d8b3-4999-978c-c18cb12065d3",
+          "doc_count": 41575
+        },
+        {
+          "key": "750a80fe-60b9-423b-aca1-dcc7937d2c84",
+          "doc_count": 41028
+        },
+        {
+          "key": "d2c71720-e156-4943-8182-0a7bbe477a37",
+          "doc_count": 40990
+        },
+        {
+          "key": "a69decc7-76ba-496a-a66e-f91049c02cf0",
+          "doc_count": 40941
+        },
+        {
+          "key": "98ece30d-bf85-4122-b872-7786031b457f",
+          "doc_count": 40772
+        },
+        {
+          "key": "46374ee7-7c70-48d8-bf16-2e6c1626565e",
+          "doc_count": 40701
+        },
+        {
+          "key": "40987883-03cf-494a-a5cf-7c77c7aadb79",
+          "doc_count": 40643
+        },
+        {
+          "key": "d3920b32-8de2-4c92-a787-71497171595d",
+          "doc_count": 40134
+        },
+        {
+          "key": "a5fe6f13-2121-41dd-a036-dae15546ad91",
+          "doc_count": 40102
+        },
+        {
+          "key": "d0105f1d-a9a0-4cd4-817d-aebfb5512923",
+          "doc_count": 39529
+        },
+        {
+          "key": "de5203b1-5a44-4010-948c-b7d33f46397a",
+          "doc_count": 39377
+        },
+        {
+          "key": "27b2b46f-4cae-4ffa-870d-b17e51d627f2",
+          "doc_count": 39326
+        },
+        {
+          "key": "81d00e23-92aa-45d7-b289-5cf045ddfbf4",
+          "doc_count": 39263
+        },
+        {
+          "key": "c6969e30-ca21-4576-954d-9c0e052bdde9",
+          "doc_count": 39183
+        },
+        {
+          "key": "9d8ced48-62c5-4ce0-99e7-a03550c674c0",
+          "doc_count": 39033
+        },
+        {
+          "key": "b1beb057-bc34-49a9-b784-2a50af226712",
+          "doc_count": 39002
+        },
+        {
+          "key": "75e3aff5-b3d0-45c3-835c-5ffde192c63f",
+          "doc_count": 38590
+        },
+        {
+          "key": "b000920c-6f7d-49d3-9d0f-2bb630d2e01a",
+          "doc_count": 38162
+        },
+        {
+          "key": "826420a8-3d4a-4cee-901c-f0f2ee9e00b4",
+          "doc_count": 38088
+        },
+        {
+          "key": "cf93f9ef-b45e-474c-9ca9-3edc4ad11a4d",
+          "doc_count": 37868
+        },
+        {
+          "key": "5caa5b0d-24b7-4c69-9c7b-089f343b7efc",
+          "doc_count": 37824
+        },
+        {
+          "key": "07389fe4-c6dc-4e6c-87d2-345e2d183050",
+          "doc_count": 37667
+        },
+        {
+          "key": "8dc14464-57b3-423e-8cb0-950ab8f36b6f",
+          "doc_count": 37465
+        },
+        {
+          "key": "fe52a17a-a7aa-4f95-a3ea-26fe640170fe",
+          "doc_count": 37446
+        },
+        {
+          "key": "3056112e-97c6-4d0d-b6c2-3c0a9adaca24",
+          "doc_count": 37342
+        },
+        {
+          "key": "9a06cc34-be24-4ebf-b599-cbb1d4b8ac7b",
+          "doc_count": 37245
+        },
+        {
+          "key": "17cea35c-721f-4d9b-b67f-d29250064d25",
+          "doc_count": 37218
+        },
+        {
+          "key": "23a47a5f-2ac1-4f81-acd3-21d5b82ed22a",
+          "doc_count": 37090
+        },
+        {
+          "key": "ce8d00be-3dcd-4d7e-9d03-f2915369dc16",
+          "doc_count": 37088
+        },
+        {
+          "key": "e1b03497-7632-4ba4-a9e0-dd230d06638c",
+          "doc_count": 37054
+        },
+        {
+          "key": "361efdf7-9845-411c-90bd-e51ec7991e87",
+          "doc_count": 36529
+        },
+        {
+          "key": "37d4d085-d8be-4826-9bc4-c6a36557fa70",
+          "doc_count": 36465
+        },
+        {
+          "key": "7a31ab80-1cc0-4456-9dea-61c2e9031a6f",
+          "doc_count": 36374
+        },
+        {
+          "key": "7cb4bbe6-d9b7-4cdb-b3bf-97a971487f75",
+          "doc_count": 36164
+        },
+        {
+          "key": "fd66cee6-5310-4201-9949-0ea04a05b72b",
+          "doc_count": 36029
+        },
+        {
+          "key": "7820adf7-b24b-4a25-83b2-f73d897d9050",
+          "doc_count": 36014
+        },
+        {
+          "key": "30ab9c2a-0b54-4c04-84ca-bc7abdd90b52",
+          "doc_count": 35981
+        },
+        {
+          "key": "fd09683f-efe8-446c-9e43-7d11f62e597c",
+          "doc_count": 35942
+        },
+        {
+          "key": "38db50bb-72f3-4416-aeb9-61457e655a6d",
+          "doc_count": 35833
+        },
+        {
+          "key": "41e1a09b-bd55-4d20-a480-5d8187f7afca",
+          "doc_count": 35783
+        },
+        {
+          "key": "687efa84-c549-4743-a193-72d198d8e19c",
+          "doc_count": 35692
+        },
+        {
+          "key": "db3181c9-48dd-489f-96ab-a5888f5a938c",
+          "doc_count": 35311
+        },
+        {
+          "key": "48e1b8c1-91aa-4b87-8ca0-de1f81232eaf",
+          "doc_count": 35244
+        },
+        {
+          "key": "5bd3bf29-b78d-4bf3-bbd7-bbfb4eaf36a1",
+          "doc_count": 35168
+        },
+        {
+          "key": "14a8f79f-eab7-48da-ad50-bda142703820",
+          "doc_count": 35010
+        },
+        {
+          "key": "2d2f8a69-b58f-4320-9cdf-8a7b87219fa4",
+          "doc_count": 34940
+        },
+        {
+          "key": "75c7a013-8dab-4f9c-ae6d-3a7cc24b67ce",
+          "doc_count": 34834
+        },
+        {
+          "key": "9e103d5f-fc45-4375-b416-802659e6dc1b",
+          "doc_count": 34829
+        },
+        {
+          "key": "656d1c9a-cbb7-4dde-ac24-62323af5b831",
+          "doc_count": 34520
+        },
+        {
+          "key": "65007e62-740c-4302-ba20-260fe68da291",
+          "doc_count": 34441
+        },
+        {
+          "key": "d601bd5e-4f4c-4637-9196-4bd821dbd2e2",
+          "doc_count": 34403
+        },
+        {
+          "key": "db4bb0df-8539-4617-ab5f-eb118aa3126b",
+          "doc_count": 34344
+        },
+        {
+          "key": "15aa4812-aad2-4b26-a1d8-d4f8d79e6163",
+          "doc_count": 34108
+        },
+        {
+          "key": "d8f04cbf-f08f-4ec4-a6ae-3d473244fb16",
+          "doc_count": 34017
+        },
+        {
+          "key": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "doc_count": 33988
+        },
+        {
+          "key": "81316846-80cb-4913-8941-b31537761eb0",
+          "doc_count": 33693
+        },
+        {
+          "key": "c7821624-d246-43b8-9dfd-de470f9dc294",
+          "doc_count": 33207
+        },
+        {
+          "key": "28f7935c-535c-4ca8-ac75-13056d0fe852",
+          "doc_count": 33144
+        },
+        {
+          "key": "570dcca6-a84f-43aa-8053-1a2ac60d9ead",
+          "doc_count": 32831
+        },
+        {
+          "key": "3451a762-d117-430e-968c-dd747ed53887",
+          "doc_count": 32717
+        },
+        {
+          "key": "82bcf2f2-b2d6-45a5-b0ca-d70d8ab4ebf8",
+          "doc_count": 32452
+        },
+        {
+          "key": "9368e302-f8e7-4714-aed4-db2faa861e5c",
+          "doc_count": 32442
+        },
+        {
+          "key": "678dc436-3370-4992-a361-761dab8c3fda",
+          "doc_count": 32198
+        },
+        {
+          "key": "b4cce5b5-6450-443c-8988-a279b9cefaab",
+          "doc_count": 32112
+        },
+        {
+          "key": "1e86442f-35a5-4e7b-9a38-4599e4d3b510",
+          "doc_count": 32082
+        },
+        {
+          "key": "00038086-3303-4b89-b2d6-1b84e7598f0e",
+          "doc_count": 31957
+        },
+        {
+          "key": "1549b662-ec36-436a-8593-76f7642ec9e4",
+          "doc_count": 31850
+        },
+        {
+          "key": "aced32f9-e511-48c7-8e9e-b625777bdf7f",
+          "doc_count": 31846
+        },
+        {
+          "key": "21b563bc-70c2-46d5-bce8-2489db2db3d8",
+          "doc_count": 31785
+        },
+        {
+          "key": "645bcd10-a74f-4207-a375-0254b954b7ad",
+          "doc_count": 31529
+        },
+        {
+          "key": "edbd0bc4-c292-426b-9a6c-44bbccab2d11",
+          "doc_count": 31349
+        },
+        {
+          "key": "ad3198a5-3e39-4dd9-9d87-755a11b8e8fa",
+          "doc_count": 31151
+        },
+        {
+          "key": "6f82f182-39b4-4b3f-9087-91f6afafc04e",
+          "doc_count": 31102
+        },
+        {
+          "key": "4cd8e87c-93b6-41cc-9189-50585cdb0518",
+          "doc_count": 31096
+        },
+        {
+          "key": "57a6bf5f-cda1-41fd-8c12-804c95f74841",
+          "doc_count": 30866
+        },
+        {
+          "key": "0266a3f4-872b-4d21-a6b4-5c9818d8742b",
+          "doc_count": 30348
+        },
+        {
+          "key": "0b263d0e-6571-4883-946e-78baf248eb63",
+          "doc_count": 30071
+        },
+        {
+          "key": "c282d7ee-b624-42a2-ace1-aff9bfff5e7c",
+          "doc_count": 29961
+        },
+        {
+          "key": "10290664-644c-47d2-bf5a-49be94566fdf",
+          "doc_count": 29852
+        },
+        {
+          "key": "33b5b5e7-f4e6-435c-9e0f-bb264d58581b",
+          "doc_count": 29802
+        },
+        {
+          "key": "821c1855-6817-40ee-8732-7f472d238513",
+          "doc_count": 29514
+        },
+        {
+          "key": "e53e1268-8af3-4221-9f7e-41199858bf18",
+          "doc_count": 29513
+        },
+        {
+          "key": "4f5fc75f-f983-4ef8-9723-ba375615d926",
+          "doc_count": 29215
+        },
+        {
+          "key": "974f7564-a7fb-409a-bb67-35b7cafec327",
+          "doc_count": 29171
+        },
+        {
+          "key": "7beb32ba-1af4-42c0-a76e-9cbf1bb3b124",
+          "doc_count": 29128
+        },
+        {
+          "key": "b1549ab7-5fc7-4966-a210-0846484fb171",
+          "doc_count": 29017
+        },
+        {
+          "key": "5f2b5c3a-1b93-4db4-b6b4-7468f03abee1",
+          "doc_count": 28936
+        },
+        {
+          "key": "879d475f-4b76-4d18-8cf6-a7e5a6d44926",
+          "doc_count": 28779
+        },
+        {
+          "key": "e1e8586c-bdd4-47d1-bc06-0ef384ed409b",
+          "doc_count": 28461
+        },
+        {
+          "key": "552ce2e5-b627-4d6d-b914-6b495d0a79e6",
+          "doc_count": 28295
+        },
+        {
+          "key": "4db72a36-c08b-4a6b-8c68-ab45ebb0efce",
+          "doc_count": 27914
+        },
+        {
+          "key": "37213da3-a1c7-4644-917e-8f8440e1c4d4",
+          "doc_count": 27605
+        },
+        {
+          "key": "b17204ee-8a17-4ba1-9e74-bfadca6dce08",
+          "doc_count": 27584
+        },
+        {
+          "key": "b764863c-de93-4d7c-b0cf-1bb57166141d",
+          "doc_count": 27451
+        },
+        {
+          "key": "ef59f7cc-ed42-45fc-9abc-5edfb2c8caec",
+          "doc_count": 27398
+        },
+        {
+          "key": "181352ea-3598-4f32-b919-c8f6097f4c65",
+          "doc_count": 27243
+        },
+        {
+          "key": "2b946e47-7b37-48dd-83bb-fd892c026f9f",
+          "doc_count": 26841
+        },
+        {
+          "key": "22436fe4-5049-4266-9849-335dd3f161aa",
+          "doc_count": 26808
+        },
+        {
+          "key": "80daac2f-e496-4c65-b196-6be7a9c4c98e",
+          "doc_count": 26789
+        },
+        {
+          "key": "7fbf76b1-6bd6-4217-a5bc-1d89e45f6a68",
+          "doc_count": 26590
+        },
+        {
+          "key": "63ce9d6b-ec89-4e17-880d-c0a31acb4a6d",
+          "doc_count": 26546
+        },
+        {
+          "key": "77e77e52-6927-46bc-b3e8-b1b043f2f3c7",
+          "doc_count": 26433
+        },
+        {
+          "key": "3b9ecf1e-3c04-4d8b-84cd-9ae48e70e13a",
+          "doc_count": 26285
+        },
+        {
+          "key": "f93c403b-d0f0-4be1-8a4b-ed9aa3b513e3",
+          "doc_count": 26198
+        },
+        {
+          "key": "7e4aacd3-0a24-49ab-b019-518b7069b682",
+          "doc_count": 26107
+        },
+        {
+          "key": "dfd53a42-8f63-4040-93a5-3f1347ce7686",
+          "doc_count": 26072
+        },
+        {
+          "key": "b8508402-51fe-42a9-90ea-8ff9eff7eed2",
+          "doc_count": 25934
+        },
+        {
+          "key": "cd7b335e-6f5c-4259-ba45-5e334a719464",
+          "doc_count": 25890
+        },
+        {
+          "key": "1bfc0147-2df1-4488-bcf7-d140e24dda51",
+          "doc_count": 25756
+        },
+        {
+          "key": "ba1c8acd-1c39-4544-996d-41c1a0cbad45",
+          "doc_count": 25754
+        },
+        {
+          "key": "48b4b812-c52e-4f47-9327-e761f6fc2e28",
+          "doc_count": 25620
+        },
+        {
+          "key": "8960fcec-05c0-43c5-a83e-87ace7d3091d",
+          "doc_count": 25535
+        },
+        {
+          "key": "78d74353-0ead-4d58-904e-85709609823e",
+          "doc_count": 25500
+        },
+        {
+          "key": "6b2c3ca9-69ad-4316-a2d1-33399e9f547e",
+          "doc_count": 25308
+        },
+        {
+          "key": "e0e37702-32af-405b-b652-ee54b5bb94e2",
+          "doc_count": 25273
+        },
+        {
+          "key": "518518b7-9e85-42ea-b419-2d23a3ef546a",
+          "doc_count": 25175
+        },
+        {
+          "key": "8dd13cdf-1425-497d-a4ff-bb5dadfe21a8",
+          "doc_count": 25098
+        },
+        {
+          "key": "8b196eb7-1fbf-4eac-9f58-1fccae076f7f",
+          "doc_count": 25017
+        },
+        {
+          "key": "1c729855-f3dd-439d-b326-54d62f57b0fd",
+          "doc_count": 24988
+        },
+        {
+          "key": "b3d3a357-9fa6-453c-9f02-d86a1bbc762a",
+          "doc_count": 24869
+        },
+        {
+          "key": "f39780bd-7108-4685-8e6a-b340ff5a5965",
+          "doc_count": 24588
+        },
+        {
+          "key": "364a24d9-d4a8-4e0b-8e50-07b90f844548",
+          "doc_count": 24529
+        },
+        {
+          "key": "c2ac3134-b825-4cc1-85f5-8a0f44764ba2",
+          "doc_count": 24119
+        },
+        {
+          "key": "68f09e0c-85a4-4b68-9692-ba1061217f4c",
+          "doc_count": 24034
+        },
+        {
+          "key": "0191c073-6b37-4d9f-b610-92301f34d9ce",
+          "doc_count": 24016
+        },
+        {
+          "key": "48f5d475-7381-4d06-88eb-119796b9d189",
+          "doc_count": 23803
+        },
+        {
+          "key": "ceba331e-9da3-44ee-8970-f1eb8d1a68d6",
+          "doc_count": 23607
+        },
+        {
+          "key": "011a5f7c-663d-4fed-b11e-58b3b6610005",
+          "doc_count": 23579
+        },
+        {
+          "key": "d3017649-e4bf-4991-a62d-6c7abc013465",
+          "doc_count": 23515
+        },
+        {
+          "key": "2941b767-e90b-41b9-9627-6e589e0c0c85",
+          "doc_count": 23492
+        },
+        {
+          "key": "b7a79601-c07b-46d5-bd09-d4472b0d9431",
+          "doc_count": 23356
+        },
+        {
+          "key": "651aaf03-f83a-458a-a69d-eb0f6a3e588e",
+          "doc_count": 23315
+        },
+        {
+          "key": "dd783e7e-36d8-4fcd-b7fe-9a481d785560",
+          "doc_count": 23284
+        },
+        {
+          "key": "ba77d411-4179-4dbd-b6c1-39b8a71ae795",
+          "doc_count": 23281
+        },
+        {
+          "key": "899855ee-4fd9-4e85-9033-880058303b5c",
+          "doc_count": 23260
+        },
+        {
+          "key": "fccc3c1d-d9df-4ffd-b7e1-1b9eb11f95b1",
+          "doc_count": 23159
+        },
+        {
+          "key": "063825dc-b8c3-4962-aea4-9994bcc09bc8",
+          "doc_count": 23109
+        },
+        {
+          "key": "c94a06a5-df24-4546-adba-4f7940661826",
+          "doc_count": 23034
+        },
+        {
+          "key": "53af19e1-9cb3-4834-8974-62adc640491c",
+          "doc_count": 22994
+        },
+        {
+          "key": "d3579463-3a9b-4016-bc10-53b966ffb521",
+          "doc_count": 22804
+        },
+        {
+          "key": "91f4f1c9-37e3-430b-8020-f8d65af8e422",
+          "doc_count": 22773
+        },
+        {
+          "key": "fdf7bb59-aad2-4f10-879f-6c0e7d3baa64",
+          "doc_count": 22756
+        },
+        {
+          "key": "1e054b9b-0193-4ff3-b623-9264cf982d4d",
+          "doc_count": 22595
+        },
+        {
+          "key": "0e5201c0-bad2-4e28-9322-5c5dca8862c8",
+          "doc_count": 22564
+        },
+        {
+          "key": "93341fe7-38f8-4ef2-8dfc-ae550aa522dc",
+          "doc_count": 22551
+        },
+        {
+          "key": "8a9e3b42-e6e8-4485-b304-3cbf6d709a6c",
+          "doc_count": 22442
+        },
+        {
+          "key": "2df867b1-89de-4539-8414-67c47a88f0c8",
+          "doc_count": 21982
+        },
+        {
+          "key": "042dbdba-a449-4291-8777-577a5a4045de",
+          "doc_count": 21964
+        },
+        {
+          "key": "3fedbb40-3988-4665-bf86-6b1c89c57215",
+          "doc_count": 21884
+        },
+        {
+          "key": "24ff1625-184b-45dc-99b5-98c56d3dd3c3",
+          "doc_count": 21795
+        },
+        {
+          "key": "d5b9fb39-d233-4cd0-8682-c4deff1e337b",
+          "doc_count": 21619
+        },
+        {
+          "key": "65271c56-1b6c-4ee9-b8df-b4e92031f794",
+          "doc_count": 21440
+        },
+        {
+          "key": "0e2f3962-e905-48f2-a1c6-19d16e2bd5ba",
+          "doc_count": 21321
+        },
+        {
+          "key": "d5b27393-7d3f-4b91-aebe-9066f9b1562d",
+          "doc_count": 21314
+        },
+        {
+          "key": "e7016bd5-cb10-45b9-8959-0f5750f7a5db",
+          "doc_count": 21216
+        },
+        {
+          "key": "6e6e2b47-fa3e-4bd9-8f1c-105b741d31df",
+          "doc_count": 21209
+        },
+        {
+          "key": "33fd0737-6207-42cc-bc64-cc637266b476",
+          "doc_count": 21110
+        },
+        {
+          "key": "3ff3bf5c-7aba-40c3-80b2-1b00ea1abdd5",
+          "doc_count": 21086
+        },
+        {
+          "key": "b6d6cab1-f73d-4e26-86a5-e38cbe218f59",
+          "doc_count": 21076
+        },
+        {
+          "key": "c49bc91d-0a50-497b-8b17-d77808745cf9",
+          "doc_count": 21034
+        },
+        {
+          "key": "7be20c8d-a23f-406e-8f03-aa9dfb4b30b1",
+          "doc_count": 20957
+        },
+        {
+          "key": "4438ad00-6ba8-4900-8793-3b5c182150b4",
+          "doc_count": 20921
+        },
+        {
+          "key": "b58043bc-9e47-4a8f-9e4b-5d4c510ea0e1",
+          "doc_count": 20906
+        },
+        {
+          "key": "c2dcb184-6c90-4aa3-9ebb-33b2d53837b9",
+          "doc_count": 20888
+        },
+        {
+          "key": "da4681c3-64ba-4c99-8575-6cf0b2e55468",
+          "doc_count": 20881
+        },
+        {
+          "key": "372d25cd-e4c6-4c58-8d3f-abe16887c805",
+          "doc_count": 20844
+        },
+        {
+          "key": "d11f19ae-e946-4a0e-83e5-2052ae8cca62",
+          "doc_count": 20585
+        },
+        {
+          "key": "d1c20e8e-d875-473b-bfbf-fecf35ed00d0",
+          "doc_count": 20518
+        },
+        {
+          "key": "fa1518c7-2cb3-49a3-98a6-67e0581b7669",
+          "doc_count": 20457
+        },
+        {
+          "key": "3617a6a3-d384-48de-948d-2d1e1c54e090",
+          "doc_count": 20297
+        },
+        {
+          "key": "70f5686f-c1ef-4b9a-a7ae-2536bc7a7766",
+          "doc_count": 20099
+        },
+        {
+          "key": "1aa66130-6668-4c4b-8383-a51b8e8389ec",
+          "doc_count": 20025
+        },
+        {
+          "key": "931b72d6-1704-4bb9-9323-c4ac8207f3db",
+          "doc_count": 19897
+        },
+        {
+          "key": "bf9066a2-2c5f-4cf2-821a-1a68b4df5b1b",
+          "doc_count": 19875
+        },
+        {
+          "key": "9cecfba6-6501-401c-9043-e95ba70164f3",
+          "doc_count": 19865
+        },
+        {
+          "key": "0582c7d8-f9f8-4f1b-acab-9bb5598c10c4",
+          "doc_count": 19814
+        },
+        {
+          "key": "77b762ba-7cda-4617-97d7-e78df7f6dfab",
+          "doc_count": 19805
+        },
+        {
+          "key": "6b565194-9707-42da-8052-9f9cf5f9aa60",
+          "doc_count": 19753
+        },
+        {
+          "key": "025a810b-28f6-427d-b342-16fdf5f74f4b",
+          "doc_count": 19747
+        },
+        {
+          "key": "156e4092-a68c-4b6d-a3a8-a36edcd74867",
+          "doc_count": 19733
+        },
+        {
+          "key": "7ffc9cc5-83d4-42b8-a924-527320fd1d4e",
+          "doc_count": 19720
+        },
+        {
+          "key": "a8f0fbaf-68b3-4e73-83d7-24d238ac966d",
+          "doc_count": 19683
+        },
+        {
+          "key": "72059315-e131-42ba-b7c6-489415e297b9",
+          "doc_count": 19660
+        },
+        {
+          "key": "9b27c2f1-8b0a-4482-8424-8a9bb3bf0cf9",
+          "doc_count": 19593
+        },
+        {
+          "key": "f33e9494-7b3c-4ac6-a735-59693b5a9638",
+          "doc_count": 19519
+        },
+        {
+          "key": "0ed6268e-7449-414c-a93c-57ea68f8ab3e",
+          "doc_count": 19513
+        },
+        {
+          "key": "96c3abce-e58b-4f4a-9d65-615e760da213",
+          "doc_count": 19493
+        },
+        {
+          "key": "4a1f1862-cb5f-42c5-b3c8-bfc51b1fd140",
+          "doc_count": 19425
+        },
+        {
+          "key": "9e1958fb-1dc4-4375-ae35-67ba7f9c7afe",
+          "doc_count": 19386
+        },
+        {
+          "key": "adae5c6c-72f3-4cd8-a00b-3ea71d516abc",
+          "doc_count": 19171
+        },
+        {
+          "key": "f630e3ea-697f-404a-8683-b86712c26c43",
+          "doc_count": 19105
+        },
+        {
+          "key": "0e0d4dba-9c5d-4dbf-9ac8-09114c56ec03",
+          "doc_count": 19061
+        },
+        {
+          "key": "50ee2f53-7f79-4808-bceb-3e660fd1e666",
+          "doc_count": 19040
+        },
+        {
+          "key": "a6743a43-b86a-4265-9521-fad3a24461a6",
+          "doc_count": 19034
+        },
+        {
+          "key": "7c1ff9a0-1532-485d-96c8-57076e2713ce",
+          "doc_count": 19011
+        },
+        {
+          "key": "a8ae97e3-ece0-4c43-b193-bdd61d724e2d",
+          "doc_count": 18970
+        },
+        {
+          "key": "666bc60d-a7b9-4e37-9af8-85d9cf7078f8",
+          "doc_count": 18943
+        },
+        {
+          "key": "0f3f26e2-cc13-47a3-a268-4c321b621586",
+          "doc_count": 18940
+        },
+        {
+          "key": "bf5b0620-1ff0-45af-a2eb-96f3c739edf2",
+          "doc_count": 18886
+        },
+        {
+          "key": "1f5a1b81-e361-4d65-ab1c-6fb7e30c9910",
+          "doc_count": 18866
+        },
+        {
+          "key": "ce98b978-4542-45c6-aecf-79cf3f6979ed",
+          "doc_count": 18842
+        },
+        {
+          "key": "a2a17035-1e6c-46df-9178-a610df825336",
+          "doc_count": 18806
+        },
+        {
+          "key": "c1e2b821-96a2-422f-a1fe-7a53aaa2e9bf",
+          "doc_count": 18758
+        },
+        {
+          "key": "6d9d4f55-4cb4-4c8f-acc7-b465eb5f703c",
+          "doc_count": 18699
+        },
+        {
+          "key": "9aa11cc8-6c2d-4202-b30b-c8454338bbd2",
+          "doc_count": 18615
+        },
+        {
+          "key": "f4f833ea-0abf-4059-948e-132c64dda1be",
+          "doc_count": 18500
+        },
+        {
+          "key": "b101e53b-8934-42ef-92db-904c226f29a8",
+          "doc_count": 18473
+        },
+        {
+          "key": "c3134980-bf5c-49b8-a289-790d45f02c86",
+          "doc_count": 18471
+        },
+        {
+          "key": "c7a96a19-db06-48dc-bce7-5bf9bb4921a0",
+          "doc_count": 18409
+        },
+        {
+          "key": "7ad07cff-f782-4ddf-b780-3a757cdb77e0",
+          "doc_count": 18363
+        },
+        {
+          "key": "ad5c4ec7-ed56-4d3e-881a-963af217d334",
+          "doc_count": 18224
+        },
+        {
+          "key": "c9dad611-5e60-4456-934e-75b0e0842ddd",
+          "doc_count": 18221
+        },
+        {
+          "key": "3799e4f9-f685-4796-99b5-f78524441b93",
+          "doc_count": 18202
+        },
+        {
+          "key": "cb2973af-0d5a-4fbf-80ab-ec96ede33ef0",
+          "doc_count": 17937
+        },
+        {
+          "key": "2ee6534e-46ab-4233-98c4-d13c4262ce2e",
+          "doc_count": 17917
+        },
+        {
+          "key": "99b04c9f-908e-42bd-92bc-41aa94b72949",
+          "doc_count": 17915
+        },
+        {
+          "key": "e23109b4-e143-437c-b329-3dff7cb35488",
+          "doc_count": 17902
+        },
+        {
+          "key": "aac5fd7f-8043-4aa8-811f-e50de70d96f3",
+          "doc_count": 17886
+        },
+        {
+          "key": "7110b8ba-0ead-4666-8279-e30f53e343d0",
+          "doc_count": 17839
+        },
+        {
+          "key": "c8eeddef-b903-4aa3-a0fb-44344b8bf301",
+          "doc_count": 17820
+        },
+        {
+          "key": "4bec11d1-f8c3-43a7-9e70-ee0256fcedaf",
+          "doc_count": 17816
+        },
+        {
+          "key": "1d17fdad-d338-4ae0-9232-dbf18eaf9f66",
+          "doc_count": 17671
+        },
+        {
+          "key": "b590be71-5a03-4f29-bcd4-e91c1b876137",
+          "doc_count": 17609
+        },
+        {
+          "key": "e7644bac-b532-41fb-92ae-1fb6502203f5",
+          "doc_count": 17520
+        },
+        {
+          "key": "8157bc94-5fba-4bf6-98bd-9ba653b595e8",
+          "doc_count": 17443
+        },
+        {
+          "key": "ec135c9b-ff89-4f28-aa18-88b16d932d94",
+          "doc_count": 17440
+        },
+        {
+          "key": "4ef6540c-e6cf-4678-bc43-b57435354de0",
+          "doc_count": 17400
+        },
+        {
+          "key": "d315c4a3-0bee-49d1-8d03-726358937cde",
+          "doc_count": 17340
+        },
+        {
+          "key": "fe51bced-93ce-45b2-b0c6-f7256719a07b",
+          "doc_count": 17300
+        },
+        {
+          "key": "2e4ccf50-bb7d-43a6-9640-088b248c2c5a",
+          "doc_count": 17298
+        },
+        {
+          "key": "c5eeb223-0515-423a-a51a-151426c8f60d",
+          "doc_count": 17160
+        },
+        {
+          "key": "bfc1bc5b-ddee-4880-a5d5-90f7c950c692",
+          "doc_count": 17117
+        },
+        {
+          "key": "ced8c9bc-e8b5-49e7-860a-289fc913860c",
+          "doc_count": 16956
+        },
+        {
+          "key": "e34cf41b-196c-4199-85d5-4d2ca5954b09",
+          "doc_count": 16931
+        },
+        {
+          "key": "ad4e4ea0-2ac9-4030-b4bd-bf4206e79bcc",
+          "doc_count": 16910
+        },
+        {
+          "key": "8295ea14-c4fd-499b-bc68-2907ed36badc",
+          "doc_count": 16872
+        },
+        {
+          "key": "54ae6783-dbb5-403a-b0e6-11a3b07d491a",
+          "doc_count": 16857
+        },
+        {
+          "key": "6ae7221e-2085-46cf-9ad0-353269e95bc8",
+          "doc_count": 16847
+        },
+        {
+          "key": "dad057a8-0648-4e11-9652-740ce7f86d62",
+          "doc_count": 16841
+        },
+        {
+          "key": "7b1f4ee4-7f50-4c82-9007-ba76528a84df",
+          "doc_count": 16687
+        },
+        {
+          "key": "1db8b527-7713-405b-b7ec-bc824580ccc6",
+          "doc_count": 16663
+        },
+        {
+          "key": "cb4882a8-19d3-41a1-9373-c1a868b5ac9b",
+          "doc_count": 16651
+        },
+        {
+          "key": "767e0c9c-3747-4400-896e-26e2ee149b4a",
+          "doc_count": 16569
+        },
+        {
+          "key": "139f2c47-4051-4c44-b95a-45fd20b1a8b9",
+          "doc_count": 16497
+        },
+        {
+          "key": "a5d9992f-ebbb-457c-b56a-b6cd0429e2d6",
+          "doc_count": 16479
+        },
+        {
+          "key": "ebd4ee05-1c41-46ab-9ef2-8937ea4f6112",
+          "doc_count": 16476
+        },
+        {
+          "key": "513dd822-f211-42c3-9af2-ee3c798cd1b8",
+          "doc_count": 16421
+        },
+        {
+          "key": "ca8f64d0-40d2-452a-b1b8-713a3861fe69",
+          "doc_count": 16386
+        },
+        {
+          "key": "c804f67a-efed-4ff6-a875-dc132a040058",
+          "doc_count": 16363
+        },
+        {
+          "key": "4fed055b-3c46-4ec4-b76d-84d43df9258b",
+          "doc_count": 16351
+        },
+        {
+          "key": "0038ce2e-43bb-4f70-8dd6-dca34efd3fca",
+          "doc_count": 16296
+        },
+        {
+          "key": "5c861676-8285-4a04-b1c5-94ce73342320",
+          "doc_count": 16247
+        },
+        {
+          "key": "76015dea-c909-4e6d-a8e1-3bf35763571e",
+          "doc_count": 16182
+        },
+        {
+          "key": "e01f53f2-8e1b-41cb-9e5a-3dfb3ccf44d6",
+          "doc_count": 16182
+        },
+        {
+          "key": "2e96b570-4567-4538-add2-bca9552f6d32",
+          "doc_count": 16166
+        },
+        {
+          "key": "b30a7dd2-d974-4073-bdd0-cb4ea5402bae",
+          "doc_count": 16151
+        },
+        {
+          "key": "50b0bbe4-f075-4427-8dfc-fcc469dd3e78",
+          "doc_count": 16140
+        },
+        {
+          "key": "3c367a2d-eec0-4ef1-b3bc-4cbebb320c5a",
+          "doc_count": 16053
+        },
+        {
+          "key": "4bf197cb-6fbc-4b22-82d0-849fffb5906e",
+          "doc_count": 15917
+        },
+        {
+          "key": "5794eddf-4efd-4117-953b-c66568841a68",
+          "doc_count": 15866
+        },
+        {
+          "key": "96a6898e-1fb6-4c49-a1f2-afb96058dbf8",
+          "doc_count": 15835
+        },
+        {
+          "key": "13bac7f8-ff25-4d02-82d7-516dc6355beb",
+          "doc_count": 15726
+        },
+        {
+          "key": "18cc4ad5-9449-470e-9195-5858b12d822c",
+          "doc_count": 15719
+        },
+        {
+          "key": "4f436daa-01d5-4be6-b5c3-fdd255677536",
+          "doc_count": 15701
+        },
+        {
+          "key": "98c884c9-ace1-47b8-afb6-3b0c10499172",
+          "doc_count": 15674
+        },
+        {
+          "key": "f56d3b76-c8c7-4280-969a-65fce63cff0b",
+          "doc_count": 15637
+        },
+        {
+          "key": "c5916431-004f-465a-a505-589e2de29c8b",
+          "doc_count": 15623
+        },
+        {
+          "key": "a5ec0be5-1c6f-448a-b75d-76085fe3ff20",
+          "doc_count": 15605
+        },
+        {
+          "key": "90d6f994-d652-49d0-b6e6-924c65c4c079",
+          "doc_count": 15512
+        },
+        {
+          "key": "e8a10a16-86af-42b2-be40-9d6a1b21859a",
+          "doc_count": 15486
+        },
+        {
+          "key": "28ddc5cc-5aa4-42cc-a29d-4d516de9ba86",
+          "doc_count": 15389
+        },
+        {
+          "key": "78bb515d-4508-45d6-94e2-e53638ce2fe4",
+          "doc_count": 15324
+        },
+        {
+          "key": "d68063b0-2d3e-4a7c-bf2b-cf2a1fb629f9",
+          "doc_count": 15300
+        },
+        {
+          "key": "437826f3-69f9-43d9-b3c3-c0de0e26cd88",
+          "doc_count": 15164
+        },
+        {
+          "key": "654e092c-edbd-456c-8cce-2bcbdff71a04",
+          "doc_count": 15006
+        },
+        {
+          "key": "6d99bdeb-a96f-47bf-8e28-ce1093347335",
+          "doc_count": 14938
+        },
+        {
+          "key": "cd177f63-761b-44f6-866e-ee19d2ac134e",
+          "doc_count": 14861
+        },
+        {
+          "key": "1eca069b-09e0-406d-9625-cb9c52e1e5cc",
+          "doc_count": 14733
+        },
+        {
+          "key": "92e4e092-6dcb-46bc-85a0-dea8310aba45",
+          "doc_count": 14534
+        },
+        {
+          "key": "e4bf5684-e7eb-44e1-860b-d5a57dde203b",
+          "doc_count": 14526
+        },
+        {
+          "key": "3e1510e2-4078-4bd6-bc2e-7d7f357b6366",
+          "doc_count": 14510
+        },
+        {
+          "key": "5939498b-0fcc-42ca-929b-99f4b2c5e1aa",
+          "doc_count": 14502
+        },
+        {
+          "key": "110fcbc8-a5cc-4a3d-9508-f14d172492f7",
+          "doc_count": 14473
+        },
+        {
+          "key": "fd62a976-d195-492a-b6f0-f57fef8b6acc",
+          "doc_count": 14404
+        },
+        {
+          "key": "4146072c-ed77-4bed-a03a-8363982a91e8",
+          "doc_count": 14309
+        },
+        {
+          "key": "613232f2-7ef5-4267-b4b4-96de1c94a7e5",
+          "doc_count": 14248
+        },
+        {
+          "key": "2d1faedc-9db5-4318-83a1-e884f27e9ac8",
+          "doc_count": 14232
+        },
+        {
+          "key": "f0bb124f-5840-41ea-98ab-b8fd8802ea5f",
+          "doc_count": 14205
+        },
+        {
+          "key": "54e35994-c613-4ce7-9afd-0636a88a1857",
+          "doc_count": 14182
+        },
+        {
+          "key": "2148b4f7-a770-4bca-b276-da70ae948690",
+          "doc_count": 14151
+        },
+        {
+          "key": "361ac837-a369-4728-b907-3dcc6521defa",
+          "doc_count": 14142
+        },
+        {
+          "key": "5277e72c-9e53-4c98-85f1-ee413bc473cd",
+          "doc_count": 14113
+        },
+        {
+          "key": "3f5c29cf-9b20-4476-90fb-0399c7c51a0b",
+          "doc_count": 14099
+        },
+        {
+          "key": "560ba8f5-0dab-46f6-985d-7b37397344cd",
+          "doc_count": 13934
+        },
+        {
+          "key": "662b1aa5-9c19-4eb9-9766-1da78a117456",
+          "doc_count": 13843
+        },
+        {
+          "key": "a6966178-9495-4093-9cb2-dfed4acddde6",
+          "doc_count": 13724
+        },
+        {
+          "key": "5db52f01-8d71-43e5-b835-0ff7d33d715b",
+          "doc_count": 13661
+        },
+        {
+          "key": "9764480a-6e4a-4800-9bb7-b6fb73bccc50",
+          "doc_count": 13661
+        },
+        {
+          "key": "5a9ae910-9e4b-488b-af8e-88074fabc3a4",
+          "doc_count": 13641
+        },
+        {
+          "key": "837d99c6-3045-4ba3-8951-643ddb3d6676",
+          "doc_count": 13566
+        },
+        {
+          "key": "a4378725-7967-47bc-aada-0220e02e1f96",
+          "doc_count": 13538
+        },
+        {
+          "key": "53aa69a7-bd66-468b-8ffa-ec6cb06d7d8d",
+          "doc_count": 13412
+        },
+        {
+          "key": "74ba1d92-d9a5-486e-8e52-bb44d51e1788",
+          "doc_count": 13382
+        },
+        {
+          "key": "3c6f1ea5-f2e7-4203-9cfe-74ec2fb1b035",
+          "doc_count": 13325
+        },
+        {
+          "key": "7915973f-a3b0-4d2c-86e7-02d40647393c",
+          "doc_count": 13249
+        },
+        {
+          "key": "341611f4-8b65-4655-b244-9be91a1109cd",
+          "doc_count": 13151
+        },
+        {
+          "key": "9835e4d7-a817-430f-9f55-5fc3325e4399",
+          "doc_count": 13149
+        },
+        {
+          "key": "720670ea-78bd-4703-9738-514111203942",
+          "doc_count": 13074
+        },
+        {
+          "key": "3fe3a250-0f48-4a9b-bb71-36d798694912",
+          "doc_count": 13061
+        },
+        {
+          "key": "5e24c385-dab9-40a3-a2dd-2cf8758821b6",
+          "doc_count": 13000
+        },
+        {
+          "key": "901108f3-c6a0-41cf-bf52-faa96a5a366d",
+          "doc_count": 12924
+        },
+        {
+          "key": "8f3923b5-4802-40ff-bf98-0acba66691ec",
+          "doc_count": 12898
+        },
+        {
+          "key": "a77b7747-8a1e-40ff-8c63-fb9087cc099d",
+          "doc_count": 12844
+        },
+        {
+          "key": "697b5707-b86f-43c5-a114-93a3fc602719",
+          "doc_count": 12841
+        },
+        {
+          "key": "a2352be4-1126-4504-ac86-c36234f123fa",
+          "doc_count": 12724
+        },
+        {
+          "key": "86b2bfc9-ca99-4250-b93a-f86f3777236d",
+          "doc_count": 12682
+        },
+        {
+          "key": "16e722d1-cf07-4bb9-a4ff-3c38ab0bcebf",
+          "doc_count": 12671
+        },
+        {
+          "key": "13510466-6232-4313-9e46-ea197b82750c",
+          "doc_count": 12645
+        },
+        {
+          "key": "8096525f-6f67-4bd2-a160-48ed4bea8aa7",
+          "doc_count": 12557
+        },
+        {
+          "key": "1c8d18f4-5af2-4d86-98d2-8a5ed06456e2",
+          "doc_count": 12506
+        },
+        {
+          "key": "d90e8316-2649-475e-a8c0-80130dab1fd2",
+          "doc_count": 12497
+        },
+        {
+          "key": "4aecf17c-154a-42fb-a3c0-f5e621c791e6",
+          "doc_count": 12472
+        },
+        {
+          "key": "a2beb85e-f2b8-4366-8b3b-e5c5cc117aaf",
+          "doc_count": 12425
+        },
+        {
+          "key": "17969b7f-c1d0-4c84-9cbc-de64b90a62a5",
+          "doc_count": 12404
+        },
+        {
+          "key": "e2c129bc-e45b-43d1-ab52-86e52093080b",
+          "doc_count": 12320
+        },
+        {
+          "key": "8c813d8c-e589-4ad2-977c-7b952db74130",
+          "doc_count": 12313
+        },
+        {
+          "key": "6e6bec70-a148-49c8-9f97-e64e2dfae5b7",
+          "doc_count": 12289
+        },
+        {
+          "key": "c0655a3e-f118-499d-ac98-0521280327cd",
+          "doc_count": 12147
+        },
+        {
+          "key": "5a9ca11b-ade3-409d-b811-b4637647d5f8",
+          "doc_count": 12140
+        },
+        {
+          "key": "93e97f6c-0ab6-41a7-9b58-7e230a80ec1e",
+          "doc_count": 12022
+        },
+        {
+          "key": "3e86e072-2597-4849-87d5-565afe40f988",
+          "doc_count": 11881
+        },
+        {
+          "key": "e80009a0-8a2a-499a-976f-f04869b05ce9",
+          "doc_count": 11820
+        },
+        {
+          "key": "04fe30b4-c1e5-4482-addb-67a4c2cd39ef",
+          "doc_count": 11802
+        },
+        {
+          "key": "2532cbd0-2752-4211-b249-4a9811a280f2",
+          "doc_count": 11728
+        },
+        {
+          "key": "58785b12-2f79-451b-a5c1-8d23f3f65733",
+          "doc_count": 11527
+        },
+        {
+          "key": "3ac8f738-bc3e-43e4-8358-00a32594954d",
+          "doc_count": 11433
+        },
+        {
+          "key": "0f53b3e3-c248-4026-a070-15c3fefdbbc0",
+          "doc_count": 11424
+        },
+        {
+          "key": "bfa3c276-a3a9-48cd-8d4a-4ac42f4fe10a",
+          "doc_count": 11423
+        },
+        {
+          "key": "165fe0ee-c8f1-4fb6-b148-6a7d9d0eed83",
+          "doc_count": 11335
+        },
+        {
+          "key": "cb308a44-6749-49d7-b333-66362e70d0f4",
+          "doc_count": 11333
+        },
+        {
+          "key": "a89f64ab-8b3b-4267-b18a-3207d25a45ad",
+          "doc_count": 11297
+        },
+        {
+          "key": "2c662e9e-cdc6-4bbf-93a5-1566ceca1af3",
+          "doc_count": 11252
+        },
+        {
+          "key": "abe3903e-ceba-4864-aa5d-bd985c70fa21",
+          "doc_count": 11229
+        },
+        {
+          "key": "b4154ce7-8145-4fd8-92ed-edd124d53730",
+          "doc_count": 11226
+        },
+        {
+          "key": "c892f8d1-108c-44f7-9458-0abb96633976",
+          "doc_count": 11179
+        },
+        {
+          "key": "b9b4963a-0332-40bb-b71c-a4735f323729",
+          "doc_count": 11143
+        },
+        {
+          "key": "6d09cfc1-a17c-4067-b1a0-557b8e5334ea",
+          "doc_count": 11058
+        },
+        {
+          "key": "9756b9a4-c070-4359-8a07-2383b09d0d04",
+          "doc_count": 11031
+        },
+        {
+          "key": "0cf71170-c4ea-4fb2-b13e-66a4f62d3a2d",
+          "doc_count": 11019
+        },
+        {
+          "key": "4d89070b-5dea-4a12-8a09-3f65ba33dba1",
+          "doc_count": 10964
+        },
+        {
+          "key": "3374cb0f-2f65-4e64-bbb5-93207f95eee5",
+          "doc_count": 10903
+        },
+        {
+          "key": "f266a75c-3529-4868-8669-9f98822e033f",
+          "doc_count": 10887
+        },
+        {
+          "key": "d14d21fe-da24-47e5-81fb-4bfe962ce828",
+          "doc_count": 10868
+        },
+        {
+          "key": "b5e5c781-765f-4981-af2a-c19c250e2cf0",
+          "doc_count": 10820
+        },
+        {
+          "key": "b7349341-c8e2-4628-be5f-77600ba730fa",
+          "doc_count": 10804
+        },
+        {
+          "key": "a2105c9c-b869-4637-8850-eb51ea6b1066",
+          "doc_count": 10769
+        },
+        {
+          "key": "2bfc480c-e5b3-4a9b-9587-a92c22830ace",
+          "doc_count": 10765
+        },
+        {
+          "key": "12018be6-3795-43a3-a073-a2b9d60c0af3",
+          "doc_count": 10752
+        },
+        {
+          "key": "bbf5f8ed-f33f-40ba-9d0d-1c24dfec4193",
+          "doc_count": 10702
+        },
+        {
+          "key": "f8e830e3-9b0d-4e5d-9f24-9f2ed3b465da",
+          "doc_count": 10677
+        },
+        {
+          "key": "0c6fb8af-94f4-44f8-90c6-928008101b04",
+          "doc_count": 10616
+        },
+        {
+          "key": "4f8c3594-d7b2-4985-8dd9-1ae77f9187d4",
+          "doc_count": 10615
+        },
+        {
+          "key": "f77daa20-545c-4fce-812c-cdb4d658dfa5",
+          "doc_count": 10599
+        },
+        {
+          "key": "06c35934-1b75-4196-838d-29d509951bf9",
+          "doc_count": 10505
+        },
+        {
+          "key": "724dc40a-421c-44f8-b426-969f99fa8a1c",
+          "doc_count": 10491
+        },
+        {
+          "key": "62f951c1-b6a8-430c-8652-5691f079152c",
+          "doc_count": 10453
+        },
+        {
+          "key": "79aa7602-a963-44f3-82dd-e141a387adb8",
+          "doc_count": 10415
+        },
+        {
+          "key": "e7bc6545-f14f-4fc4-9902-1aa38040f184",
+          "doc_count": 10341
+        },
+        {
+          "key": "f8944362-0f02-4ccb-bbaf-3149b2de8e22",
+          "doc_count": 10328
+        },
+        {
+          "key": "e701ecce-f9ab-445f-afcb-24f279efbc9c",
+          "doc_count": 10324
+        },
+        {
+          "key": "f18d38a1-19c2-4b33-b79a-d44ab356b01c",
+          "doc_count": 10157
+        },
+        {
+          "key": "4c51ed21-26d8-4b3c-bc5d-e49bbee4fa6d",
+          "doc_count": 10123
+        },
+        {
+          "key": "c5418751-0901-48f9-a74b-481324764113",
+          "doc_count": 9997
+        },
+        {
+          "key": "2b21081c-d5e9-49bd-b29a-0b6e4a551b78",
+          "doc_count": 9960
+        },
+        {
+          "key": "4220f82f-cf41-4709-aa0a-6e3cb04427ba",
+          "doc_count": 9899
+        },
+        {
+          "key": "7cc1fb18-45c1-499f-8476-682daa14a4a3",
+          "doc_count": 9889
+        },
+        {
+          "key": "ea4794f2-b034-464a-b178-e895d97bb15a",
+          "doc_count": 9863
+        },
+        {
+          "key": "d1de8464-14d4-43da-8a57-9792fc34d4bf",
+          "doc_count": 9833
+        },
+        {
+          "key": "6aaea1e9-290d-4886-b41b-a3a4c76dbd92",
+          "doc_count": 9811
+        },
+        {
+          "key": "15e04168-22cc-4283-9042-247ab053c7ca",
+          "doc_count": 9804
+        },
+        {
+          "key": "2d86bdb0-a563-4a35-b990-469e9e896712",
+          "doc_count": 9760
+        },
+        {
+          "key": "39de54ef-ecfe-4e9e-9f9c-d4b29f0a893f",
+          "doc_count": 9684
+        },
+        {
+          "key": "a545560f-a02a-4b8a-af4c-ed09f1f05df7",
+          "doc_count": 9605
+        },
+        {
+          "key": "0fcbf959-b714-4ba2-8152-0c1440e31323",
+          "doc_count": 9577
+        },
+        {
+          "key": "895fa45a-8875-4ae9-8f6c-d80fb7e005ae",
+          "doc_count": 9577
+        },
+        {
+          "key": "8e5fffb5-0b22-472d-8386-de291d17d513",
+          "doc_count": 9574
+        },
+        {
+          "key": "e3c0918d-ec6e-4ecd-a1db-15ec6880dade",
+          "doc_count": 9547
+        },
+        {
+          "key": "0dabd609-2505-4492-8b7a-3f8301d8d5e1",
+          "doc_count": 9528
+        },
+        {
+          "key": "e597a4f6-2be7-4538-8007-dec480dc4d6f",
+          "doc_count": 9489
+        },
+        {
+          "key": "0bffd75c-2c42-4119-bae7-1ca6d8eb4d1a",
+          "doc_count": 9488
+        },
+        {
+          "key": "9cd34069-24ca-4ae8-9c10-78ccfac6523d",
+          "doc_count": 9480
+        },
+        {
+          "key": "58619649-7813-443d-9a99-3d4cfac8e0c4",
+          "doc_count": 9449
+        },
+        {
+          "key": "f0599190-e5b7-42ed-bec8-810905f50c34",
+          "doc_count": 9341
+        },
+        {
+          "key": "8680bd09-df85-41cc-861e-dd33b6d04873",
+          "doc_count": 9295
+        },
+        {
+          "key": "431b56fc-d016-459a-97ab-1e9c8168a7f0",
+          "doc_count": 9223
+        },
+        {
+          "key": "f16e6d76-14c8-411f-83dd-f53926c6147b",
+          "doc_count": 9212
+        },
+        {
+          "key": "90739622-5232-4048-8121-9af9ec69604f",
+          "doc_count": 9156
+        },
+        {
+          "key": "f89ada44-88df-46f0-bc61-cc46d9c84673",
+          "doc_count": 9155
+        },
+        {
+          "key": "1bc74afb-698f-43a7-90e6-352dba6c74da",
+          "doc_count": 9096
+        },
+        {
+          "key": "28a8977f-392c-4705-80ed-6e5f04f1b0c0",
+          "doc_count": 9094
+        },
+        {
+          "key": "a711ca61-c052-45e9-8c20-fdb550f50be3",
+          "doc_count": 9062
+        },
+        {
+          "key": "a5b1b714-7470-4635-805d-a0cdcc6a6a4b",
+          "doc_count": 9056
+        },
+        {
+          "key": "2c2cc29c-3572-4568-a129-c8cbec34ccbe",
+          "doc_count": 8982
+        },
+        {
+          "key": "30ae66f4-b3eb-44ce-87aa-309d47e5facb",
+          "doc_count": 8956
+        },
+        {
+          "key": "a2a7754b-2346-496d-b681-eb754ef32b9e",
+          "doc_count": 8945
+        },
+        {
+          "key": "237bd113-32f3-4091-9710-4a1b074fe26d",
+          "doc_count": 8935
+        },
+        {
+          "key": "f1960cd5-e27a-40f0-b4bd-3ca7157e4bbb",
+          "doc_count": 8904
+        },
+        {
+          "key": "dbb2acdc-a808-4deb-9dc2-542d70368a3f",
+          "doc_count": 8859
+        },
+        {
+          "key": "5889291d-9105-4740-a30f-2d9d2469c264",
+          "doc_count": 8829
+        },
+        {
+          "key": "ecb0a329-c019-4a59-abe3-fa7e72055902",
+          "doc_count": 8823
+        },
+        {
+          "key": "86b1f54d-ac01-4c5e-8ed8-09da2689c7a9",
+          "doc_count": 8812
+        },
+        {
+          "key": "a2aa4105-a10a-499f-8002-c6a8cb600a74",
+          "doc_count": 8791
+        },
+        {
+          "key": "5ffc8bc6-e366-4157-b1ba-00859f1048a4",
+          "doc_count": 8789
+        },
+        {
+          "key": "0272afc1-36ee-4899-8c28-dde9d8a211d9",
+          "doc_count": 8788
+        },
+        {
+          "key": "414a5bf5-061e-4e47-8410-0f76a04f7d1d",
+          "doc_count": 8758
+        },
+        {
+          "key": "46be8190-0533-4fc7-9cab-1faa26d9906e",
+          "doc_count": 8704
+        },
+        {
+          "key": "83fede4d-f1d0-4748-84e5-f24083c7ba3c",
+          "doc_count": 8633
+        },
+        {
+          "key": "2b45c778-b10c-496b-b8cb-1e414da59ccf",
+          "doc_count": 8610
+        },
+        {
+          "key": "f016064e-c9c6-4baf-925c-e68e1190bb6d",
+          "doc_count": 8575
+        },
+        {
+          "key": "cfe5283d-89df-4662-8c45-8f0c76e90107",
+          "doc_count": 8565
+        },
+        {
+          "key": "a9b8572c-ec86-4e6b-9ed9-03d939b7f363",
+          "doc_count": 8559
+        },
+        {
+          "key": "afd773b8-280f-4a0f-98a7-7977b7e1ca24",
+          "doc_count": 8520
+        },
+        {
+          "key": "4b05f088-74a4-44a5-a161-8b1484efc240",
+          "doc_count": 8505
+        },
+        {
+          "key": "9d2a4189-6048-46e9-bac4-e5ef566334bb",
+          "doc_count": 8496
+        },
+        {
+          "key": "1ad40bde-8a2a-46bb-9252-0cdc53df5683",
+          "doc_count": 8458
+        },
+        {
+          "key": "f3d1fbbb-93d5-432e-8808-ebc08c42ef6d",
+          "doc_count": 8442
+        },
+        {
+          "key": "1fc07b28-43f5-49d1-badf-63005e1c3e9a",
+          "doc_count": 8437
+        },
+        {
+          "key": "bdf65f9c-a730-4083-bd8d-a2def3037637",
+          "doc_count": 8333
+        },
+        {
+          "key": "9fa0a48c-7dd2-4372-a768-9aea3cbd35bb",
+          "doc_count": 8321
+        },
+        {
+          "key": "bc93e4c6-fd85-4412-987f-52f6fa3bb67d",
+          "doc_count": 8230
+        },
+        {
+          "key": "ef04e127-bb7d-4bf0-82d3-767d43108f81",
+          "doc_count": 8220
+        },
+        {
+          "key": "0ed0b942-198e-4500-8fe0-1d1ef0785454",
+          "doc_count": 8202
+        },
+        {
+          "key": "e7db896a-c95b-4a18-99a4-866fff238ca5",
+          "doc_count": 8171
+        },
+        {
+          "key": "41c7a19b-6fc8-4fc4-8b43-f7bb11c82128",
+          "doc_count": 8170
+        },
+        {
+          "key": "58afd7df-a696-4dd6-a765-540f8b31c07d",
+          "doc_count": 8147
+        },
+        {
+          "key": "5fd5a403-8e94-4865-8c77-ee92cb4a95f2",
+          "doc_count": 8142
+        },
+        {
+          "key": "7757c07f-18fd-45c2-84cc-60bd3742e100",
+          "doc_count": 8139
+        },
+        {
+          "key": "080aa588-2f4c-4d65-8a55-f0b83e8aa7e6",
+          "doc_count": 8114
+        },
+        {
+          "key": "73b2abe8-93ea-4343-bc37-35693035dea0",
+          "doc_count": 8113
+        },
+        {
+          "key": "212dcc45-bf5b-43d8-a804-3351c04c2f7a",
+          "doc_count": 8100
+        },
+        {
+          "key": "046a2685-be26-4d6e-80cc-d95e907922fa",
+          "doc_count": 8097
+        },
+        {
+          "key": "dd91b2ab-b30d-4945-8f37-276b3af5fda6",
+          "doc_count": 7918
+        },
+        {
+          "key": "e77108de-88dd-4931-8085-0ea59d7ca4ee",
+          "doc_count": 7913
+        },
+        {
+          "key": "f08c31ea-0e90-4cc1-b471-dfd0584ae7cf",
+          "doc_count": 7875
+        },
+        {
+          "key": "e3efdab9-2200-480c-8960-e163ee23dddf",
+          "doc_count": 7873
+        },
+        {
+          "key": "604e4359-00b5-467b-89c0-a979abb5485e",
+          "doc_count": 7853
+        },
+        {
+          "key": "7e44229a-e8fa-4570-ada1-0cd7843a66d7",
+          "doc_count": 7843
+        },
+        {
+          "key": "c22f048c-6f77-4488-a203-865537dddba9",
+          "doc_count": 7839
+        },
+        {
+          "key": "f1512610-8631-475c-875a-a634191a9715",
+          "doc_count": 7839
+        },
+        {
+          "key": "52fa1dc5-5184-45d9-ad4a-5c2e715c6da5",
+          "doc_count": 7837
+        },
+        {
+          "key": "364b1f8d-5975-48d9-bba1-c97ab172986c",
+          "doc_count": 7818
+        },
+        {
+          "key": "25972252-d6b1-4b52-b4b8-64d09d7e7da1",
+          "doc_count": 7804
+        },
+        {
+          "key": "cd6231ce-ffb3-49fc-b726-5598bb3bc453",
+          "doc_count": 7740
+        },
+        {
+          "key": "8660ce9a-31c9-48ee-b5bc-9e6ba248ec0f",
+          "doc_count": 7735
+        },
+        {
+          "key": "de67ccab-7d04-43b9-8083-81e45f628505",
+          "doc_count": 7722
+        },
+        {
+          "key": "0eba218d-bccb-45cb-95e2-cc5625be106e",
+          "doc_count": 7693
+        },
+        {
+          "key": "2c84db50-bab1-40a6-a9ef-405f3ffcec7e",
+          "doc_count": 7654
+        },
+        {
+          "key": "2b89de41-42bd-46c6-ab61-d386f855f7fb",
+          "doc_count": 7649
+        },
+        {
+          "key": "65ab55e3-625c-40ef-8340-1b145ddc07f6",
+          "doc_count": 7509
+        },
+        {
+          "key": "bedde734-0fa1-49c4-8d97-f3b3e9bfb9ab",
+          "doc_count": 7503
+        },
+        {
+          "key": "8400a716-0aef-4131-9e79-c8ad81d244ad",
+          "doc_count": 7474
+        },
+        {
+          "key": "1cd453fb-76d7-4eb6-8a0c-9fdfd3a4c2e8",
+          "doc_count": 7444
+        },
+        {
+          "key": "43362664-f117-47cb-9fc4-56c1a1e8c962",
+          "doc_count": 7441
+        },
+        {
+          "key": "ea9de87b-7231-4a05-809f-4b658ea4173d",
+          "doc_count": 7400
+        },
+        {
+          "key": "b6ebfa9d-fed3-4e0c-8877-47c1190f346c",
+          "doc_count": 7385
+        },
+        {
+          "key": "0b2b87e2-5c7f-4b30-9ea4-dc3f5f25aacd",
+          "doc_count": 7376
+        },
+        {
+          "key": "c7ae0ade-c23e-4fe6-a3d4-79bd973374c2",
+          "doc_count": 7310
+        },
+        {
+          "key": "3501e0a6-1420-45b9-bbf9-77349e79e9d7",
+          "doc_count": 7289
+        },
+        {
+          "key": "68abd0b8-cff1-4c84-a2d9-bd4ac6df4fa4",
+          "doc_count": 7259
+        },
+        {
+          "key": "108cca70-4d1c-4882-843b-2d31ba8d6763",
+          "doc_count": 7221
+        },
+        {
+          "key": "151075fa-f464-4d76-9064-b24aa945b30f",
+          "doc_count": 7187
+        },
+        {
+          "key": "fdf98e60-9feb-4b86-a42e-ae6c7152d02c",
+          "doc_count": 7170
+        },
+        {
+          "key": "a8add96d-651c-488e-8ca3-ed3f85c7a117",
+          "doc_count": 7148
+        },
+        {
+          "key": "286b7e6d-b9a6-440c-a843-d27044d9e775",
+          "doc_count": 7107
+        },
+        {
+          "key": "6c3743dc-a66c-4fbb-9f0b-b94835888412",
+          "doc_count": 7093
+        },
+        {
+          "key": "a83151ae-e1db-4166-9dde-438f6544dca9",
+          "doc_count": 7090
+        },
+        {
+          "key": "5af1bae4-35c0-4ab7-9d08-08bbe22ca003",
+          "doc_count": 7082
+        },
+        {
+          "key": "745caa9d-02be-4a67-a142-103282aa0bda",
+          "doc_count": 7081
+        },
+        {
+          "key": "029e1b92-bd6c-4037-9a0b-10136a879a74",
+          "doc_count": 7075
+        },
+        {
+          "key": "a062eb42-d5c6-4332-8c88-64b4ac1af892",
+          "doc_count": 7069
+        },
+        {
+          "key": "92f0b5e8-27b5-48ae-be72-616657821f7b",
+          "doc_count": 7046
+        },
+        {
+          "key": "df516dc6-6ef0-426d-94e3-8a2bbb0439a5",
+          "doc_count": 7022
+        },
+        {
+          "key": "191206d2-a389-471c-9f9d-c0b8b00c35f8",
+          "doc_count": 7000
+        },
+        {
+          "key": "1720ead7-9d20-4179-8998-2a59b8bfa8d7",
+          "doc_count": 6993
+        },
+        {
+          "key": "2e185eda-1790-45e3-88d6-261304c37ed4",
+          "doc_count": 6956
+        },
+        {
+          "key": "ca356731-2be9-4e68-a475-0c363d12f54a",
+          "doc_count": 6948
+        },
+        {
+          "key": "540e18dc-09aa-4790-8b47-8d18ae86fabc",
+          "doc_count": 6930
+        },
+        {
+          "key": "d6c6e57a-4ccb-4707-b87d-c91d01d6aa42",
+          "doc_count": 6924
+        },
+        {
+          "key": "204fbebc-37cc-4331-a2be-11f38949561c",
+          "doc_count": 6916
+        },
+        {
+          "key": "6ca3402b-f015-4953-92b7-b1bdc1c36478",
+          "doc_count": 6891
+        },
+        {
+          "key": "929bf047-9ad7-48bd-88fa-c2630d423e8a",
+          "doc_count": 6888
+        },
+        {
+          "key": "b5d8168e-c310-4870-aa88-eeb3c25256fd",
+          "doc_count": 6874
+        },
+        {
+          "key": "b1ed65bb-f27e-4695-a0f5-7ca52fc0c3e6",
+          "doc_count": 6866
+        },
+        {
+          "key": "e8c034d5-c2c7-4f23-8dc0-7f94f4116306",
+          "doc_count": 6829
+        },
+        {
+          "key": "bea3ab78-a205-474d-b183-41249afd65d9",
+          "doc_count": 6817
+        },
+        {
+          "key": "2d47501f-dbed-43ce-a9c3-9c8542648ce4",
+          "doc_count": 6811
+        },
+        {
+          "key": "2fe72860-9220-4acd-894b-81b4d98a5e24",
+          "doc_count": 6788
+        },
+        {
+          "key": "90e07356-df5d-4372-a2c4-34927db9a3ec",
+          "doc_count": 6786
+        },
+        {
+          "key": "d840624f-42d5-40d9-9daa-2260f85feb54",
+          "doc_count": 6785
+        },
+        {
+          "key": "73236de8-c2cc-458c-b0c3-743c7b57db3a",
+          "doc_count": 6742
+        },
+        {
+          "key": "dcc8c1ac-38c7-4ada-a389-f4aceeacb531",
+          "doc_count": 6720
+        },
+        {
+          "key": "a986ff36-22a2-46a5-ac82-513b6fa90423",
+          "doc_count": 6717
+        },
+        {
+          "key": "ef637c01-c551-4d47-8a48-4442b8ad5ecd",
+          "doc_count": 6714
+        },
+        {
+          "key": "21b1b9de-18ba-4180-82f5-4dc1f9fcbcbf",
+          "doc_count": 6682
+        },
+        {
+          "key": "959c0dc4-fcf3-477e-af63-c00a005dbc0a",
+          "doc_count": 6652
+        },
+        {
+          "key": "b00cf471-6bbe-4f94-846e-288900398b65",
+          "doc_count": 6651
+        },
+        {
+          "key": "331b6d1b-842e-4c63-aa23-75ef275d8a9f",
+          "doc_count": 6617
+        },
+        {
+          "key": "7ed2ce52-26e5-4847-9563-955ae3e97455",
+          "doc_count": 6528
+        },
+        {
+          "key": "62c35d43-f15c-451d-a8be-1b9c6928b8bd",
+          "doc_count": 6490
+        },
+        {
+          "key": "5486b66d-2082-433d-9223-bd789ebca29c",
+          "doc_count": 6445
+        },
+        {
+          "key": "1b6bb28e-e443-4cd3-910a-c6c43849c2cd",
+          "doc_count": 6441
+        },
+        {
+          "key": "c659d35f-cd8c-43b5-b0ae-bcb8a8d24b25",
+          "doc_count": 6414
+        },
+        {
+          "key": "3a0d8092-c577-4775-a586-1542574edc53",
+          "doc_count": 6388
+        },
+        {
+          "key": "b12b08da-3d05-4406-a051-0139a33ecf35",
+          "doc_count": 6351
+        },
+        {
+          "key": "282fe9c2-d6cb-4325-b3b5-b70ab1d22bbb",
+          "doc_count": 6343
+        },
+        {
+          "key": "f9821639-abd8-433a-8c4a-56cc5c572bd0",
+          "doc_count": 6337
+        },
+        {
+          "key": "d5a1b706-c624-43df-afcf-9cea7094e75b",
+          "doc_count": 6325
+        },
+        {
+          "key": "cbc9700e-6714-499f-8994-643c12853d2e",
+          "doc_count": 6307
+        },
+        {
+          "key": "bfb53140-79c1-4625-81aa-3f37de7c0c2f",
+          "doc_count": 6305
+        },
+        {
+          "key": "0c88b9e2-1b9b-4578-9bb8-e7414cc09dbc",
+          "doc_count": 6255
+        },
+        {
+          "key": "a2eb724e-58a9-4840-a87e-5b6ca1c344dc",
+          "doc_count": 6250
+        },
+        {
+          "key": "535d4a21-8650-41d0-b92f-b6c028db13e2",
+          "doc_count": 6249
+        },
+        {
+          "key": "d4b04a67-3c67-4d8b-85f6-9d501415ca89",
+          "doc_count": 6242
+        },
+        {
+          "key": "af7a39b5-5a5b-4179-bcf4-0df30e98475e",
+          "doc_count": 6241
+        },
+        {
+          "key": "83a4f2c7-7a52-46cc-a6c6-62b1aad5883d",
+          "doc_count": 6237
+        },
+        {
+          "key": "d5c32031-231f-4213-b0f1-2dc4bbf711a0",
+          "doc_count": 6152
+        },
+        {
+          "key": "fd9201e8-391d-4ab2-b7d4-b5dc39b0e995",
+          "doc_count": 6081
+        },
+        {
+          "key": "0f65c2e4-fc98-4a2c-bfbe-24de6ab1feb6",
+          "doc_count": 6021
+        },
+        {
+          "key": "932e8ecc-fb16-4ce1-9863-e0e586e3ab34",
+          "doc_count": 6006
+        },
+        {
+          "key": "b803d3a7-34b4-447b-b239-2988a83181e7",
+          "doc_count": 5978
+        },
+        {
+          "key": "8bcb95b2-ab5c-4368-8ead-14588eeb9c98",
+          "doc_count": 5975
+        },
+        {
+          "key": "44328ef7-fc7f-4ff6-b51b-ed9049857e11",
+          "doc_count": 5920
+        },
+        {
+          "key": "1d53fb30-d749-4e7c-beab-f83a0354fdf7",
+          "doc_count": 5919
+        },
+        {
+          "key": "55e724a4-336a-4315-99e7-01bf0c94f222",
+          "doc_count": 5914
+        },
+        {
+          "key": "662088ed-7dc8-4043-8046-8e1035ae742f",
+          "doc_count": 5892
+        },
+        {
+          "key": "b0e9fd61-1e0f-408f-b035-d7952614d7f3",
+          "doc_count": 5880
+        },
+        {
+          "key": "e7496fd0-725a-42eb-bf35-af72885b6c0d",
+          "doc_count": 5865
+        },
+        {
+          "key": "55d60f69-eee9-4386-952a-805dfb71830a",
+          "doc_count": 5850
+        },
+        {
+          "key": "6f470382-cb0b-4634-a796-2248bfa97fdc",
+          "doc_count": 5830
+        },
+        {
+          "key": "137a4346-a8ba-419e-bcd9-aa854d6df779",
+          "doc_count": 5780
+        },
+        {
+          "key": "a0546df1-b727-402f-b9b8-570e65e58026",
+          "doc_count": 5778
+        },
+        {
+          "key": "fb4ced29-6329-4777-a9e6-cfc0e4031eac",
+          "doc_count": 5725
+        },
+        {
+          "key": "f0f0731a-e2c2-415e-a41c-9f514296844c",
+          "doc_count": 5653
+        },
+        {
+          "key": "67893f3c-c409-41c6-a8f2-47956739a911",
+          "doc_count": 5633
+        },
+        {
+          "key": "954ec5e0-4fcd-414d-8ad2-46b4b75cfc74",
+          "doc_count": 5614
+        },
+        {
+          "key": "5ab5f23d-292e-4bea-ba06-12db0f8a8c86",
+          "doc_count": 5613
+        },
+        {
+          "key": "23655eb9-7798-4865-9a92-1dbbc609511d",
+          "doc_count": 5579
+        },
+        {
+          "key": "96588aed-3b7a-4179-b92b-2159427f4fcb",
+          "doc_count": 5547
+        },
+        {
+          "key": "ec248223-f277-4c02-b1fa-60056b5a689a",
+          "doc_count": 5520
+        },
+        {
+          "key": "2cebadf7-6d52-49b2-b3a7-d4969a36aa12",
+          "doc_count": 5419
+        },
+        {
+          "key": "f5d395b8-c3c9-43df-b4ff-63d65c6a971e",
+          "doc_count": 5417
+        },
+        {
+          "key": "3172ee72-4b10-4d6b-b4b3-f3319b25c60d",
+          "doc_count": 5410
+        },
+        {
+          "key": "94103329-846d-4b67-964a-721cc0d21ca1",
+          "doc_count": 5406
+        },
+        {
+          "key": "4960f30c-c1c7-490e-966a-61ad02969e38",
+          "doc_count": 5400
+        },
+        {
+          "key": "a72205bf-d800-46a4-83a8-5fae54cdf877",
+          "doc_count": 5385
+        },
+        {
+          "key": "50cfe20a-9100-4710-89f9-a97bc3aa53d7",
+          "doc_count": 5369
+        },
+        {
+          "key": "de56670c-2032-4833-9a89-46f7d6a037c7",
+          "doc_count": 5345
+        },
+        {
+          "key": "39289378-eed8-442c-ba0b-fce8b1679d8f",
+          "doc_count": 5336
+        },
+        {
+          "key": "4cbe1f28-fa9a-46e6-862e-292037b847a8",
+          "doc_count": 5300
+        },
+        {
+          "key": "347579f4-d44a-4c8e-a578-09c2a8132573",
+          "doc_count": 5279
+        },
+        {
+          "key": "b46bfb83-12b3-49f6-b94a-a68a1fd02b4e",
+          "doc_count": 5276
+        },
+        {
+          "key": "473400bf-fe83-4bd6-9f69-c4608f4cdf4f",
+          "doc_count": 5248
+        },
+        {
+          "key": "cc11b4e3-823d-4490-95b2-afe6a1f3a9d2",
+          "doc_count": 5213
+        },
+        {
+          "key": "0ec58818-0c78-4804-a899-632f103371d8",
+          "doc_count": 5194
+        },
+        {
+          "key": "e6c164f8-ddcd-4649-bd26-b653c8bf4ee2",
+          "doc_count": 5185
+        },
+        {
+          "key": "d07e7b8a-2222-477f-a7f3-f098bbfdaf54",
+          "doc_count": 5170
+        },
+        {
+          "key": "589ee0cf-456c-4d9c-8e7e-3adc3cec0e09",
+          "doc_count": 5161
+        },
+        {
+          "key": "fd14095c-3658-4e00-8cec-729a89459e92",
+          "doc_count": 5161
+        },
+        {
+          "key": "a5fdee09-34c4-48bc-99ff-a503c93a9d7e",
+          "doc_count": 5158
+        },
+        {
+          "key": "9ef0bd4b-c016-4791-8a3f-a99c218c1d29",
+          "doc_count": 5120
+        },
+        {
+          "key": "4b92de1f-866d-4b82-af69-37d46753f289",
+          "doc_count": 5081
+        },
+        {
+          "key": "43c69d2a-0fd2-4d34-a1ef-50d0f9c01353",
+          "doc_count": 5069
+        },
+        {
+          "key": "6cab4420-11e4-4b55-85ac-6ecfdda70184",
+          "doc_count": 5041
+        },
+        {
+          "key": "508ab646-d530-49aa-ac3c-0e2aba9a8011",
+          "doc_count": 5021
+        },
+        {
+          "key": "a4babe52-5740-44e4-9ea2-acef4797f127",
+          "doc_count": 5002
+        },
+        {
+          "key": "1ea6c281-e2ca-4e79-80b7-63e27812044c",
+          "doc_count": 5000
+        },
+        {
+          "key": "da1ef9b1-761b-4bc3-8ac0-b9a109101f5f",
+          "doc_count": 4998
+        },
+        {
+          "key": "7cea906d-ae65-420c-a6f7-a9a3ad64fb93",
+          "doc_count": 4970
+        },
+        {
+          "key": "37287863-bf14-438e-a194-cc2ee7ae24be",
+          "doc_count": 4957
+        },
+        {
+          "key": "0901af29-834b-4502-91c8-f3b0f56be2bd",
+          "doc_count": 4956
+        },
+        {
+          "key": "2f740a87-8049-435d-9d06-1c393c9c11b7",
+          "doc_count": 4932
+        },
+        {
+          "key": "ee447b09-cb73-43d0-8ca0-1ab55be4db1b",
+          "doc_count": 4897
+        },
+        {
+          "key": "f2696243-01cd-4b91-9c13-1b30c8a85898",
+          "doc_count": 4875
+        },
+        {
+          "key": "91a0a18a-3196-4f87-87b6-02c7f8a12996",
+          "doc_count": 4862
+        },
+        {
+          "key": "89f59779-16cd-4179-86c9-23d13739d5f1",
+          "doc_count": 4854
+        },
+        {
+          "key": "b20167e0-4a23-4483-a01a-da509ca2d67d",
+          "doc_count": 4796
+        },
+        {
+          "key": "fe04dab1-5a3d-4c28-a450-012658e982d8",
+          "doc_count": 4750
+        },
+        {
+          "key": "fb33ec4c-1bab-48f2-9faf-a5205a9a2c37",
+          "doc_count": 4746
+        },
+        {
+          "key": "8b727955-5ef2-4339-b5af-e17177377470",
+          "doc_count": 4745
+        },
+        {
+          "key": "b133b7cb-c0a1-4cd7-9775-cbc78fea50fc",
+          "doc_count": 4731
+        },
+        {
+          "key": "9b34b218-efb2-43b9-9b9e-dac3c470a9f9",
+          "doc_count": 4663
+        },
+        {
+          "key": "fe09c4c1-f6f9-421d-ad3d-d46795a2c399",
+          "doc_count": 4617
+        },
+        {
+          "key": "295a8445-346f-4ea2-b0cf-4a3863c72cdb",
+          "doc_count": 4601
+        },
+        {
+          "key": "902f9e08-9180-4f12-97b6-d8662f2b583f",
+          "doc_count": 4565
+        },
+        {
+          "key": "147f3f52-4399-474b-b43d-8379c680d67b",
+          "doc_count": 4560
+        },
+        {
+          "key": "9dff5483-99ae-4e6c-a3c8-c64ea8f1c151",
+          "doc_count": 4506
+        },
+        {
+          "key": "bd211251-f857-4110-89df-ae59772e44c9",
+          "doc_count": 4486
+        },
+        {
+          "key": "ac8c109d-b69c-4359-87f4-8714f8c8a65d",
+          "doc_count": 4480
+        },
+        {
+          "key": "69d150df-eba4-4ab3-9156-71cb0db41830",
+          "doc_count": 4475
+        },
+        {
+          "key": "8dfc3d88-8f6b-4432-b69c-534717906004",
+          "doc_count": 4425
+        },
+        {
+          "key": "23b85d9d-4669-40db-901f-aaad686fe0b8",
+          "doc_count": 4421
+        },
+        {
+          "key": "00df4fe2-0025-45ec-814a-36777155e077",
+          "doc_count": 4402
+        },
+        {
+          "key": "9ab47b07-99a9-4509-884b-be9383908b28",
+          "doc_count": 4400
+        },
+        {
+          "key": "7026b70a-7245-42bd-8162-81ae9a6cfbcb",
+          "doc_count": 4351
+        },
+        {
+          "key": "eeb4872b-7fb4-4ecd-8ce5-82e194f04735",
+          "doc_count": 4337
+        },
+        {
+          "key": "25cd5e12-7830-4f46-bf6d-9b6deb706f44",
+          "doc_count": 4336
+        },
+        {
+          "key": "6e922c92-b37d-4c46-8982-19d945ff8fd1",
+          "doc_count": 4336
+        },
+        {
+          "key": "29f47c07-8130-4dfa-be3b-f446a7bd6330",
+          "doc_count": 4334
+        },
+        {
+          "key": "0395f3c4-0277-43b6-a36d-e07720588790",
+          "doc_count": 4329
+        },
+        {
+          "key": "5d0a9aa8-91f2-4fa4-b4df-554a4221dfcb",
+          "doc_count": 4317
+        },
+        {
+          "key": "252e1e9e-4bb0-4baa-bdaf-fa39b7900c69",
+          "doc_count": 4276
+        },
+        {
+          "key": "99c71f17-1446-4c38-a336-321fe6948dfc",
+          "doc_count": 4266
+        },
+        {
+          "key": "f4666aa7-93f0-41f7-83c2-497af7a06887",
+          "doc_count": 4245
+        },
+        {
+          "key": "6f510e69-96b2-4817-bab7-3a36c8250c79",
+          "doc_count": 4212
+        },
+        {
+          "key": "fc67a16e-9e6e-47ec-86c2-0b6def5a1a33",
+          "doc_count": 4179
+        },
+        {
+          "key": "d1b25dcd-472e-4902-b53c-3b164269e049",
+          "doc_count": 4167
+        },
+        {
+          "key": "23ca5883-852a-40ab-b8d3-7e4985202844",
+          "doc_count": 4135
+        },
+        {
+          "key": "1da8098a-1e82-4b8b-bf81-d30e423cdaba",
+          "doc_count": 4115
+        },
+        {
+          "key": "b10b9eb2-3786-4483-8b73-3cfdf1a9eb90",
+          "doc_count": 4086
+        },
+        {
+          "key": "2bbafa00-3162-4e8e-947c-64a13b8d3fef",
+          "doc_count": 4069
+        },
+        {
+          "key": "18c215c3-c02f-47e9-bb66-196c33c8f672",
+          "doc_count": 4065
+        },
+        {
+          "key": "2e746628-f895-4367-ae31-62e81e0b6b98",
+          "doc_count": 4050
+        },
+        {
+          "key": "d61fa59c-fd22-475a-bcb6-74d4093eb3a8",
+          "doc_count": 4046
+        },
+        {
+          "key": "34cad268-8226-4280-b637-dde38c82a29e",
+          "doc_count": 4039
+        },
+        {
+          "key": "86213e22-6c51-482c-aabf-2c3790211bdc",
+          "doc_count": 4036
+        },
+        {
+          "key": "b4816028-0711-4307-a98f-0a13fd1024f4",
+          "doc_count": 4018
+        },
+        {
+          "key": "677f57a9-9a0d-4e69-8622-96aa1e6392c2",
+          "doc_count": 4000
+        },
+        {
+          "key": "9c963109-9898-4953-a351-d5ee36d6115b",
+          "doc_count": 3974
+        },
+        {
+          "key": "2b03a9d6-3575-43ea-8f43-38cbe0ee72e6",
+          "doc_count": 3945
+        },
+        {
+          "key": "8282ecae-6fba-4c4c-b393-cef07e6820b4",
+          "doc_count": 3941
+        },
+        {
+          "key": "1200dfa1-c9d1-42c9-9be0-2b399f0297e3",
+          "doc_count": 3937
+        },
+        {
+          "key": "f42a166d-719c-44d6-a458-fb083f3f83b1",
+          "doc_count": 3927
+        },
+        {
+          "key": "093030d9-a124-42a8-8cf3-8c6904fefbe7",
+          "doc_count": 3921
+        },
+        {
+          "key": "333ac26a-30bc-4e0c-a6ef-c57a40f6bd99",
+          "doc_count": 3916
+        },
+        {
+          "key": "4c512712-3b53-4403-a059-d31d44c7d62d",
+          "doc_count": 3888
+        },
+        {
+          "key": "4c9d08ce-71c1-47b8-a572-2d40e5984c49",
+          "doc_count": 3876
+        },
+        {
+          "key": "1ffce054-8e3e-4209-9ff4-c26fa6c24c2f",
+          "doc_count": 3850
+        },
+        {
+          "key": "c5d42fed-eed0-4e14-9625-f8a9c0ff6bb1",
+          "doc_count": 3827
+        },
+        {
+          "key": "08bfaeb8-abb4-4b33-b0e7-ed1242377bbd",
+          "doc_count": 3821
+        },
+        {
+          "key": "0b4692d3-ece5-40ee-9000-c9538b7f7ae3",
+          "doc_count": 3811
+        },
+        {
+          "key": "64b54f96-91f0-4442-b6de-173aa1a5c31b",
+          "doc_count": 3789
+        },
+        {
+          "key": "09a76937-b01a-4f4a-aefd-825876453015",
+          "doc_count": 3781
+        },
+        {
+          "key": "5e926e06-23b7-4461-a86c-e9219f5a3606",
+          "doc_count": 3769
+        },
+        {
+          "key": "196bb137-2f82-40d5-b294-e730af29749f",
+          "doc_count": 3738
+        },
+        {
+          "key": "b8972f6b-c67f-45c0-b348-954866e04a0f",
+          "doc_count": 3705
+        },
+        {
+          "key": "5663707e-1f94-40a1-97f3-aaeff1d41d20",
+          "doc_count": 3683
+        },
+        {
+          "key": "964c24a3-cca4-4028-a0d8-b83513d14b7d",
+          "doc_count": 3678
+        },
+        {
+          "key": "e6b4d68a-59b5-4b74-a5ce-daadd930d3ca",
+          "doc_count": 3644
+        },
+        {
+          "key": "a73b61c5-812c-453b-b12b-5c65929e947a",
+          "doc_count": 3638
+        },
+        {
+          "key": "a50e98bd-13e9-41fe-a5cc-aee4f240628b",
+          "doc_count": 3635
+        },
+        {
+          "key": "66e00116-15fa-4149-a94a-eb91b98b622c",
+          "doc_count": 3631
+        },
+        {
+          "key": "665f34ed-bfa3-4b25-a838-3b97f4dce586",
+          "doc_count": 3580
+        },
+        {
+          "key": "0d420238-284f-45f9-afbf-e1f3c690f192",
+          "doc_count": 3559
+        },
+        {
+          "key": "9a266240-3fd0-4b36-8c98-d1b022f987b5",
+          "doc_count": 3546
+        },
+        {
+          "key": "be72355e-a5d6-4094-8635-0127dfb510aa",
+          "doc_count": 3520
+        },
+        {
+          "key": "2c07346d-2239-479b-91e4-787a8f589457",
+          "doc_count": 3507
+        },
+        {
+          "key": "3624883b-4d6a-471d-9c3d-b4482aaa0e9b",
+          "doc_count": 3490
+        },
+        {
+          "key": "707cb4fe-eea9-4d13-bfcf-2ede1ef90684",
+          "doc_count": 3472
+        },
+        {
+          "key": "ae3510e6-b214-4d3b-80a5-72dbe01a6e5d",
+          "doc_count": 3440
+        },
+        {
+          "key": "f8fdb5ef-e14b-4ebb-9682-e4cad362856c",
+          "doc_count": 3440
+        },
+        {
+          "key": "7886c689-ed46-47e9-8dba-4c0468212c65",
+          "doc_count": 3429
+        },
+        {
+          "key": "9a0f0d12-aea7-4be8-9904-ad85f39b2e1c",
+          "doc_count": 3406
+        },
+        {
+          "key": "d4863ab9-f1b1-4dbc-944e-fc415e585fc7",
+          "doc_count": 3391
+        },
+        {
+          "key": "b053e65d-4255-4370-b6d6-06a553c70518",
+          "doc_count": 3363
+        },
+        {
+          "key": "95773d4c-a441-410c-9fd1-aed26b41b0af",
+          "doc_count": 3359
+        },
+        {
+          "key": "8ed556b0-b801-4575-ae53-db7cacbfd0c9",
+          "doc_count": 3355
+        },
+        {
+          "key": "d1983d53-434a-436e-a698-3a2745eb61dc",
+          "doc_count": 3335
+        },
+        {
+          "key": "38b011a4-5b21-419c-9d7c-fd1ec13d09f2",
+          "doc_count": 3317
+        },
+        {
+          "key": "5a1f3d7f-affe-44e9-aa16-a7e8824e8992",
+          "doc_count": 3293
+        },
+        {
+          "key": "9a09745d-4449-46a2-b8b3-60f3c0d25e83",
+          "doc_count": 3258
+        },
+        {
+          "key": "2d4658e3-0d1a-43fc-97ff-b4813dd1f86e",
+          "doc_count": 3257
+        },
+        {
+          "key": "33d00b3b-e0b0-4e22-9a22-83583612240c",
+          "doc_count": 3253
+        },
+        {
+          "key": "a748a0fe-a6ae-4ce7-b88f-4e4ec1dc080c",
+          "doc_count": 3240
+        },
+        {
+          "key": "ef967959-19e5-4e21-8821-89f822d3303b",
+          "doc_count": 3240
+        },
+        {
+          "key": "0c15e83e-79ee-4ee3-86e3-e5f98a51dc11",
+          "doc_count": 3214
+        },
+        {
+          "key": "57a6d741-de89-40b3-a427-9926e19c215e",
+          "doc_count": 3207
+        },
+        {
+          "key": "fc40fabd-0a70-48fa-b142-79990cd259a5",
+          "doc_count": 3157
+        },
+        {
+          "key": "4900d7ce-9442-4305-9889-c9cbbb953eaa",
+          "doc_count": 3154
+        },
+        {
+          "key": "bbc393a6-bbad-4e54-96f6-ccf1ff1282f2",
+          "doc_count": 3142
+        },
+        {
+          "key": "5302ea7f-1c6f-4fc9-8c20-97dd38c0c783",
+          "doc_count": 3125
+        },
+        {
+          "key": "cfe5c00e-bec3-4120-a8eb-62c5353f3e80",
+          "doc_count": 3124
+        },
+        {
+          "key": "9f3bbc7b-c682-4f66-88b3-48eef3a38f38",
+          "doc_count": 3090
+        },
+        {
+          "key": "e85a9948-9c9e-451d-9485-b2b4cb7b73d5",
+          "doc_count": 3073
+        },
+        {
+          "key": "ef2cbc53-5a0d-414c-92a4-7951e5d7d7c6",
+          "doc_count": 3070
+        },
+        {
+          "key": "6d4b658a-90b4-4639-8b06-b7f07637f6aa",
+          "doc_count": 3062
+        },
+        {
+          "key": "40d35f62-cf89-488a-bad3-66e66d38c10c",
+          "doc_count": 3022
+        },
+        {
+          "key": "b20588fd-61f4-4765-8025-30c81a5f4250",
+          "doc_count": 3003
+        },
+        {
+          "key": "08adc6ee-21d1-4619-8094-d728747cd54e",
+          "doc_count": 2998
+        },
+        {
+          "key": "c1cd61c1-9414-4c51-bc16-7f7c24972cde",
+          "doc_count": 2998
+        },
+        {
+          "key": "fd8dae05-5c60-455e-ac8d-ace2649d6cbe",
+          "doc_count": 2996
+        },
+        {
+          "key": "07ff9355-01ec-46d6-954a-d16c87fd6ee8",
+          "doc_count": 2968
+        },
+        {
+          "key": "97b858df-0110-4d27-a891-75e6a0f18938",
+          "doc_count": 2965
+        },
+        {
+          "key": "d81c6ad6-fb8f-4c31-bba3-f2b65f780893",
+          "doc_count": 2961
+        },
+        {
+          "key": "79be41bc-8142-485a-9d57-d6195f9a7c81",
+          "doc_count": 2954
+        },
+        {
+          "key": "5fc62538-9719-4e72-b88a-a268c1459427",
+          "doc_count": 2952
+        },
+        {
+          "key": "abb0a03c-4dcb-4f6f-a31d-55268f63d44c",
+          "doc_count": 2952
+        },
+        {
+          "key": "9c1d51f2-067e-452b-a52b-ea7b03e50e25",
+          "doc_count": 2945
+        },
+        {
+          "key": "9d9b81f1-3a9a-4515-b741-a145293f1fef",
+          "doc_count": 2929
+        },
+        {
+          "key": "ee566f77-2d46-41cb-89e2-7c040d4ca44c",
+          "doc_count": 2911
+        },
+        {
+          "key": "797d5f6c-249c-4354-a709-8bb3a6b7cde8",
+          "doc_count": 2895
+        },
+        {
+          "key": "92c44030-9b38-4433-9883-3d635fd63888",
+          "doc_count": 2880
+        },
+        {
+          "key": "0072bf11-a354-4998-8730-c0cb4cfc9517",
+          "doc_count": 2856
+        },
+        {
+          "key": "8783e947-93cf-4b60-b387-d10642b0eee0",
+          "doc_count": 2829
+        },
+        {
+          "key": "34344d35-1857-4ef3-924e-bfab3c2524fd",
+          "doc_count": 2813
+        },
+        {
+          "key": "5e8863ea-56ec-40f3-8075-d42b35d12e72",
+          "doc_count": 2790
+        },
+        {
+          "key": "64ef2d9d-7ed0-4794-900f-38a73be0ea56",
+          "doc_count": 2789
+        },
+        {
+          "key": "59734d15-8edb-41a4-b3f2-f9bd3407460b",
+          "doc_count": 2788
+        },
+        {
+          "key": "7408ba44-08d7-49ea-b08c-1678b5ea5122",
+          "doc_count": 2788
+        },
+        {
+          "key": "99a0182e-2230-44f6-85e5-d22c3eac45b7",
+          "doc_count": 2781
+        },
+        {
+          "key": "bfe01d36-2a16-46d6-857d-43fd4780dfec",
+          "doc_count": 2779
+        },
+        {
+          "key": "f4214a7a-6793-48e0-ac41-9baff83096d3",
+          "doc_count": 2743
+        },
+        {
+          "key": "2eb8ff2f-4826-4fc3-be68-22d805bcae88",
+          "doc_count": 2742
+        },
+        {
+          "key": "a808b0bb-6826-42a2-9d89-eb5c9f7bfa7a",
+          "doc_count": 2728
+        },
+        {
+          "key": "3eb6d387-985a-4eed-be62-3fcfc26534cd",
+          "doc_count": 2707
+        },
+        {
+          "key": "33bac15d-b1d0-42a1-8801-86149887eeef",
+          "doc_count": 2704
+        },
+        {
+          "key": "3a64a2f1-4880-4c61-b2ad-2fc4dafb9aa5",
+          "doc_count": 2699
+        },
+        {
+          "key": "b62cf6c0-e046-4c3f-9765-d0e046072b0f",
+          "doc_count": 2687
+        },
+        {
+          "key": "a1b2bdfd-00c7-4c31-8046-2c991ca777d0",
+          "doc_count": 2686
+        },
+        {
+          "key": "f3327705-8d69-4d9c-88b7-584a08c74653",
+          "doc_count": 2673
+        },
+        {
+          "key": "7400877a-13b8-423d-9074-5371a8234157",
+          "doc_count": 2665
+        },
+        {
+          "key": "634e3223-6a13-48ff-98d2-95a56f234f32",
+          "doc_count": 2663
+        },
+        {
+          "key": "945d6d7d-c768-4189-be9d-f693104d590c",
+          "doc_count": 2636
+        },
+        {
+          "key": "401fec56-515d-4fa8-87d1-507e742f4f6f",
+          "doc_count": 2627
+        },
+        {
+          "key": "50b4c365-5472-4fe8-8825-b1fa0ac57fb3",
+          "doc_count": 2612
+        },
+        {
+          "key": "73015e30-4a80-4c56-9063-66166ffc84f1",
+          "doc_count": 2610
+        },
+        {
+          "key": "d6f12b28-bb9f-44f9-9000-08f644658bf8",
+          "doc_count": 2568
+        },
+        {
+          "key": "c8f66c18-4cab-41b8-91a7-7c4873e28a67",
+          "doc_count": 2562
+        },
+        {
+          "key": "2ba96485-62cd-453c-a317-e7c220b7202e",
+          "doc_count": 2561
+        },
+        {
+          "key": "1844b78c-58c1-4031-98c9-54f97fc16e09",
+          "doc_count": 2558
+        },
+        {
+          "key": "187a8e18-2f00-4aef-9b15-8fb664a0af44",
+          "doc_count": 2555
+        },
+        {
+          "key": "6d710d01-54f6-448b-bbf9-adee9e46fc3c",
+          "doc_count": 2543
+        },
+        {
+          "key": "d062e531-60e4-46ae-8eb1-8cd7cbf9ce59",
+          "doc_count": 2540
+        },
+        {
+          "key": "a8cafd75-ca3b-42c6-8b8e-52aafa15753b",
+          "doc_count": 2538
+        },
+        {
+          "key": "b26cc2c9-1141-4502-805a-b9dd1d83c321",
+          "doc_count": 2531
+        },
+        {
+          "key": "5d7869be-8526-43d8-af53-f16a15ebadb5",
+          "doc_count": 2519
+        },
+        {
+          "key": "1eb85009-7d5d-4663-8c74-d87b62290365",
+          "doc_count": 2503
+        },
+        {
+          "key": "6f6bf083-d27a-417d-9205-e5a70c2b7a0d",
+          "doc_count": 2503
+        },
+        {
+          "key": "a3173073-2467-4365-9d32-17122929e27e",
+          "doc_count": 2489
+        },
+        {
+          "key": "0fb6618f-f8d6-4361-8b2d-0923d4aa3c09",
+          "doc_count": 2469
+        },
+        {
+          "key": "584e9356-3882-4380-b249-342dd4a11236",
+          "doc_count": 2469
+        },
+        {
+          "key": "dce98228-c00d-4532-a614-c20384e34e24",
+          "doc_count": 2463
+        },
+        {
+          "key": "cb465c2a-3d5e-45b0-ba3f-510a6965b1bb",
+          "doc_count": 2427
+        },
+        {
+          "key": "d2e46893-099f-45eb-9a76-d2a66f43bec8",
+          "doc_count": 2426
+        },
+        {
+          "key": "2829ee78-3ce7-4a2c-936b-8b485b5c41a8",
+          "doc_count": 2424
+        },
+        {
+          "key": "0d05a365-36e8-4150-a350-23ed33f79b17",
+          "doc_count": 2412
+        },
+        {
+          "key": "9a65ce92-d7c5-413c-abf0-b4280282d0a2",
+          "doc_count": 2406
+        },
+        {
+          "key": "4c20f76b-dae3-4980-985d-6c67602dbcf7",
+          "doc_count": 2402
+        },
+        {
+          "key": "5ddcbd44-1802-46b0-bae5-11126409c03d",
+          "doc_count": 2401
+        },
+        {
+          "key": "c359c2e5-cd20-4057-9179-35a7a5b5da72",
+          "doc_count": 2401
+        },
+        {
+          "key": "921cf6ba-3f58-41ac-90fb-33fa4ec6b282",
+          "doc_count": 2398
+        },
+        {
+          "key": "efc8b829-65b0-4fff-b6b2-f1148c68f80d",
+          "doc_count": 2392
+        },
+        {
+          "key": "b5234343-b0f1-472a-9db7-dfa78affd402",
+          "doc_count": 2376
+        },
+        {
+          "key": "383d5325-b1ae-4739-b5ff-8afc4e30a0db",
+          "doc_count": 2312
+        },
+        {
+          "key": "b80d24e8-17ff-4092-88d7-7e5ad11c117a",
+          "doc_count": 2304
+        },
+        {
+          "key": "00aa427f-2b32-4bd8-8bdc-ac46c0bf222d",
+          "doc_count": 2284
+        },
+        {
+          "key": "b1db48d5-22e7-4f5e-bce2-d267b447cdaa",
+          "doc_count": 2277
+        },
+        {
+          "key": "984693b4-6f5b-4290-8d5f-203015967f27",
+          "doc_count": 2255
+        },
+        {
+          "key": "53064db5-a272-46f9-85d2-d1b78e9a3293",
+          "doc_count": 2250
+        },
+        {
+          "key": "9fab87bf-c5a7-4296-acdc-f22859cfe620",
+          "doc_count": 2248
+        },
+        {
+          "key": "b1c7a275-21f6-4b66-895d-d497359b34a1",
+          "doc_count": 2248
+        },
+        {
+          "key": "af4f13cd-f1e8-4e18-ac7a-b0aeee90c749",
+          "doc_count": 2217
+        },
+        {
+          "key": "65d603ef-19be-4d6f-92dc-76c5e4220175",
+          "doc_count": 2194
+        },
+        {
+          "key": "22a10e7e-df5c-486c-bb0f-489005f9c337",
+          "doc_count": 2191
+        },
+        {
+          "key": "e165b318-d5f7-40d5-a0d9-82ba3c31060f",
+          "doc_count": 2176
+        },
+        {
+          "key": "3cf3933f-c230-4e48-bc48-aa8ab47dc388",
+          "doc_count": 2123
+        },
+        {
+          "key": "9d35f82b-c19b-4dce-b296-808598d1fb6b",
+          "doc_count": 2114
+        },
+        {
+          "key": "dad311dc-baec-4ec3-b269-ca5e91ade433",
+          "doc_count": 2103
+        },
+        {
+          "key": "c13a5966-99a3-4383-b9ef-259cf46800fe",
+          "doc_count": 2102
+        },
+        {
+          "key": "350ed733-b782-4195-a5dd-e61e5c82d837",
+          "doc_count": 2091
+        },
+        {
+          "key": "02edea37-e897-409a-a372-8865460ba9c1",
+          "doc_count": 2090
+        },
+        {
+          "key": "0604a91b-bb40-4cd4-a521-c11d3a38681d",
+          "doc_count": 2088
+        },
+        {
+          "key": "a2845484-4243-44a3-8cd3-0a4866513ffc",
+          "doc_count": 2086
+        },
+        {
+          "key": "7c2c5cdc-80e6-49d5-8e95-08fc7da0a370",
+          "doc_count": 2080
+        },
+        {
+          "key": "de7bcb30-71ad-474d-aeed-ee384dc0bf04",
+          "doc_count": 2064
+        },
+        {
+          "key": "aeed0286-ffe4-45b8-a7b9-bcee18361433",
+          "doc_count": 2021
+        },
+        {
+          "key": "833306f7-91b6-4ff7-bc16-0e406334d991",
+          "doc_count": 2014
+        },
+        {
+          "key": "9ed5c28a-3ba3-40f9-9dcf-5a022f8a4da3",
+          "doc_count": 2000
+        },
+        {
+          "key": "aa10c0b4-fed5-46d8-b854-e501412bd9f3",
+          "doc_count": 2000
+        },
+        {
+          "key": "a8f577b2-7c23-4ae8-a61a-ce0e3972bf1a",
+          "doc_count": 1995
+        },
+        {
+          "key": "994b60a2-88f1-49ec-a6da-27d56dfa6f16",
+          "doc_count": 1982
+        },
+        {
+          "key": "c1122f57-9ab9-4552-9393-7d56b0bbe852",
+          "doc_count": 1979
+        },
+        {
+          "key": "eaed5ba6-aa32-4a57-a9e1-afc6b01d1c98",
+          "doc_count": 1959
+        },
+        {
+          "key": "8e5c6e53-4bb7-4540-b287-df79b94681c1",
+          "doc_count": 1952
+        },
+        {
+          "key": "0b065abc-f9a3-400f-a36a-e3bfc4effc82",
+          "doc_count": 1948
+        },
+        {
+          "key": "ab3c6b74-477b-4f79-8711-0643851021f0",
+          "doc_count": 1923
+        },
+        {
+          "key": "56c04958-243b-4428-8213-d98c3c57452f",
+          "doc_count": 1920
+        },
+        {
+          "key": "9421b646-df94-4227-9779-4e2d04c20efd",
+          "doc_count": 1910
+        },
+        {
+          "key": "a0ec3ce6-fc8a-48b7-9105-cecf27602e37",
+          "doc_count": 1907
+        },
+        {
+          "key": "560b2536-a07e-46c0-b179-6ba1ba6f5b20",
+          "doc_count": 1897
+        },
+        {
+          "key": "fb97dfb4-72be-4dc1-9f5a-2faea75341b4",
+          "doc_count": 1895
+        },
+        {
+          "key": "10b23c8c-6a68-456c-a300-5401a49600af",
+          "doc_count": 1889
+        },
+        {
+          "key": "3602074e-1160-46a8-b796-349eb14b598a",
+          "doc_count": 1883
+        },
+        {
+          "key": "d08a71aa-fe87-4bf5-ac68-8e7497bf585c",
+          "doc_count": 1870
+        },
+        {
+          "key": "74473bcd-2107-493d-8a78-c66b5d3e5061",
+          "doc_count": 1863
+        },
+        {
+          "key": "b67747ce-3162-4748-90fc-c7a223410e75",
+          "doc_count": 1863
+        },
+        {
+          "key": "18129adf-b6e3-4288-8ed3-013af1034499",
+          "doc_count": 1860
+        },
+        {
+          "key": "ad913810-d1bb-4a64-a9f8-5c166d0ef974",
+          "doc_count": 1848
+        },
+        {
+          "key": "c16e25c8-1e93-4571-881f-b757d3e48700",
+          "doc_count": 1840
+        },
+        {
+          "key": "7382e087-cdc4-48ff-9a1c-38571e24b124",
+          "doc_count": 1826
+        },
+        {
+          "key": "d3418740-2a9b-4df4-af06-4799c7d27a7c",
+          "doc_count": 1825
+        },
+        {
+          "key": "8ca4e30d-8c92-451f-abe1-7c29429a007c",
+          "doc_count": 1823
+        },
+        {
+          "key": "394dda75-c336-4ca3-acdd-1c2a317d7361",
+          "doc_count": 1821
+        },
+        {
+          "key": "3f428108-a28d-435e-a1ef-de7ac1853087",
+          "doc_count": 1818
+        },
+        {
+          "key": "72f0493a-b4a7-4d0c-a3ea-dab177a95a61",
+          "doc_count": 1817
+        },
+        {
+          "key": "7e43ea77-d2e5-4bdc-a4f7-a4792866f53f",
+          "doc_count": 1807
+        },
+        {
+          "key": "11170c5e-033a-4410-aed1-3dee2458bc43",
+          "doc_count": 1804
+        },
+        {
+          "key": "a2422e89-eee0-4bdc-a6e2-350d21e74534",
+          "doc_count": 1785
+        },
+        {
+          "key": "03e04b8e-1dea-49ac-8a46-4276ddcfed21",
+          "doc_count": 1777
+        },
+        {
+          "key": "013c6135-cb98-45f5-ad86-98e4050481a8",
+          "doc_count": 1770
+        },
+        {
+          "key": "15a1cc29-b66c-4633-ad9c-c2c094b19902",
+          "doc_count": 1749
+        },
+        {
+          "key": "196c4f1c-53f9-480f-a012-dc0522629047",
+          "doc_count": 1743
+        },
+        {
+          "key": "1f2933c1-3f7a-4521-9b16-2c34b369ee95",
+          "doc_count": 1740
+        },
+        {
+          "key": "b8e6077e-ae92-481f-a018-ed18bcefb62d",
+          "doc_count": 1738
+        },
+        {
+          "key": "241d64f1-480a-48ae-8ec2-cd12af4a16e9",
+          "doc_count": 1700
+        },
+        {
+          "key": "47ac1531-5213-4848-a32d-5bb396ab9348",
+          "doc_count": 1688
+        },
+        {
+          "key": "7710b487-1e24-4d65-b062-1651841b8af9",
+          "doc_count": 1684
+        },
+        {
+          "key": "028990be-11ff-4c6b-9684-59cb1e1c3ab6",
+          "doc_count": 1660
+        },
+        {
+          "key": "59428ba2-556f-4179-a9e6-3926f09e0bf3",
+          "doc_count": 1652
+        },
+        {
+          "key": "97bc50fd-b67d-44cb-9cd0-b716e250c9cf",
+          "doc_count": 1650
+        },
+        {
+          "key": "8728ef71-fdcc-4027-8139-38b2c0628fba",
+          "doc_count": 1641
+        },
+        {
+          "key": "d8cccd6e-37fa-407a-8b56-3cfe0614731f",
+          "doc_count": 1640
+        },
+        {
+          "key": "e86d229d-b29c-458c-b01a-f4112270567e",
+          "doc_count": 1640
+        },
+        {
+          "key": "bb875de1-0246-48c2-bd20-8c709262e8b0",
+          "doc_count": 1628
+        },
+        {
+          "key": "c5b01fdb-4b98-482e-ab6f-0b276a483cda",
+          "doc_count": 1627
+        },
+        {
+          "key": "c02ce6fc-a2f3-497e-bc3c-0adce054db72",
+          "doc_count": 1601
+        },
+        {
+          "key": "d4711660-a622-4c15-adb8-608b7ac6a084",
+          "doc_count": 1600
+        },
+        {
+          "key": "3483a248-ef52-4978-a208-4e498f42888a",
+          "doc_count": 1594
+        },
+        {
+          "key": "3a771a31-8cd0-40ac-befc-69509201b61b",
+          "doc_count": 1592
+        },
+        {
+          "key": "2e3a8e5c-eef9-462d-a690-3a91fe111e13",
+          "doc_count": 1575
+        },
+        {
+          "key": "6ac89a16-4604-4a78-9047-dcc57e5c0130",
+          "doc_count": 1572
+        },
+        {
+          "key": "72161544-62e7-4e30-b399-ac8115c3a250",
+          "doc_count": 1564
+        },
+        {
+          "key": "71e55d91-4c0c-4a13-9421-c732348b0a47",
+          "doc_count": 1562
+        },
+        {
+          "key": "ecd540e2-b2b5-452f-b5e8-d54aac884f49",
+          "doc_count": 1559
+        },
+        {
+          "key": "caaa464d-e290-4761-8550-75edc6d00119",
+          "doc_count": 1545
+        },
+        {
+          "key": "080f57e4-505c-4e56-bfad-d1861609f146",
+          "doc_count": 1527
+        },
+        {
+          "key": "799c19c2-dcfb-4a45-b8ce-1e2e50029a85",
+          "doc_count": 1507
+        },
+        {
+          "key": "8291b0f8-11f1-4b84-8d39-65317801676f",
+          "doc_count": 1507
+        },
+        {
+          "key": "2b4ed452-cda9-458a-aaf3-742a07201add",
+          "doc_count": 1506
+        },
+        {
+          "key": "70c60dcf-1fe8-4060-b627-c3f3295a47fa",
+          "doc_count": 1504
+        },
+        {
+          "key": "94b17bab-a41a-4cb2-8ae4-209e31c5144d",
+          "doc_count": 1504
+        },
+        {
+          "key": "853b3473-e9b4-4e2d-a9c9-5b85df1d3b44",
+          "doc_count": 1497
+        },
+        {
+          "key": "8e2f9392-55ac-49f3-bcc2-131a00122626",
+          "doc_count": 1493
+        },
+        {
+          "key": "30c58ee8-97ae-495a-b2ff-4786d24a683a",
+          "doc_count": 1491
+        },
+        {
+          "key": "b78f17de-fe61-4824-845a-beacc34eb23f",
+          "doc_count": 1490
+        },
+        {
+          "key": "ee88d7b1-fd77-4a3e-ba94-d4dca37a90e1",
+          "doc_count": 1467
+        },
+        {
+          "key": "97c1db9d-b3c1-4c05-9b55-e99c37773a29",
+          "doc_count": 1462
+        },
+        {
+          "key": "de41423b-7326-413a-880f-58176ef95ec7",
+          "doc_count": 1458
+        },
+        {
+          "key": "85e930bf-6e90-4700-85d1-4c3330efbafb",
+          "doc_count": 1456
+        },
+        {
+          "key": "6226705f-4867-464d-9fab-4e81ecee731f",
+          "doc_count": 1453
+        },
+        {
+          "key": "b52c8127-5d40-4227-97b3-379ac874848c",
+          "doc_count": 1451
+        },
+        {
+          "key": "2da2091a-dc52-4d1b-82ba-d13fc09e456a",
+          "doc_count": 1450
+        },
+        {
+          "key": "d1b5070b-4c78-4069-9f99-048378a3b140",
+          "doc_count": 1444
+        },
+        {
+          "key": "ca63df90-51f3-4b6e-b3eb-6e15efb34e72",
+          "doc_count": 1441
+        },
+        {
+          "key": "ca93c0e1-287b-464f-8db9-976071b4a401",
+          "doc_count": 1440
+        },
+        {
+          "key": "2cbea272-fd0d-4759-aba6-0183f243447a",
+          "doc_count": 1422
+        },
+        {
+          "key": "3d2b5be0-7c1d-4693-9226-94bc0061123b",
+          "doc_count": 1417
+        },
+        {
+          "key": "7340c0df-8829-4197-9dc7-0328b8e7f5dd",
+          "doc_count": 1415
+        },
+        {
+          "key": "b7a5dadd-7429-489b-9b3b-72abcd9518a3",
+          "doc_count": 1415
+        },
+        {
+          "key": "18e90610-0be2-444d-beed-2929c548215b",
+          "doc_count": 1405
+        },
+        {
+          "key": "1c0e1256-2e97-4332-a9ae-d600e9d293ab",
+          "doc_count": 1405
+        },
+        {
+          "key": "b6d0f953-29b4-41da-a255-2ed07c83edf1",
+          "doc_count": 1403
+        },
+        {
+          "key": "4520451d-bd3b-4095-b777-24a420d442c1",
+          "doc_count": 1402
+        },
+        {
+          "key": "cc9958e5-fa68-402d-a21c-6bbc724e59d4",
+          "doc_count": 1393
+        },
+        {
+          "key": "da067ad9-b545-4701-aa3b-8d2990f8c1c0",
+          "doc_count": 1391
+        },
+        {
+          "key": "b2702e1a-0ec8-4618-8fea-3a51cf213d31",
+          "doc_count": 1390
+        },
+        {
+          "key": "f5118065-6cf3-402d-a35d-8fdd2830f4da",
+          "doc_count": 1387
+        },
+        {
+          "key": "4c003df0-f59b-460d-886a-31088b34141d",
+          "doc_count": 1381
+        },
+        {
+          "key": "1c8ec291-8067-4b48-848b-410c2c768420",
+          "doc_count": 1377
+        },
+        {
+          "key": "5664e8bd-a09a-412f-a71b-434504c2a136",
+          "doc_count": 1377
+        },
+        {
+          "key": "ef30a918-b583-41f1-9ac4-4a37591b515a",
+          "doc_count": 1376
+        },
+        {
+          "key": "2812522a-8fe9-4b30-9ab4-a85e8196e7c8",
+          "doc_count": 1361
+        },
+        {
+          "key": "f87652d3-6a0a-4aac-9419-e2963e10f347",
+          "doc_count": 1360
+        },
+        {
+          "key": "de9a1acc-2ca6-4c36-92af-e7ea8b29c096",
+          "doc_count": 1339
+        },
+        {
+          "key": "9e539693-c61a-4f13-9966-8f001b90d5c9",
+          "doc_count": 1338
+        },
+        {
+          "key": "5a262e5d-0605-4067-ba71-3fd578c3c6bb",
+          "doc_count": 1335
+        },
+        {
+          "key": "df1ba8de-421a-4031-a447-2a6a93f72fa8",
+          "doc_count": 1333
+        },
+        {
+          "key": "4305303f-976d-4074-accc-91e205435cc8",
+          "doc_count": 1332
+        },
+        {
+          "key": "f98ef42a-4d06-4b4f-a284-9c46dd2b9331",
+          "doc_count": 1327
+        },
+        {
+          "key": "fb7db48e-1599-420e-8f10-1f20fe1c6aa3",
+          "doc_count": 1323
+        },
+        {
+          "key": "9576cbeb-8852-44ab-b1c8-6c708f30a7a8",
+          "doc_count": 1322
+        },
+        {
+          "key": "0a410c4a-cd4f-4bd8-b6ba-a0c2baa37622",
+          "doc_count": 1317
+        },
+        {
+          "key": "11f88400-8e44-4592-88e4-9d2ce4f37716",
+          "doc_count": 1313
+        },
+        {
+          "key": "cdb97417-84b2-4414-9b2b-170fd2824612",
+          "doc_count": 1307
+        },
+        {
+          "key": "99e84c7d-dd3c-40d9-9526-54f4342cda95",
+          "doc_count": 1303
+        },
+        {
+          "key": "4965a3ea-45b1-43ff-8afb-be9471b7a56f",
+          "doc_count": 1298
+        },
+        {
+          "key": "59954c3b-4318-4d80-8859-15b3b10ffe5d",
+          "doc_count": 1297
+        },
+        {
+          "key": "ee345eb5-ddeb-4afc-b8de-af6b873519ae",
+          "doc_count": 1293
+        },
+        {
+          "key": "253a8fd3-899b-42e9-abf6-db86c6528808",
+          "doc_count": 1286
+        },
+        {
+          "key": "3399bc0c-500f-41fb-8d52-e2d44bc30ef9",
+          "doc_count": 1282
+        },
+        {
+          "key": "ea9d9c05-11b3-4514-898e-66bd8560ec5b",
+          "doc_count": 1282
+        },
+        {
+          "key": "5d307007-02e3-4c84-9e18-6356b50a5a56",
+          "doc_count": 1280
+        },
+        {
+          "key": "85955977-70f6-4203-93cb-c8958339dab5",
+          "doc_count": 1280
+        },
+        {
+          "key": "231db0f8-ed96-43fa-92d3-146a2f539065",
+          "doc_count": 1272
+        },
+        {
+          "key": "feb74628-8724-466f-8c8c-b3d3b72f2417",
+          "doc_count": 1272
+        },
+        {
+          "key": "53a8ce69-d9b9-4ae2-848a-dab0d4d810d1",
+          "doc_count": 1268
+        },
+        {
+          "key": "f5c38252-89f1-4753-af3a-da8818fe3a86",
+          "doc_count": 1262
+        },
+        {
+          "key": "65c412fe-1f9f-4f10-aa75-9845b66ef235",
+          "doc_count": 1258
+        },
+        {
+          "key": "b0099c3d-bc60-42ae-a9a1-d602a2b1e965",
+          "doc_count": 1242
+        },
+        {
+          "key": "5e28819b-69d8-46e6-abf6-45c4614f94b4",
+          "doc_count": 1229
+        },
+        {
+          "key": "9a861ebe-f8d7-4eb1-a2c8-3006f07cfec2",
+          "doc_count": 1223
+        },
+        {
+          "key": "c353d24a-6b4b-4380-be8f-79a6033f12e6",
+          "doc_count": 1222
+        },
+        {
+          "key": "a9223e1d-7a81-4311-800e-211c5a1b8205",
+          "doc_count": 1217
+        },
+        {
+          "key": "50ca2a08-0e76-4f56-9976-d344dd201a9b",
+          "doc_count": 1213
+        },
+        {
+          "key": "6dfc669f-c5dd-446b-83f6-bcdbd6b255e6",
+          "doc_count": 1201
+        },
+        {
+          "key": "abf5b4f3-ed39-4bb9-acd6-9ee50acac0ad",
+          "doc_count": 1186
+        },
+        {
+          "key": "a4b888a2-94bf-4680-b912-84964a236c82",
+          "doc_count": 1180
+        },
+        {
+          "key": "1da2a87d-4fc7-4233-b127-59cb8d1ca5ee",
+          "doc_count": 1167
+        },
+        {
+          "key": "6ff03009-ca7f-44fe-b207-18a98e862cc3",
+          "doc_count": 1165
+        },
+        {
+          "key": "ec55fc6e-8e4e-4b69-b3b5-1564083bc98c",
+          "doc_count": 1163
+        },
+        {
+          "key": "92393847-2bfb-42e3-9ec3-be1f434b93e6",
+          "doc_count": 1158
+        },
+        {
+          "key": "6fac4ce7-3c5d-4b97-974e-c3c87fee96da",
+          "doc_count": 1153
+        },
+        {
+          "key": "c82309d8-01f5-4502-b664-bd543bf90aee",
+          "doc_count": 1134
+        },
+        {
+          "key": "8f62e9b0-96e5-4d64-8008-b2b8692050db",
+          "doc_count": 1133
+        },
+        {
+          "key": "af8d9012-273c-421c-80ae-00ad098604a0",
+          "doc_count": 1115
+        },
+        {
+          "key": "42fd87a2-bed6-4563-9958-2ed95029d10a",
+          "doc_count": 1099
+        },
+        {
+          "key": "b9d08bac-6b78-484b-9a96-da61552f53a5",
+          "doc_count": 1098
+        },
+        {
+          "key": "de74c9df-b567-4db6-a0be-1bd9add27509",
+          "doc_count": 1094
+        },
+        {
+          "key": "2c00d087-1df6-4744-807d-056be36eed0d",
+          "doc_count": 1089
+        },
+        {
+          "key": "67174355-6ee7-4a4c-af45-60e848973853",
+          "doc_count": 1068
+        },
+        {
+          "key": "7232e59b-b0e1-49cd-9632-b8ae1f49f828",
+          "doc_count": 1058
+        },
+        {
+          "key": "5f74a2b2-6453-446b-99c9-96702e2b4dd6",
+          "doc_count": 1057
+        },
+        {
+          "key": "e9becbae-c612-45ee-9b58-b3b0d063fb24",
+          "doc_count": 1052
+        },
+        {
+          "key": "8cd3a748-7f59-40e9-9cf3-3951e1e6430d",
+          "doc_count": 1047
+        },
+        {
+          "key": "751b5d4c-aba7-4c1f-b0a1-dfe2e9346d1b",
+          "doc_count": 1040
+        },
+        {
+          "key": "e2fda823-8a6e-4bd8-8602-924615373938",
+          "doc_count": 1038
+        },
+        {
+          "key": "4ecc6eb6-5f2f-4b00-8d26-a58bfa0e7f02",
+          "doc_count": 1035
+        },
+        {
+          "key": "908ccd97-c8e1-4c7c-9871-7a80e2940032",
+          "doc_count": 1032
+        },
+        {
+          "key": "b0a3324f-849a-43bf-811a-9dd10f04806b",
+          "doc_count": 1032
+        },
+        {
+          "key": "fb4ff58a-9f16-4a42-af52-0d9a5f08f630",
+          "doc_count": 1031
+        },
+        {
+          "key": "19281ae4-8184-4827-b4db-7336a74cf1a0",
+          "doc_count": 1023
+        },
+        {
+          "key": "729795c1-560e-4248-8e7e-29547eb2491a",
+          "doc_count": 1023
+        },
+        {
+          "key": "f9303b78-ecee-4d9e-a49d-65cea976bc56",
+          "doc_count": 1016
+        },
+        {
+          "key": "fa83c2bd-926c-42f1-8cd4-d57c5fd21f33",
+          "doc_count": 1015
+        },
+        {
+          "key": "c9316f11-d955-4472-a276-6a26a6514590",
+          "doc_count": 1013
+        },
+        {
+          "key": "0403a198-cdae-42d8-bb83-9a6b143b2693",
+          "doc_count": 1009
+        },
+        {
+          "key": "7583a361-cd91-4d25-9bbe-d6760020c298",
+          "doc_count": 1005
+        },
+        {
+          "key": "85c49a26-53b6-4bce-b33c-d00bd651d583",
+          "doc_count": 1005
+        },
+        {
+          "key": "1e69489f-c371-426e-b0ee-b9eb7ad7c4a6",
+          "doc_count": 1000
+        },
+        {
+          "key": "15258831-7ed9-4d24-a324-ac85df1732e9",
+          "doc_count": 999
+        },
+        {
+          "key": "dbd36c3b-ae05-414e-ada6-76aa7c52eb6f",
+          "doc_count": 996
+        },
+        {
+          "key": "860fb49c-e09d-4ac6-a18a-7b9cb3e3d191",
+          "doc_count": 992
+        },
+        {
+          "key": "641115f4-abb8-4658-8f38-2db1e7b17270",
+          "doc_count": 987
+        },
+        {
+          "key": "af60ac71-fbfb-4648-95fb-0eb5fe24765b",
+          "doc_count": 984
+        },
+        {
+          "key": "d9d38b3f-5173-4051-98a6-2efad16fc8da",
+          "doc_count": 968
+        },
+        {
+          "key": "9d9016ef-a88f-4312-a0bf-638fc4be53ba",
+          "doc_count": 965
+        },
+        {
+          "key": "755d800f-0156-4139-b813-27369a1ebf32",
+          "doc_count": 922
+        },
+        {
+          "key": "82c60e09-2939-4896-9ce9-5c63fe19cac9",
+          "doc_count": 920
+        },
+        {
+          "key": "ba08b40c-8f92-4bc4-b3f3-84a63590fbae",
+          "doc_count": 917
+        },
+        {
+          "key": "0219b24b-8357-4281-bad4-526e4a93ead4",
+          "doc_count": 916
+        },
+        {
+          "key": "5fb78d38-455f-4437-b8b6-95af83e5f3df",
+          "doc_count": 906
+        },
+        {
+          "key": "d2b966fd-f02a-4bce-a815-35deea5fce1c",
+          "doc_count": 895
+        },
+        {
+          "key": "997c4dda-0465-40c0-af8d-67f8f90dea3b",
+          "doc_count": 894
+        },
+        {
+          "key": "8f11280d-8a77-464e-b59a-4b91d260d451",
+          "doc_count": 880
+        },
+        {
+          "key": "da46ceaf-6084-48da-9e53-4d1ae2a51ddf",
+          "doc_count": 880
+        },
+        {
+          "key": "185e82f5-6b63-4eae-9b91-fb9f73a3d494",
+          "doc_count": 878
+        },
+        {
+          "key": "466ee466-51d5-4bab-99e6-92e534e6877b",
+          "doc_count": 870
+        },
+        {
+          "key": "886f3b02-e2f2-4c49-9ace-df25bf5d091a",
+          "doc_count": 869
+        },
+        {
+          "key": "dac3d053-05ac-4203-99db-c3bc24502525",
+          "doc_count": 869
+        },
+        {
+          "key": "b7704325-2dfd-4fcf-8193-01b5bdce825d",
+          "doc_count": 866
+        },
+        {
+          "key": "98f5f2e1-1d43-4db4-830a-9833c47838cc",
+          "doc_count": 864
+        },
+        {
+          "key": "76e76ec1-e0fd-41ab-aefd-b90430a694ac",
+          "doc_count": 855
+        },
+        {
+          "key": "688b7731-d818-4063-b29d-666bd0024b8b",
+          "doc_count": 853
+        },
+        {
+          "key": "30a62ff2-0323-46a5-8441-88eb1b572a14",
+          "doc_count": 852
+        },
+        {
+          "key": "4efa66cf-8adb-414b-b78c-8e651d20f84d",
+          "doc_count": 851
+        },
+        {
+          "key": "8e4ff036-d38e-455f-a0fe-4ac50823f4fb",
+          "doc_count": 851
+        },
+        {
+          "key": "df63ff28-de42-4d24-af67-5fa4c6c5a6d0",
+          "doc_count": 850
+        },
+        {
+          "key": "76aab8f5-69d4-4ce9-b0c9-837b64a2dd06",
+          "doc_count": 845
+        },
+        {
+          "key": "38de3690-984e-4f0c-84a5-be0e7b8b6f33",
+          "doc_count": 839
+        },
+        {
+          "key": "6f2cd35e-9ee6-44d5-b182-cdd19d01a4c3",
+          "doc_count": 834
+        },
+        {
+          "key": "81dc7cdb-66be-4683-ae79-068a784378b1",
+          "doc_count": 832
+        },
+        {
+          "key": "9a0d6dc0-689f-4327-8cf3-1c530443f49a",
+          "doc_count": 824
+        },
+        {
+          "key": "49e13482-50cc-43fe-b7cc-567a4acb703e",
+          "doc_count": 822
+        },
+        {
+          "key": "5f681b65-9a7e-4b79-8a17-fc95cc26b837",
+          "doc_count": 821
+        },
+        {
+          "key": "4ce170f6-0d78-4323-ab12-6aaf89c30697",
+          "doc_count": 818
+        },
+        {
+          "key": "41350373-fc6f-4dd9-b908-27805fff9155",
+          "doc_count": 817
+        },
+        {
+          "key": "2741952c-1674-49cf-9e48-a8d97ef40819",
+          "doc_count": 815
+        },
+        {
+          "key": "c19c539d-2f8c-4a99-b956-15921ec345ed",
+          "doc_count": 803
+        },
+        {
+          "key": "3ef3ced6-9fa0-4d30-98b4-2d1337d2477d",
+          "doc_count": 794
+        },
+        {
+          "key": "c3a7b339-122e-4fe9-8851-371b1fdf584e",
+          "doc_count": 791
+        },
+        {
+          "key": "f055caf8-90f1-4dca-af32-0be193f53438",
+          "doc_count": 788
+        },
+        {
+          "key": "c882214e-8ba4-482b-9998-070b5547dc54",
+          "doc_count": 778
+        },
+        {
+          "key": "f8d0dae7-8927-4f5f-9538-ecddce2e614f",
+          "doc_count": 778
+        },
+        {
+          "key": "0a0e4054-0568-4352-9ef1-baa72d577ee5",
+          "doc_count": 771
+        },
+        {
+          "key": "382ecf04-5613-4825-99d6-a4665a93fc7e",
+          "doc_count": 762
+        },
+        {
+          "key": "66e4324f-e76d-4ba9-b1a1-c06e1141301b",
+          "doc_count": 761
+        },
+        {
+          "key": "2936c837-ad9f-40d8-bea0-58b2a635c637",
+          "doc_count": 760
+        },
+        {
+          "key": "8c85d229-23d8-410b-8be1-90e8b134a6ba",
+          "doc_count": 760
+        },
+        {
+          "key": "538bdd33-b616-4825-8542-7033cc8a185f",
+          "doc_count": 759
+        },
+        {
+          "key": "8a9faad0-fa47-4229-8e05-27d654953dc1",
+          "doc_count": 756
+        },
+        {
+          "key": "07589481-ba4d-4521-b6f4-4816bfdcde55",
+          "doc_count": 751
+        },
+        {
+          "key": "49db9725-7bdc-4c38-8548-c32994e811c1",
+          "doc_count": 750
+        },
+        {
+          "key": "1f8c7572-5cda-44be-9a78-0658217fc279",
+          "doc_count": 749
+        },
+        {
+          "key": "781b461a-2788-4fa6-b3df-bbed9447f5a3",
+          "doc_count": 746
+        },
+        {
+          "key": "9ab48e8d-be42-41c3-8a37-ed8c4cf27b9b",
+          "doc_count": 742
+        },
+        {
+          "key": "b027383d-6705-4d06-8514-db6ef16efdb5",
+          "doc_count": 742
+        },
+        {
+          "key": "11853b5e-4c9b-4e20-ad80-98715aaeb146",
+          "doc_count": 741
+        },
+        {
+          "key": "c1101236-fd32-456a-8d2b-770ae7538224",
+          "doc_count": 738
+        },
+        {
+          "key": "73d176ad-883f-4ec7-91c0-c0bdae8b8a6c",
+          "doc_count": 736
+        },
+        {
+          "key": "3b54500b-069c-4a27-bc64-9a0c8a1fd2be",
+          "doc_count": 735
+        },
+        {
+          "key": "fb4cc282-eba5-4156-b7c7-df41e0581b68",
+          "doc_count": 733
+        },
+        {
+          "key": "0f99d9f4-ba3e-46e2-afa8-14f9251a94f7",
+          "doc_count": 732
+        },
+        {
+          "key": "1b42f60a-906a-4639-96e7-c5fcfc3231c3",
+          "doc_count": 718
+        },
+        {
+          "key": "c4f0b43b-1a43-43bc-b302-2aecd37d8054",
+          "doc_count": 718
+        },
+        {
+          "key": "6eb1dbc4-ea33-456b-8782-0a953900d37a",
+          "doc_count": 717
+        },
+        {
+          "key": "ba0cbea4-9a25-49de-bfb4-02201b392f5e",
+          "doc_count": 715
+        },
+        {
+          "key": "9c4f4765-2d02-452c-9ae9-cdd1d4846d5d",
+          "doc_count": 712
+        },
+        {
+          "key": "fb88e9c7-3e72-4a80-b247-c9f9452ecbaa",
+          "doc_count": 710
+        },
+        {
+          "key": "55ddd3f9-0e9a-40e8-9e8f-d3a3ab871434",
+          "doc_count": 702
+        },
+        {
+          "key": "a2f11cb7-2862-4d0d-aefd-47ea67efd8fd",
+          "doc_count": 702
+        },
+        {
+          "key": "420eaa67-a376-49ae-bcf8-52edffc98f14",
+          "doc_count": 699
+        },
+        {
+          "key": "c4306d83-64da-4a45-bcb4-efd743caa2a3",
+          "doc_count": 688
+        },
+        {
+          "key": "0bd3c741-55bd-4fd1-ae3c-4cbfd82ff14e",
+          "doc_count": 684
+        },
+        {
+          "key": "5a5ebf30-9472-4abd-a600-c116ddc10b9f",
+          "doc_count": 677
+        },
+        {
+          "key": "90935586-d4ef-4370-b2c4-713cdb85ab8b",
+          "doc_count": 673
+        },
+        {
+          "key": "ff0d1543-247c-4039-a8ff-cf4fc224c449",
+          "doc_count": 670
+        },
+        {
+          "key": "e2b852a7-66e6-4115-bd49-982d8d6df6ed",
+          "doc_count": 663
+        },
+        {
+          "key": "4e0a5514-829d-441a-9148-8064e971315c",
+          "doc_count": 661
+        },
+        {
+          "key": "41800344-33b3-4201-b9d2-cabbbf564fbc",
+          "doc_count": 649
+        },
+        {
+          "key": "3bbf3659-4b21-40b7-b74f-f17a60097154",
+          "doc_count": 648
+        },
+        {
+          "key": "c530ad19-9847-4ea7-a807-f6753c3936d6",
+          "doc_count": 646
+        },
+        {
+          "key": "c6e89321-fc23-4cba-ad79-be3e52edfb6d",
+          "doc_count": 644
+        },
+        {
+          "key": "ac3660d8-492b-49d0-8652-c4f7100648b0",
+          "doc_count": 635
+        },
+        {
+          "key": "1599bdcc-9eec-4d68-a2c4-83e2c2e7d9c6",
+          "doc_count": 624
+        },
+        {
+          "key": "c96ca51c-908e-41cc-ae10-ac1fb72ca3d9",
+          "doc_count": 623
+        },
+        {
+          "key": "d6b13e38-15e2-4717-b337-ca1085948ede",
+          "doc_count": 622
+        },
+        {
+          "key": "e78939ad-42a2-4908-b914-baf5a33fabe0",
+          "doc_count": 620
+        },
+        {
+          "key": "984cbaa8-d801-4aa9-ad57-ec469f103a2f",
+          "doc_count": 618
+        },
+        {
+          "key": "c4b0239c-44fd-417a-8885-d14830c11ffb",
+          "doc_count": 610
+        },
+        {
+          "key": "80dcaaae-9e3c-4000-b8bf-e1e29a5da9a4",
+          "doc_count": 609
+        },
+        {
+          "key": "73c8068d-07f8-4c8e-a7df-d20a29ad21f9",
+          "doc_count": 604
+        },
+        {
+          "key": "9ae0d5de-ed81-4d76-88c8-2b980289f04a",
+          "doc_count": 586
+        },
+        {
+          "key": "6db3622e-9eab-4b8e-8625-ea71a2a11c13",
+          "doc_count": 578
+        },
+        {
+          "key": "d767f759-af64-4464-8614-c77ca44cad8d",
+          "doc_count": 577
+        },
+        {
+          "key": "361fbabf-9ee1-4e16-8926-0caaec3afdf9",
+          "doc_count": 570
+        },
+        {
+          "key": "95c52c0c-c3d3-46d0-9515-cb5cc9423f6a",
+          "doc_count": 569
+        },
+        {
+          "key": "d2a34fa6-6ecb-4493-85d4-3ba7829e7c08",
+          "doc_count": 569
+        },
+        {
+          "key": "4bdf0ada-c6fa-4600-b61d-86bec23123dd",
+          "doc_count": 568
+        },
+        {
+          "key": "c44e18ab-837b-4a58-b8df-dc521a173029",
+          "doc_count": 565
+        },
+        {
+          "key": "ad31f8cf-b9ae-422a-9ad1-605b76bdaa26",
+          "doc_count": 564
+        },
+        {
+          "key": "4cdf5c2f-1a44-4fd5-bdd8-de08c8a660e2",
+          "doc_count": 563
+        },
+        {
+          "key": "3e725fee-3ca5-4344-911e-53c6279fd346",
+          "doc_count": 560
+        },
+        {
+          "key": "6e5548ba-77a9-43e0-b913-0a5ad1b2e4b2",
+          "doc_count": 560
+        },
+        {
+          "key": "7f1d48a1-3e44-440a-8cf9-034977f32670",
+          "doc_count": 557
+        },
+        {
+          "key": "7f7939c8-5276-4fbb-b12c-de89a5a8044f",
+          "doc_count": 555
+        },
+        {
+          "key": "2fe53355-8ec5-4d00-ac6f-85d49c2af7a4",
+          "doc_count": 552
+        },
+        {
+          "key": "dcf848dc-3794-487e-ae84-5a322be2e69d",
+          "doc_count": 546
+        },
+        {
+          "key": "aa977d4a-0dd6-4441-87d4-5efb60435a0b",
+          "doc_count": 545
+        },
+        {
+          "key": "e1520949-52f7-45ca-abe9-7b55c406ea2d",
+          "doc_count": 545
+        },
+        {
+          "key": "699a6c55-fded-431b-8657-a0239b21e147",
+          "doc_count": 543
+        },
+        {
+          "key": "3f0c10ea-bbbc-4250-b8cd-8bf2c2f397d4",
+          "doc_count": 542
+        },
+        {
+          "key": "47e638be-2983-4d22-b05d-260dd5881e9c",
+          "doc_count": 531
+        },
+        {
+          "key": "539721d9-f5f8-489b-a816-abc28b2748e8",
+          "doc_count": 531
+        },
+        {
+          "key": "0a2d0c9f-985b-4e21-973c-621427d93f70",
+          "doc_count": 506
+        },
+        {
+          "key": "0b49ad25-2508-4c2f-a249-b859a06188df",
+          "doc_count": 506
+        },
+        {
+          "key": "feec2eee-841a-47d3-9751-df5f28cdd366",
+          "doc_count": 506
+        },
+        {
+          "key": "9f4ed3ee-33f7-47e9-a4a5-a1224fec2b6e",
+          "doc_count": 503
+        },
+        {
+          "key": "df4d8fd5-7b9c-4136-84e8-647441fc9c12",
+          "doc_count": 503
+        },
+        {
+          "key": "2ee56f8c-db1d-43aa-bfb7-3fb2a19601df",
+          "doc_count": 500
+        },
+        {
+          "key": "279f3d11-4df4-4149-8350-cb357cfd17e6",
+          "doc_count": 495
+        },
+        {
+          "key": "061dfaff-0c45-459e-ac56-738fe4cbe213",
+          "doc_count": 493
+        },
+        {
+          "key": "d29aa22a-03d0-4b01-b18b-fec07cea3db8",
+          "doc_count": 493
+        },
+        {
+          "key": "12e36192-5f03-4d22-904a-18025d3b5339",
+          "doc_count": 491
+        },
+        {
+          "key": "264e9ed8-1408-4121-9968-34cc6af127e8",
+          "doc_count": 487
+        },
+        {
+          "key": "85ae9fb4-de87-41ce-abb3-44fda2fb24a8",
+          "doc_count": 485
+        },
+        {
+          "key": "ad54388f-ad6c-4b88-a718-4a25ad06a06f",
+          "doc_count": 483
+        },
+        {
+          "key": "0cd685ef-a90b-4757-823b-95330e99adb0",
+          "doc_count": 478
+        },
+        {
+          "key": "f271128e-2e79-430b-81a4-a92ec7c969b8",
+          "doc_count": 474
+        },
+        {
+          "key": "084dbc24-8fbf-4630-a6cb-65a514e3352d",
+          "doc_count": 471
+        },
+        {
+          "key": "1a521b08-c325-42c1-8fb4-1f31f7baa9fb",
+          "doc_count": 463
+        },
+        {
+          "key": "c47957d1-795f-47fe-8a1d-a20ac0a73d2c",
+          "doc_count": 463
+        },
+        {
+          "key": "0ee18084-d0dd-4267-8866-2633bba541f7",
+          "doc_count": 457
+        },
+        {
+          "key": "83bc4996-1baa-4d78-b617-b84c9fe42439",
+          "doc_count": 454
+        },
+        {
+          "key": "08fdc20d-be37-4dc4-97ef-abddffdc825a",
+          "doc_count": 447
+        },
+        {
+          "key": "57b1a2a3-78ab-4e69-a77e-a8fd4394ee5a",
+          "doc_count": 447
+        },
+        {
+          "key": "11f5ea79-3522-4aad-ad90-c91e7ed93383",
+          "doc_count": 445
+        },
+        {
+          "key": "e2a12ef3-cf03-4ce4-8aff-802ccf2aec1d",
+          "doc_count": 441
+        },
+        {
+          "key": "e9607b87-6dcb-4ffa-a4bf-d17ac197ca70",
+          "doc_count": 440
+        },
+        {
+          "key": "b89eca60-6b60-480b-a4aa-143132d2d973",
+          "doc_count": 430
+        },
+        {
+          "key": "edba82ff-204c-4800-98e5-b898848b0c07",
+          "doc_count": 430
+        },
+        {
+          "key": "9bd4ff72-1cb2-431f-bf7b-b5d47e08cc02",
+          "doc_count": 425
+        },
+        {
+          "key": "f3a5ec1a-49dd-4a52-8bd8-67cacae7a7ac",
+          "doc_count": 425
+        },
+        {
+          "key": "9d52a7c1-2e4e-4491-9dbd-153094e77f40",
+          "doc_count": 423
+        },
+        {
+          "key": "4efa0623-a625-4949-aea4-7cb60a99b6f8",
+          "doc_count": 422
+        },
+        {
+          "key": "cd9e44d9-40cd-4a75-ab9c-4db2ac9e87ea",
+          "doc_count": 421
+        },
+        {
+          "key": "8478c770-81ca-4586-a2b2-6b9373b83ee4",
+          "doc_count": 420
+        },
+        {
+          "key": "e40bcf8a-0d64-4d88-a02d-fa047b195e8b",
+          "doc_count": 420
+        },
+        {
+          "key": "9c5e903b-7d8b-4d06-825d-5857ab7d61b5",
+          "doc_count": 413
+        },
+        {
+          "key": "8f886a6c-a477-42b0-8587-db4832177be9",
+          "doc_count": 412
+        },
+        {
+          "key": "71ba86a8-8666-474d-b89a-7bcf15ab338a",
+          "doc_count": 398
+        },
+        {
+          "key": "a9d290d5-93cd-42da-9f99-377e20af72c2",
+          "doc_count": 398
+        },
+        {
+          "key": "0bada388-4adf-4b8c-b733-0a1bfc7c233c",
+          "doc_count": 390
+        },
+        {
+          "key": "9425666e-ca07-494e-a6c7-27185389098b",
+          "doc_count": 387
+        },
+        {
+          "key": "e5f377de-c662-4eec-a4d4-b41b18441f3a",
+          "doc_count": 381
+        },
+        {
+          "key": "0a8f691f-004d-41d8-89fb-9f808a8268c5",
+          "doc_count": 379
+        },
+        {
+          "key": "a7463c8a-27f0-485e-b794-fb78d94beda7",
+          "doc_count": 378
+        },
+        {
+          "key": "9475a9e1-cd56-4f5c-8d21-4206b088231b",
+          "doc_count": 374
+        },
+        {
+          "key": "d39addaf-58af-414f-94a4-e04bbf60d0d3",
+          "doc_count": 374
+        },
+        {
+          "key": "fd36e434-8c4d-4d97-a15d-e4d55f312d73",
+          "doc_count": 370
+        },
+        {
+          "key": "8cae9490-b1c1-4199-a44e-3a1396666072",
+          "doc_count": 361
+        },
+        {
+          "key": "8ef66009-4c41-45a1-a2c1-4555da6d8e29",
+          "doc_count": 357
+        },
+        {
+          "key": "ccb7a859-069a-49d4-962c-8e43037bd18d",
+          "doc_count": 357
+        },
+        {
+          "key": "482a6157-ef46-456c-8a83-6be0f90048a6",
+          "doc_count": 352
+        },
+        {
+          "key": "f4573d80-dd92-4337-9005-ba71e8a8563a",
+          "doc_count": 350
+        },
+        {
+          "key": "07c47dd3-a0a9-434a-b144-71c32996f278",
+          "doc_count": 343
+        },
+        {
+          "key": "9dab6ff1-4fec-463b-a7bf-2a28ae708ff1",
+          "doc_count": 341
+        },
+        {
+          "key": "701ab711-6c81-4142-96f4-bbef63fe92b1",
+          "doc_count": 336
+        },
+        {
+          "key": "cc05ec4b-2d82-4d89-a43c-e313c8641cf5",
+          "doc_count": 334
+        },
+        {
+          "key": "99c4ec83-ec62-42b5-b745-4bdf7cc2c669",
+          "doc_count": 329
+        },
+        {
+          "key": "72cf005e-4a65-4b22-b418-899ce8af8cfc",
+          "doc_count": 325
+        },
+        {
+          "key": "7e74ff72-c969-4ab6-bdf4-b3ec60d65c48",
+          "doc_count": 314
+        },
+        {
+          "key": "8fc295af-ccc7-4029-ab7d-d25a02ec9d4a",
+          "doc_count": 310
+        },
+        {
+          "key": "80d86dbf-8de3-4c1c-83b5-7df2b2103971",
+          "doc_count": 308
+        },
+        {
+          "key": "0575c5db-b3b9-42e6-9317-6e0c5ab56083",
+          "doc_count": 305
+        },
+        {
+          "key": "314f66a9-2b8f-4085-b10c-0f083ce2f1eb",
+          "doc_count": 304
+        },
+        {
+          "key": "ccba425a-25e0-4d94-8fde-3890be03ae1b",
+          "doc_count": 304
+        },
+        {
+          "key": "29b8da72-4420-4f65-b755-a006a23cf65a",
+          "doc_count": 302
+        },
+        {
+          "key": "b293a647-5fb8-4b82-bf5b-571e7d6fad03",
+          "doc_count": 302
+        },
+        {
+          "key": "06f009f9-6f9a-4391-97ed-85f4d9fb3df0",
+          "doc_count": 300
+        },
+        {
+          "key": "58d0090c-167e-4d7a-8ad5-c50681626692",
+          "doc_count": 293
+        },
+        {
+          "key": "95e9354e-9f06-4156-b69d-0279ae1f7baa",
+          "doc_count": 293
+        },
+        {
+          "key": "5d8e5fc0-facb-47db-8688-b0f9768238b0",
+          "doc_count": 292
+        },
+        {
+          "key": "7781cb6c-e687-4632-a8d8-b1a593689cb5",
+          "doc_count": 292
+        },
+        {
+          "key": "8712f032-61a0-4257-85b2-091b1e871db5",
+          "doc_count": 288
+        },
+        {
+          "key": "e1c453ac-0479-405c-9742-03a511b33e60",
+          "doc_count": 283
+        },
+        {
+          "key": "902d6b61-4eec-4e87-89e0-9494117ef7c6",
+          "doc_count": 282
+        },
+        {
+          "key": "e27dc54d-8114-4927-b400-694caab9872e",
+          "doc_count": 280
+        },
+        {
+          "key": "8ce0abe6-4231-4e5d-b8ac-60fc3ea020a7",
+          "doc_count": 277
+        },
+        {
+          "key": "dbb14b3f-3a6b-4f3c-872d-9a5a28064a61",
+          "doc_count": 265
+        },
+        {
+          "key": "b33e9dc3-8e86-40ab-a0bd-d11d817ea370",
+          "doc_count": 260
+        },
+        {
+          "key": "3d4401cb-b3dd-48bd-912a-709bb4ecf5f8",
+          "doc_count": 259
+        },
+        {
+          "key": "77d89822-9c2d-47b8-ab06-62819d13d377",
+          "doc_count": 248
+        },
+        {
+          "key": "3c6099e4-3a0c-44c8-942a-f44860aea12b",
+          "doc_count": 242
+        },
+        {
+          "key": "20b99ca1-9efa-429a-975a-f8677b3d6f41",
+          "doc_count": 241
+        },
+        {
+          "key": "c7883ffb-d381-4748-9694-e5abdaa46dbc",
+          "doc_count": 241
+        },
+        {
+          "key": "9357e02f-20fc-4bc5-9bcb-dc8abcbebf16",
+          "doc_count": 240
+        },
+        {
+          "key": "67bd4898-23ba-45b8-bc44-8efe56eaf92a",
+          "doc_count": 238
+        },
+        {
+          "key": "0df55e93-0fce-4ba6-a344-1d9918b60816",
+          "doc_count": 233
+        },
+        {
+          "key": "03e291b1-e74e-489a-8ec9-d23ff481c13c",
+          "doc_count": 232
+        },
+        {
+          "key": "00049fe7-5ca2-4936-be50-c736221ef186",
+          "doc_count": 228
+        },
+        {
+          "key": "08524f6f-f3f9-4cad-9835-3fe3407ce026",
+          "doc_count": 219
+        },
+        {
+          "key": "433d3c37-8dde-42e4-a344-2cb6605c5da2",
+          "doc_count": 214
+        },
+        {
+          "key": "c1814060-b6f8-43c3-8d17-e13d096c389c",
+          "doc_count": 211
+        },
+        {
+          "key": "b94e389e-a791-4d2b-83de-0d705b5f2e88",
+          "doc_count": 210
+        },
+        {
+          "key": "0da18fe6-2e2a-43fc-9d2a-ffb2cefc05c0",
+          "doc_count": 205
+        },
+        {
+          "key": "107eb510-ccbf-4842-a835-b0543b9fe3c0",
+          "doc_count": 199
+        },
+        {
+          "key": "67ddac20-b412-42c3-bbf4-57dfa68eef7a",
+          "doc_count": 199
+        },
+        {
+          "key": "6aca6f67-a2e9-440d-a503-9501db6e6f36",
+          "doc_count": 198
+        },
+        {
+          "key": "9204dc40-4014-4738-b12b-1782c63eb163",
+          "doc_count": 196
+        },
+        {
+          "key": "07b7085e-90c6-446b-bf05-70dd9ce77ecb",
+          "doc_count": 195
+        },
+        {
+          "key": "b9100361-3f7b-4da0-a146-a2ea092adcb1",
+          "doc_count": 195
+        },
+        {
+          "key": "c2c93e11-9235-40b8-b439-895e92ddb5d8",
+          "doc_count": 187
+        },
+        {
+          "key": "03eac319-23c7-429e-9fa4-480640007d62",
+          "doc_count": 183
+        },
+        {
+          "key": "e7080e87-d140-4014-85ea-da02d70c6fa1",
+          "doc_count": 182
+        },
+        {
+          "key": "e458a753-550e-4103-abbe-53aa9d33b9b4",
+          "doc_count": 181
+        },
+        {
+          "key": "8aca64de-cccc-4496-bdcb-7f3720cb586d",
+          "doc_count": 180
+        },
+        {
+          "key": "aa53dc91-0cf2-4714-a6e0-f00f9139dcd8",
+          "doc_count": 180
+        },
+        {
+          "key": "29388da4-4d07-4aff-9e90-560556b0b0db",
+          "doc_count": 179
+        },
+        {
+          "key": "3e3a7f7d-cbec-4704-8c2d-70a342bc7d07",
+          "doc_count": 179
+        },
+        {
+          "key": "e8ba42b7-c4e4-4e57-aca8-58768f8f5f72",
+          "doc_count": 176
+        },
+        {
+          "key": "12346a3e-f54e-4dcf-b43d-ad40566a741a",
+          "doc_count": 173
+        },
+        {
+          "key": "9b62118d-9b90-46b1-854d-06a5a9a22a90",
+          "doc_count": 169
+        },
+        {
+          "key": "5076f892-a05d-4018-9c2c-d537a22095af",
+          "doc_count": 168
+        },
+        {
+          "key": "384a1909-f66c-4551-9b26-ea985cd9ccd8",
+          "doc_count": 167
+        },
+        {
+          "key": "d7dc7e86-062e-44e3-a1a6-0f8e4e0b296a",
+          "doc_count": 163
+        },
+        {
+          "key": "35655e6c-afef-44ed-ac58-c2dd75cf1248",
+          "doc_count": 162
+        },
+        {
+          "key": "692a33d6-cebb-4b16-873a-39c26f2c5a8f",
+          "doc_count": 162
+        },
+        {
+          "key": "81843c4f-38cd-488e-867a-28665ad54b36",
+          "doc_count": 162
+        },
+        {
+          "key": "d5faeefc-956b-4724-ac1a-b46d489de01d",
+          "doc_count": 162
+        },
+        {
+          "key": "dd2c002f-1f3f-41a5-a483-0849ca798049",
+          "doc_count": 159
+        },
+        {
+          "key": "312cf3f1-2913-4c63-9ba8-0b870cd3c120",
+          "doc_count": 158
+        },
+        {
+          "key": "4328cd7c-810d-45c1-aa21-0bcb98225611",
+          "doc_count": 156
+        },
+        {
+          "key": "8a54c5fa-2900-4859-a2d6-1b7faedafac4",
+          "doc_count": 156
+        },
+        {
+          "key": "e6c7d9d7-1550-4678-bae3-a4138bc48a9e",
+          "doc_count": 156
+        },
+        {
+          "key": "99170e98-19d7-4e9e-abd1-4190c5d54b6f",
+          "doc_count": 155
+        },
+        {
+          "key": "6acaebd6-e8d2-454a-8f50-e7a6734b8c79",
+          "doc_count": 152
+        },
+        {
+          "key": "ef02b508-69db-449a-a87e-01e4afadec89",
+          "doc_count": 151
+        },
+        {
+          "key": "3d31a3c7-b074-4ab9-a2a2-7f491f9446a9",
+          "doc_count": 150
+        },
+        {
+          "key": "8858de59-2aa5-4938-8c27-ed9973ac7c98",
+          "doc_count": 150
+        },
+        {
+          "key": "e1c7bc41-50a4-4723-b8b3-f970844ffb65",
+          "doc_count": 150
+        },
+        {
+          "key": "ea038139-f569-477f-a168-9b26d3f49f1d",
+          "doc_count": 150
+        },
+        {
+          "key": "ee8a365e-25fd-4505-a154-af6f290c127a",
+          "doc_count": 150
+        },
+        {
+          "key": "4dfb5828-3653-4604-ac00-db1e1da98b02",
+          "doc_count": 148
+        },
+        {
+          "key": "7fa09825-a2b5-462c-8f7d-d0765a083754",
+          "doc_count": 143
+        },
+        {
+          "key": "a2e28c8c-78c0-4352-9dfd-d3d6d2c6ee41",
+          "doc_count": 143
+        },
+        {
+          "key": "c6c6ee10-c7ce-41a9-9552-7984654b87ce",
+          "doc_count": 142
+        },
+        {
+          "key": "6f5f1bc1-997e-47bc-add6-64bc4a7769b9",
+          "doc_count": 141
+        },
+        {
+          "key": "d3412433-4df9-4828-89e0-73956898f749",
+          "doc_count": 140
+        },
+        {
+          "key": "b3f10d7b-6763-4f79-9789-f6abc68b9720",
+          "doc_count": 139
+        },
+        {
+          "key": "4c46db9d-74d7-4e45-9ed2-0da40ec6b44f",
+          "doc_count": 135
+        },
+        {
+          "key": "b3d53973-5bac-432a-90d3-7956baa09c5d",
+          "doc_count": 128
+        },
+        {
+          "key": "ec8f29eb-6d25-4a48-841c-49d6217761a4",
+          "doc_count": 128
+        },
+        {
+          "key": "0a854fba-3da1-4d7b-88e1-1204a993ee00",
+          "doc_count": 126
+        },
+        {
+          "key": "199dc2c5-b3fb-40e4-bbbb-0b5ef2bbf777",
+          "doc_count": 120
+        },
+        {
+          "key": "874aef0a-1594-42c9-9d4d-58b1b38d5a7e",
+          "doc_count": 120
+        },
+        {
+          "key": "43fc7071-8c60-450a-a940-91f363781aa9",
+          "doc_count": 119
+        },
+        {
+          "key": "c3115ab6-3a4d-465e-81e7-f06d4d6fd39a",
+          "doc_count": 118
+        },
+        {
+          "key": "4aa8af3e-e98a-49cf-9cc3-a49de4be8203",
+          "doc_count": 107
+        },
+        {
+          "key": "bf0ba3d1-a95a-4547-961b-a45c457acfd8",
+          "doc_count": 104
+        },
+        {
+          "key": "055a7f42-988e-4984-891d-9fac55be7515",
+          "doc_count": 102
+        },
+        {
+          "key": "e4b8508e-fc18-464d-adef-e77f1d7a0fdc",
+          "doc_count": 102
+        },
+        {
+          "key": "bb83e45d-1ed3-41ed-834a-f0f7cff4c464",
+          "doc_count": 100
+        },
+        {
+          "key": "6ed17163-76e1-48f1-9ccb-19cc462c2639",
+          "doc_count": 99
+        },
+        {
+          "key": "ef6fc567-7054-474f-bf4c-71321468572a",
+          "doc_count": 99
+        },
+        {
+          "key": "66fc2613-3189-42ed-b230-ed772e8ff748",
+          "doc_count": 97
+        },
+        {
+          "key": "bf1a26f8-6e89-4b95-b512-16430cccb6df",
+          "doc_count": 97
+        },
+        {
+          "key": "bd886680-593a-419c-ac6a-1f8bbc8f4c33",
+          "doc_count": 95
+        },
+        {
+          "key": "cc4dc9c2-057a-4bdd-976a-961074875998",
+          "doc_count": 95
+        },
+        {
+          "key": "bb233277-6d17-4056-b462-a6511dfa6ba0",
+          "doc_count": 92
+        },
+        {
+          "key": "bdfab4d7-0b99-42bf-9325-944422b88bea",
+          "doc_count": 92
+        },
+        {
+          "key": "7a9fa627-38e1-4cd4-9c0e-c24ab5ac27ae",
+          "doc_count": 88
+        },
+        {
+          "key": "60a62dab-82d0-45ca-842d-e20dd4a20e4a",
+          "doc_count": 86
+        },
+        {
+          "key": "8d4fa68b-b9ab-43df-983f-d3284002107f",
+          "doc_count": 86
+        },
+        {
+          "key": "a8823dd5-32d7-4465-932b-accdf76ef4ff",
+          "doc_count": 82
+        },
+        {
+          "key": "df6fb7be-235f-4f01-9079-a5fb25ede1e0",
+          "doc_count": 78
+        },
+        {
+          "key": "818674f5-af4c-43f0-82f1-69e66444e2e3",
+          "doc_count": 75
+        },
+        {
+          "key": "b3b89632-0a22-4532-a05b-6830d07542f7",
+          "doc_count": 75
+        },
+        {
+          "key": "00baf06d-5fee-4630-bd12-dd069a03c96e",
+          "doc_count": 71
+        },
+        {
+          "key": "f477ab07-21ac-45b4-b846-38dfd3ce05ce",
+          "doc_count": 68
+        },
+        {
+          "key": "42f0b085-b821-4190-b826-1508855ae49b",
+          "doc_count": 66
+        },
+        {
+          "key": "2055f2a0-475f-41a6-a721-b5036659f22a",
+          "doc_count": 64
+        },
+        {
+          "key": "5235b5b5-5cbe-4de7-8286-bc2e95ba1748",
+          "doc_count": 63
+        },
+        {
+          "key": "6928bd35-4c17-49e1-aa0c-7785196bd4be",
+          "doc_count": 62
+        },
+        {
+          "key": "a3a25673-c2b7-4054-8c8d-7ed87c27e0d8",
+          "doc_count": 61
+        },
+        {
+          "key": "f42a9828-c1d2-47a1-afac-7138e62b3fb1",
+          "doc_count": 60
+        },
+        {
+          "key": "94dd2cee-ed7d-4f98-894f-efafeac92b5b",
+          "doc_count": 59
+        },
+        {
+          "key": "07b5fa00-42c8-4f87-b467-b05eabfc15cd",
+          "doc_count": 58
+        },
+        {
+          "key": "d8f424cb-42f0-47b2-967d-919068de9f6a",
+          "doc_count": 56
+        },
+        {
+          "key": "1a70a966-b196-4e05-8e87-5072e6da023f",
+          "doc_count": 55
+        },
+        {
+          "key": "4a8b7fc9-cbc2-45b3-806f-73cc6a13c369",
+          "doc_count": 54
+        },
+        {
+          "key": "de96ed89-4b6e-4a57-ba68-01027102b89b",
+          "doc_count": 53
+        },
+        {
+          "key": "b6215017-a6a2-4363-b7cd-8c7d934e3f7a",
+          "doc_count": 51
+        },
+        {
+          "key": "c70f7411-9256-4254-9af9-84a5211d650c",
+          "doc_count": 49
+        },
+        {
+          "key": "fbac84f2-8db7-4af5-96b1-9d8885370c10",
+          "doc_count": 47
+        },
+        {
+          "key": "64541d64-d190-4c41-aabf-03d6cce9f3fe",
+          "doc_count": 45
+        },
+        {
+          "key": "eac8c59f-3173-4ce6-8772-a421d991b0ff",
+          "doc_count": 45
+        },
+        {
+          "key": "38226d50-12ee-4766-bd42-5bcb98149c89",
+          "doc_count": 44
+        },
+        {
+          "key": "b761d317-a36e-4a05-a5f4-bd3e3963daf6",
+          "doc_count": 44
+        },
+        {
+          "key": "f6ae123f-1433-4b82-97e2-d7a5f0560930",
+          "doc_count": 44
+        },
+        {
+          "key": "e6e6af0a-f258-4899-b3fc-d07e09f0fbc6",
+          "doc_count": 42
+        },
+        {
+          "key": "2d2abb35-06b6-4fc4-beb6-edf3b841acf2",
+          "doc_count": 40
+        },
+        {
+          "key": "f187fd6c-179b-4c0b-b6bf-971a985760e3",
+          "doc_count": 40
+        },
+        {
+          "key": "1d14acd1-20ef-4a55-8206-f04c8a75ea3e",
+          "doc_count": 37
+        },
+        {
+          "key": "610c8eb0-f2b9-458c-936e-3efe5e8522ca",
+          "doc_count": 37
+        },
+        {
+          "key": "bdaa6842-3055-465e-82f6-da577e987cde",
+          "doc_count": 35
+        },
+        {
+          "key": "7ab16fd8-1f09-4c60-a7d6-b71d8c342513",
+          "doc_count": 32
+        },
+        {
+          "key": "01408127-16e4-4ff0-98fb-a012f7479fe5",
+          "doc_count": 30
+        },
+        {
+          "key": "40284e03-593b-4a42-9634-63e2e0e78df6",
+          "doc_count": 29
+        },
+        {
+          "key": "93a2a79b-2728-429b-b095-94ec8dee8a4d",
+          "doc_count": 29
+        },
+        {
+          "key": "a009c9de-fe2e-4124-9ba5-ca189d41b913",
+          "doc_count": 26
+        },
+        {
+          "key": "d1974f4a-fdfd-4daf-b9b1-e63d9d060feb",
+          "doc_count": 24
+        },
+        {
+          "key": "7fc152cd-0eaf-4d64-8291-591a188820b7",
+          "doc_count": 23
+        },
+        {
+          "key": "bf049384-ffe2-4418-a1a3-fc5552ba850f",
+          "doc_count": 23
+        },
+        {
+          "key": "13acedfa-8a82-4135-9a3b-09ffddb0d693",
+          "doc_count": 19
+        },
+        {
+          "key": "9e8c4024-45b1-4c06-854d-9f6d807dae67",
+          "doc_count": 19
+        },
+        {
+          "key": "6dbb614d-03b6-4d44-be10-db7e4d9288a4",
+          "doc_count": 15
+        },
+        {
+          "key": "74ba48da-0660-4836-a730-0815b62e1c31",
+          "doc_count": 14
+        },
+        {
+          "key": "eb6e1b84-05ba-4e5f-9046-7cbc88d9b494",
+          "doc_count": 14
+        },
+        {
+          "key": "0024bce6-9970-4067-a279-68d99dd694de",
+          "doc_count": 12
+        },
+        {
+          "key": "ef83b1d4-4aaa-4986-a771-c7dbc9c674ee",
+          "doc_count": 12
+        },
+        {
+          "key": "6c2b2e25-f628-48eb-a0e2-bb783db72afa",
+          "doc_count": 8
+        },
+        {
+          "key": "bf0e00ca-98a5-47b0-ad2d-26dc837b5939",
+          "doc_count": 7
+        },
+        {
+          "key": "059b7cd4-03d9-4ed5-acac-a4cc41ab5c1d",
+          "doc_count": 6
+        },
+        {
+          "key": "2e65e24b-b7e2-40a4-a40c-09edafc1e3f4",
+          "doc_count": 6
+        },
+        {
+          "key": "4490a0ff-49f1-491a-823f-761a396a670e",
+          "doc_count": 5
+        },
+        {
+          "key": "78edbca3-a9c6-48a5-9b10-9ef1999c3d64",
+          "doc_count": 5
+        },
+        {
+          "key": "f2f68b10-b620-4ef8-ac32-c799b38b6d56",
+          "doc_count": 4
+        }
+      ]
+    },
+    "max_dm": {
+      "value": 1708622887114,
+      "value_as_string": "2024-02-22T17:28:07.114Z"
+    }
+  }
+}

--- a/__tests__/mock/search-7c1deb90e8a8c3a05d72e6a9e505a428.json
+++ b/__tests__/mock/search-7c1deb90e8a8c3a05d72e6a9e505a428.json
@@ -1,0 +1,17062 @@
+{
+  "timed_out": false,
+  "_shards": {
+    "total": 48,
+    "successful": 48,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1310,
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bdaf32eb-1713-4390-a96a-1dca49671b34",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.3299451488425,
+            "lat": 45.68320932749771
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1d2e551d-a8bb-45fa-a6eb-22634c1a32ea",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.93333,
+            "lat": 2.58333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d0811d28-1a8a-4a5d-8fc3-066849be8b83",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9037942234,
+            "lat": 33.37659
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "55a75c3e-f4cf-4795-9056-d5f2fdd3aa7d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.083882957,
+            "lat": 34.431897
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a2619b87-f2ff-40ba-a364-47f655e0123d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1976118178,
+            "lat": 34.402723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2b34b030-809d-4cf1-9f24-31a09f74e264",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.96191,
+            "lat": 38.37945
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "095b86fa-4f0a-4f73-b2aa-6f80db9f9c11",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.413883,
+            "lat": 39.851096
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "726b16bb-423e-4543-8e98-84c6d642fa3d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.0039,
+            "lat": 26.1072
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0ac32d72-f63e-46bc-9e29-9e1f355284fd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.3306175,
+            "lat": 35.45903097
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "04d2254f-a241-421c-85f9-2ed8b56935fb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.506447,
+            "lat": 43.840464
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e3b8e1ea-fce8-46df-84b0-ad27d0ec93cb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.3990529,
+            "lat": 33.65522057
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d5d38397-c1f6-4410-bf02-4fa650ac841a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.862103,
+            "lat": 47.417428
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d726e664-1efd-42fd-a267-5e5b775f650a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.1333,
+            "lat": 45.7833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f4a8d0aa-111d-4473-b050-ba7c168ec231",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.6108017,
+            "lat": 33.2715999
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d2d912b3-d1b2-4445-b6e8-5bf9257ed769",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.704013,
+            "lat": 43.051827
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c8d3bb81-e57f-4ae3-b4a5-763fad51e8cd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.5775612,
+            "lat": 32.92391365
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5a8fd659-3099-4721-b82c-e85989549491",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.5513964,
+            "lat": 36.65197017
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "751ea1ad-4ecd-4a79-855b-fc8482e8cc32",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.6108016,
+            "lat": 33.0971983
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "607c1f63-a672-4560-ad32-ae057c46c676",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.398097,
+            "lat": 41.343335
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7f44d2a8-dff0-407e-99ab-28043d1ecee6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.5000214,
+            "lat": 36.93661798
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "81f65220-3347-4e17-978f-cb38d4454d7f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8980459,
+            "lat": 36.94990921
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f172b54b-5a62-443b-95ab-5724141f3af9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.8463059,
+            "lat": 33.06670221
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b560fbac-846c-4ff3-b695-74ceeca65d56",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.839157,
+            "lat": 32.064445
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a3d2fc1a-7348-4abf-be61-2a0107821dff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.453883,
+            "lat": 44.889588
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "afa71196-0f4e-46a2-bc04-d7fe8dca8fe3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.00895,
+            "lat": 32.20008
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "59116ffd-61a9-424e-b4f8-58385a940fba",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6d2855f6-4efd-4402-94fa-51bf7b1f644b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fdfa8a08-154f-47f5-822a-b9f4012f4804",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.023447,
+            "lat": 31.205281
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2483e949-8581-46b5-a74a-0c4733933819",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.193023,
+            "lat": 42.650472
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0f83a8cd-8e81-4c7e-9642-621a6f14e2df",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.836547,
+            "lat": 44.941823
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "153decf6-03ac-4588-bee1-d0e44bad9e94",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.8590515,
+            "lat": 32.0150703
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "165209b1-1929-45ff-bdfd-2ed4a94fa02f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.8833,
+            "lat": 46.0167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1c30494c-55b2-4b40-9fb9-a44ff9a4758a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.439479,
+            "lat": 42.389635
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "31b6b7fd-deb1-4270-a035-580cc9ca98d8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.3327093,
+            "lat": 35.96393964
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "901efb09-d016-410c-9671-be8f6e80baee",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.6679820779544,
+            "lat": 47.87203858912037
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3332e492-1668-48ab-9630-f0c2e3fe0495",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.03092781327021,
+            "lat": 46.758468841048824
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aac2dc63-e1f4-4678-afc3-40a978822aef",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.371391,
+            "lat": 33.646389
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b590eb33-59a1-4e5c-a027-2403edbe9b6f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.398433,
+            "lat": 41.571013
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a7d0a2f5-8ad3-4014-a79c-57da60a50d2e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.003878,
+            "lat": 36.736608
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "40c9cedb-0795-4ccc-8a65-e5bab1085d22",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.267818,
+            "lat": 31.657602
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bd334ca1-ec18-45db-9bd4-ba1641049431",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.948747,
+            "lat": 31.97208
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "829dfc17-5695-42fb-bf94-e3f831cb66a5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.538789,
+            "lat": 29.492256
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "86bf5f48-c5a2-42a8-844b-1b9094bca319",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.90498,
+            "lat": 38.26932
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e525b068-3f42-48bd-a1a8-055a989bee84",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.3075,
+            "lat": 16.8127778
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1355c007-2d3f-4ea8-8470-413bda4d482b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.05,
+            "lat": 28.76
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a51f533d-7845-43ed-aee0-a2da4f6882ea",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.68,
+            "lat": 29.83
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e7cbe74c-2e2f-427c-ac9d-20b4c72f3bd3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.58529,
+            "lat": 32.78286
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fadd49c1-da35-4820-9796-f49067f24883",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3814233,
+            "lat": 35.68598484
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f3d3317a-b063-473f-8628-a00659f15b22",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.552364,
+            "lat": 45.498218
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cecf4cfd-49e9-4d0f-86e6-b06a94c25627",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.6670405,
+            "lat": 36.13310831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d4327937-8878-42fd-b9d1-a04db63dce5a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.55,
+            "lat": 46.4333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6fa3d0f9-a184-48a4-990e-294f1ebf4ae0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.661108,
+            "lat": 42.185463
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5482f549-5017-4836-a06c-31a5b58ea740",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1b92c68b-6827-498f-9881-f3be90072acb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.6118402,
+            "lat": 35.96377309
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "35f8bb5c-d996-429f-a820-40a63fce05fc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.284249,
+            "lat": 41.979667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "765b0291-33c2-4ea9-afe4-ca5468da6ebc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5370025,
+            "lat": 32.6563984
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "83f8d04c-0ade-4c80-a8f5-18d2d2c0c461",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.228852,
+            "lat": 42.098255
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "95f595ab-c3e7-4b95-89aa-4e3e55c4c1ed",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.6167,
+            "lat": 41.6
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fe6e811c-3f52-4ee3-86ab-5203c3f495d6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.583333,
+            "lat": 49.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0d670b84-227e-43e8-a6e0-54a62fb70a98",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4815,
+            "lat": 32.3723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8a0e83a9-10a9-4fd8-8399-6a7601d51440",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.358505,
+            "lat": 43.889692
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "27667ae6-fdf3-4a81-b5f1-d0bb89b0eb9b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.922679,
+            "lat": 32.781433
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "72c4e360-ba36-4fd4-99f8-42138ea823ed",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.05644,
+            "lat": 38.36354
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8ca9bf98-35c8-48aa-97c2-3ed45264f398",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.89839,
+            "lat": 38.41026
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "17944548-e9f9-476e-aa30-70af60a1d858",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.2351420523,
+            "lat": 32.923296
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f4f66adb-ff07-41bf-ba3c-84777e007432",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.5287552,
+            "lat": 40.4555206
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a3339626-e91f-46a6-87c8-97bdc6b34216",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f0a79060-71e7-41ca-98d5-81e59801b5c0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.6167,
+            "lat": 45.95
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b0c1e7ce-f980-4e74-bd1e-aa48ee28f936",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.965763,
+            "lat": 31.3436806
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cf9824a9-e309-4268-933e-da7f9262fd1e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.0833,
+            "lat": 45.5833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d63f7c7a-26b1-41f9-afcd-9518187b51d0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.840656,
+            "lat": 42.693656
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d7a85ab2-6122-4912-a698-bf967913c622",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.7144,
+            "lat": 45.5225
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d80ba8b1-ff63-4cd1-9785-3440016ecd5a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1783,
+            "lat": 43.4405
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e28df87c-ea40-45f7-8481-e24005e3047f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0696879,
+            "lat": 36.42752366
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9499ff09-747f-4d55-ab51-ddd098c8601b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.7167,
+            "lat": 41.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6dd30cfd-2ab7-40b2-b1fa-0d0da857226f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.3056,
+            "lat": 47.6738
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7f76d4a5-e259-41e4-a109-fe2dba391a91",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.4,
+            "lat": 37.3667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a600ea3a-ff31-43cf-be99-810883a402d5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.25,
+            "lat": 44.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7f3d3a21-d348-4c37-bdfe-4c8735b9b30b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.0652778,
+            "lat": 16.7088889
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "13a73c3d-7b20-4826-9cd0-222a6f99cadd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.2264202,
+            "lat": 33.62859905
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0159ac0a-cb8f-40e3-a661-8ec1c7fa022c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.8643,
+            "lat": 34.0606
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4ffa167a-0ba4-49c5-8f50-cbe6948f261d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.9413313,
+            "lat": 32.0665106
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "31d7e680-d467-472d-b9c0-1658b3c12525",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45199,
+            "lat": 31.83121
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "60fe3388-9eb7-45c4-9c48-03c84c5675e4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.3167,
+            "lat": 42.6833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "62c726f3-0772-4d38-b52d-0ce81b72ed89",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.7694707,
+            "lat": 32.69712368
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "62e3e9aa-2e6f-4842-b45e-f530ac9d773c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.8451115,
+            "lat": 33.195911
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "742e99d3-1215-4684-ad0f-5e0dbde3999f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.7156996,
+            "lat": 36.58222839
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bfed732b-a008-4220-baae-b00d9330a2b8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.9967684039,
+            "lat": 34.189772
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2504720a-f699-4d4a-9208-7fcb8d71b0bb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.211826,
+            "lat": 30.644952
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "708018f6-f101-4b22-ac3f-702d24fe8b39",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.45690199622679,
+            "lat": 34.64113964333336
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aafd9371-ab43-40a5-9b4e-545b0f1650f0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.3538889,
+            "lat": 34.5394444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "279b7707-0a61-4779-b96e-979dd7f783da",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.0744444,
+            "lat": 34.9855556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f755d2cc-1397-48de-9207-d4f57b5d3b3f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.51666,
+            "lat": 2.83333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1d76ef00-1869-47bd-9a1e-c74cf90c7cb5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -71.9,
+            "lat": 45.3833333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9f5c2bf0-7d24-4443-98c9-8443e94c987b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -93.1,
+            "lat": 16.7269444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5b2f4fde-a0b6-4e8c-8402-198a58e0b5e4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.999116,
+            "lat": 34.110751
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b0dc0bbc-d801-423b-8dc4-16428c1d0374",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.065862,
+            "lat": 30.422836
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c6b8f1d4-589c-4205-a164-eb55909230da",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -100.771401,
+            "lat": 31.449556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3396d9f8-75c0-43d4-abc7-9b76c298e21b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4488694187,
+            "lat": 32.574107
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f68f7c15-c693-48ab-989a-0f16816d6965",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9439,
+            "lat": 31.987097
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9abe8355-7703-49fb-a5bb-67864df77ffa",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.26508,
+            "lat": 38.18831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "277ad874-3362-4e13-8d5f-bef4dbf84194",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.23666,
+            "lat": 38.09507
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a4841f1a-382e-4eac-8bf0-b603d7599a83",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.30007,
+            "lat": 38.21662
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5c22bc93-d196-4f80-a873-f0312e6d158e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.98949,
+            "lat": 32.22925
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "966a5632-7378-4165-9f96-73db5da10fb2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.222013,
+            "lat": 33.159427
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2eefed3e-1a72-44ba-b0db-cac697526c73",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.726741,
+            "lat": 47.216651
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ee36a32b-2fb1-409c-a3d1-c4b489fa0161",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.578063,
+            "lat": 42.412688
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4b70abcf-fda4-4421-b9df-a27a250fe472",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.709701,
+            "lat": 41.965476
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "33873a34-06bb-47b2-acaa-3b143cabf1d4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3833,
+            "lat": 47.2833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3dbb6726-b608-4bb3-850f-e271e6bff3a3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3f01b8d1-548d-4b52-b748-b9da9e47de38",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.583333,
+            "lat": 49.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7aaf0bd7-1f73-42e8-9a47-2285e6f0122a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.421653,
+            "lat": 36.69517459
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "878831ac-9552-41bf-95cd-0795f97f5a46",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.3230203,
+            "lat": 36.30656257
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ce4a3519-800c-40d1-805a-7bf4eb4d9baf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.8,
+            "lat": 48.1833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ce87c7a6-4a62-42d2-b973-cb57c3052869",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.6167,
+            "lat": 47.3
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "be86df96-79f3-4e61-b5ce-5fe58fb14165",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.1211,
+            "lat": 48.3636
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b468f258-3d81-42a7-8cc1-c882a7d54be9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.04793,
+            "lat": 47.80817
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5f887e06-66e6-4785-b9ab-b9442e6074b0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.8342125,
+            "lat": 35.20982735
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "56afc10d-12fa-469e-a4b8-8694fe4f1dc2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.3667,
+            "lat": 35.0167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "35765763-a99b-408d-a2b4-77d903821dd7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.70534803117107,
+            "lat": 32.430375237105956
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "57239a6d-997a-424c-8a43-e12b5cc06e50",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.1411111,
+            "lat": 34.4794444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "12459d9b-4215-49eb-b61c-2e4d51910e9b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.27936495043488,
+            "lat": 48.07011148501395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8fda4206-9583-4e86-ae25-f92268ca7353",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.2430860186517,
+            "lat": 50.01652199931778
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d7b0c864-475c-4e55-85df-5dafdc15650b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.7966667,
+            "lat": 34.4919444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6b4f762f-1fe5-4c0a-841f-6203af1c4b3d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.8,
+            "lat": 43.05
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "07be1a02-1b72-46e0-9443-bfaf43d3c906",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.4,
+            "lat": 45.95
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d6123dc4-7fd5-40f3-b5d0-478f6cae9dae",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45699,
+            "lat": 31.84704
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cae71985-f582-41b3-9e11-68a9d56d208f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.843887,
+            "lat": 32.019165
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ec2fc924-218a-4355-a432-8eb0df93ef41",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.839157,
+            "lat": 32.064445
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "be4e8153-eee2-4ed9-a3e6-d633a0833d39",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.618973,
+            "lat": 47.869207
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ff0a435d-c973-4c96-b604-428babec38ca",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.034706,
+            "lat": 49.023421
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e8820983-b0f2-42c0-a364-b6588de133ef",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.023447,
+            "lat": 31.205281
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0c8b47e7-5ea8-4941-a225-b5ee18ea2e90",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.75904,
+            "lat": 38.24872
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5c78c797-ee03-4939-ba96-09b57ccae9b6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.837393,
+            "lat": 47.240458
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "304e7637-15fd-4bf9-954b-75c1d3200275",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.062077,
+            "lat": 44.49517
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "40edcab4-c0ed-4729-8d4d-4af70961e542",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.358505,
+            "lat": 43.889692
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "830c9e63-b540-495c-b4be-3e81f70a9dc9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3,
+            "lat": 47.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9e3d4374-d04b-4767-9ce6-02e2b05babfe",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.2377,
+            "lat": 43.3675
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8e0f4b41-b948-4414-a048-2c17c5fbf6fc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.55,
+            "lat": 45.3667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "87e529ab-8217-4a71-abfb-e2527fe0e3b8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.663485,
+            "lat": 35.078382
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "66dd332c-ebab-4709-a060-c4537937aaff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.116331,
+            "lat": 34.4620667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6c7eaab4-0f4c-4b76-a88f-316d82c5069e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.588315,
+            "lat": 42.624914
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7d28e4cc-7bc9-465e-bc62-fd430d824826",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.980266,
+            "lat": 42.072418
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "92046b97-09c5-48e5-8fe7-88222564e424",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.5997222,
+            "lat": 19.5325
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bb8b2932-d3f3-4f41-8495-e2137e5b436e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.5997222,
+            "lat": 19.5325
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "96d10f1d-c5ce-49fe-895d-f70c5376f0d3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.24921,
+            "lat": 2.94472
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8bfd0ceb-7e8b-4d5f-b43a-8f6c7c87f30a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ad15ca0e-5a43-49ef-927e-5550a77a28f0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.9366,
+            "lat": 38.24785
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1722d42b-2bfe-4832-a893-d2980fc30660",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.77487,
+            "lat": 38.26303
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "04188ddc-5022-466d-9a4f-146a6fc08f8e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.8442,
+            "lat": 38.29893
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "177872a6-2276-4ae0-8b89-34d50884811c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1,
+            "lat": 43.3017
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2afb120f-a2a2-43b6-a46f-328755694655",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3283997,
+            "lat": 33.7977993
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2f3180a7-3898-493f-b836-a7fe2ece8855",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.2667,
+            "lat": 42.3
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ebabba0f-a7ae-4411-901d-b8fc1dd66c11",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.4667,
+            "lat": 47.7833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ed7732ca-bbc4-4aa8-b41b-e50183f4407a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.7,
+            "lat": 43.9667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5a5b8b94-dde6-48d8-8478-61035372fcf0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.54017,
+            "lat": 32.53162
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "607953d3-6f27-4cbd-aede-020e10fe71ba",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.980266,
+            "lat": 42.072418
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "39f7a18f-ad6e-4a82-8371-1d40d616488a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.0444,
+            "lat": 47.1056
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ce9d1ad2-4117-475d-ba3e-13af2629b41f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.6833,
+            "lat": 46.6167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7de285f2-adf3-40ac-a9ae-7bd6c8d4e83b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8241289,
+            "lat": 36.19842254
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "82ab2427-ef35-4266-a615-91e9d7b3f732",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.5520091,
+            "lat": 35.60248571
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "84b9a798-ff7d-4652-b01b-6533817b67a1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.971101,
+            "lat": 33.568315
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "99f641a3-04fb-4b90-928c-4f5d3b504929",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0675816052,
+            "lat": 34.423023
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2c95b12d-852f-483c-9582-0dca98e164d4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.2432676797999,
+            "lat": 31.14081461087519
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "69175896-2bfe-43e0-bb8c-432722d641da",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5167,
+            "lat": 46.8167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3fb55b80-ae44-4c62-9f0f-d2da4283ed1c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45,
+            "lat": 31.8333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "36de0ab2-dfa5-4556-a104-ced17852ced9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5108333333,
+            "lat": 32.4488888889
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d83b3bd8-56e5-4515-89f0-077302f73165",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.9586111,
+            "lat": 34.5730556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "98aeadf8-e261-4159-a191-afb86511a58f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.7,
+            "lat": 29.84
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7136b240-d6be-48df-9167-441ec4c01b83",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -60.2666667,
+            "lat": 6.3166667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ca28148c-bb78-490c-b2ba-38d51d6837bb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -83.05,
+            "lat": 27.68
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "32d92189-6a0f-47b0-98a9-1530ed066a57",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.78,
+            "lat": 29.96
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8e88b825-8e77-4fbd-beb7-df2ff5939cdf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -100.4470627740817,
+            "lat": 25.337229522704224
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "384ca38d-0e69-44a4-912a-efe5e9eaa7df",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.0666667,
+            "lat": 16.7
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1f5bd021-dab8-4034-85fa-3efca177265a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.8733726,
+            "lat": 33.209141
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "23581901-6ad2-408f-9dd7-08b9efe4638f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.70963,
+            "lat": 32.72195
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "89247554-bb0f-4f98-aef8-a1872d272d17",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.988198,
+            "lat": 29.47668
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "23e4234a-2ed1-44a1-b3be-1ba8a46bd051",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.49459,
+            "lat": 38.39973
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fbf2a7b0-af72-4c2a-9221-ac7ed11b11d2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.5842,
+            "lat": 48.0905
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0c4c1e31-a905-4111-b1c2-856aa21ffb8f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.578063,
+            "lat": 42.412688
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "02bb9181-7fdf-4b2f-882f-f3f0ea719d41",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.7167,
+            "lat": 41.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e561b5aa-d190-4fa8-9a2a-1e13f5e7b6ac",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.930399,
+            "lat": 34.007188
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d50522ec-b8f8-4916-a742-d9df230de319",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.55388,
+            "lat": 32.46175
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d6c24f0e-3bc5-4e42-a53c-4e82ee326103",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.4456449,
+            "lat": 36.32419911
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dfb83ba7-8cbd-46b4-8eab-7b627407b39e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.685653,
+            "lat": 45.875337
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "eaa7295d-767f-4216-9184-32dcb35565af",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.2,
+            "lat": 43.35
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "19b484c4-6dbe-4261-bd19-3cacac0e9378",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.25,
+            "lat": 45.7
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1c35abd3-fae4-4cb6-9064-e5bd11c75a32",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.9613,
+            "lat": 47.4772
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "466954b4-9589-4d8a-a73b-d9c0ba339f71",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.1,
+            "lat": 42.0167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "48daee55-7ce0-4471-954e-634918a98917",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.4428684,
+            "lat": 33.55887072
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a47f789-20f1-422c-bc48-a53a0fae8656",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.358505,
+            "lat": 43.889692
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a68e9d2-27ef-48e7-825d-06cf8e586761",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3814233,
+            "lat": 35.68598484
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2ef3fd7b-ba82-48b6-ae1e-4cee200d4451",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.568312,
+            "lat": 42.455749
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a6c91518-3873-41a5-9ddc-21828ba44530",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.73811,
+            "lat": 32.68619
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7e034595-0fb4-40ab-bd9d-157474c55ef8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5355555556,
+            "lat": 32.7852777778
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "98aff395-166f-48c6-870c-b758ff0e1910",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.5667,
+            "lat": 40.95
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "991cc3d0-82ce-4baa-86a4-235a5fea294f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.6,
+            "lat": 47.2833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7c2498e1-a9c8-4253-ad84-0b10ce7cfc1b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5370025,
+            "lat": 32.6563984
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9539fbc0-15fa-46e1-b6df-ca5ba98378f4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.45,
+            "lat": 44.1
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "85b2e690-0f3d-45c6-8cf9-162f918f36bb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.6167,
+            "lat": 43.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "22d943d9-1972-4c60-944d-10d010607ea7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.24090689809088,
+            "lat": 34.04001250669102
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4691aba6-8f00-4e17-a83e-8ad1650a7a75",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.5301184634637,
+            "lat": 31.32117132075479
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4d45a71e-3f05-41ef-ac18-5fc6d605784a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.62,
+            "lat": 30.07
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "97a655c3-326d-4edf-b264-72b429d3f693",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.48946065773008,
+            "lat": 43.865971809834356
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8ff1e92c-ee30-431a-9cf0-a80afce8dd58",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45,
+            "lat": 31.8333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ace925b8-0c38-457c-b9fa-f319262e1225",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "37a0ce0a-36ea-4672-a687-5ae26be6a045",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.996594,
+            "lat": 34.169938
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7cf7435b-1bee-4e21-9a7d-53b5b30c3ea9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.587784,
+            "lat": 32.934803
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "de2477be-db30-4bdc-9c64-01006d9c05f1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.305555,
+            "lat": 37.191825
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e8ce411a-a255-44dd-b1ef-490eaa5a65d4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.7,
+            "lat": 29.84
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8b8a6649-0861-4dec-b617-94141d78e4ec",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -88.72792,
+            "lat": 17.9291
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "20baaa69-e3dd-48ee-b213-4ff3ab1bd587",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117,
+            "lat": 48.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0efe9ebc-221b-42f3-ad0f-d4c6e6bdeada",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.2833,
+            "lat": 43.65
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0f413177-d24a-456a-8c41-ab0141143989",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.3,
+            "lat": 41.9167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4452f55f-cdb7-47c9-8d7e-089eed516a9b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3,
+            "lat": 47.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "625e44dd-b0b7-41b7-999e-7e0da71a6145",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.280416,
+            "lat": 45.63822
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "544950c0-66f2-4cee-b2db-2cc4a5883785",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.879841,
+            "lat": 48.610556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "71bc48ee-d234-4141-8c1f-d6526a274499",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4913888889,
+            "lat": 32.5752777778
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "72708c81-f440-4f7e-8dee-0cec9e549297",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.031824,
+            "lat": 47.252699
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5dd13686-f7c7-401d-832a-7f08aef3ef8d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4320983,
+            "lat": 33.6151996
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bb27672e-6418-4291-8ec9-05b0d82b16ca",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.0995322,
+            "lat": 33.32427036
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cf20f65c-61ff-4103-a49f-d965b550ad82",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.7980283,
+            "lat": 36.55532371
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fa2508c1-673f-4203-af89-3f6a2f05a320",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.4333,
+            "lat": 45.4667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b15bf8c8-979e-432e-bde8-0f9067051c69",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1359,
+            "lat": 43.6463
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9ae589a8-b2c4-49b4-a4fb-a3b1f6ef3e2c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.179865,
+            "lat": 46.602404
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "38bfdb8b-b3af-4400-a08d-e8a5aa266919",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3814233,
+            "lat": 35.68598484
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f3f85832-56c6-4af6-8229-1b6fa1da4845",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.498829,
+            "lat": 42.569645
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a68ad1c4-2333-4375-b0df-f2fdf49d802a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.57184434571354,
+            "lat": 51.43505948090899
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "df1fbedf-c8d6-41c6-b16a-4ecdef00fd55",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -100.280366,
+            "lat": 29.361793
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ab2e5b8d-057c-430a-b697-d52d0cc27e39",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -100.762938,
+            "lat": 29.783718
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7e12b152-bd2c-41b0-8fa9-6299f2ed41de",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.7583138889,
+            "lat": 34.8923638889
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ee0a0d66-965b-448a-af32-d245fe152e16",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.030955,
+            "lat": 33.176485
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3cc3a718-5ce3-483e-9300-5cafd76f2a60",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1976118178,
+            "lat": 34.402723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "918bd012-7155-4e81-bcd5-d630fe7975b9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9035778406,
+            "lat": 33.385604
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "db5a6c40-e49e-4efa-91e6-de1ac944c2fb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.3789,
+            "lat": 43.4867
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6e636695-8b0f-44da-a694-8a5cf4030fa9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.839157,
+            "lat": 32.064445
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6a2be626-10c8-47bc-96fc-71f093a5fe48",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.5667,
+            "lat": 47.85
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "785a4a17-0594-40ce-a3c0-f3bf965f372f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.3700028,
+            "lat": 31.4379009
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7aaac359-a1bf-443f-84eb-01f91e8976ae",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.5333,
+            "lat": 43.65
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7ab35e71-bf39-41d9-9f5f-b20fe84a07c2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.71766,
+            "lat": 32.74083
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "88f89dc9-47ea-48f9-9c57-1037c63f4342",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5951281,
+            "lat": 35.0441862
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "22eb2dee-487f-4378-8437-bca5fd308007",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8892102,
+            "lat": 36.12980468
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "46d751ce-b97a-4a6b-9348-343578574b15",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5386964,
+            "lat": 32.4817997
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "424147e6-e77b-4122-a211-66ce15fef8a1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3814233,
+            "lat": 35.68598484
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9846785d-ac3d-40e4-bd7b-113afb46f321",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5667,
+            "lat": 46.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "993674f5-37bd-4328-997a-9ef286ef4733",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.8553,
+            "lat": 47.3779
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "843ddc55-da56-4950-92a4-40f918376fa9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8421335,
+            "lat": 36.49110212
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "603f236f-7470-49ee-b2d0-809078677b07",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.069495,
+            "lat": 50.005021
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1004fe18-54cf-450e-8b5b-159a7a4bbc11",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5370025,
+            "lat": 32.6563984
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0dac5b06-e696-4811-9fe7-a4f5adeedf43",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "011c3e74-e6a1-44b6-a52e-5427320d445e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.458487,
+            "lat": 46.772398
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fa7db773-c693-402c-bdb9-dc8836dfab0c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.3230863,
+            "lat": 36.59449928
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dba2ce29-d39c-468a-ab8c-5939b3130821",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.32,
+            "lat": 47.81
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6ad15302-6a94-4a93-a10d-9c52f166f29f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.7,
+            "lat": 29.84
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5d08f8fd-c6f9-4be2-8ca9-d20a4b0e2d57",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.8752778,
+            "lat": 34.445
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "120f036a-1d3c-43e7-90ac-fcbada0ded89",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.2427778,
+            "lat": 34.875
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2c47512c-e221-4595-aa6e-1209b14b44e2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4869614,
+            "lat": 33.9358292
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2e2ab618-0cf9-4a84-ad1b-992ec62fa8bc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.881692,
+            "lat": 41.707223
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "edd5c017-143e-4a1b-8749-3b7d51f43bfc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.4,
+            "lat": 44.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f1737125-836e-46dc-8e1e-b78eb85e79ed",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.5667,
+            "lat": 40.95
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "16af005d-15ff-4965-bd73-0a078d8955a6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.083,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7f75c0c0-4ef4-420b-9936-eaaa27c095a1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.7167,
+            "lat": 41.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "155c3c39-0bac-4d90-ab22-21cb1be43942",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.6666666667,
+            "lat": 39.0333333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "022f5815-5815-41bb-984f-223fbe582a5c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.0067,
+            "lat": 47.9031
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d9e6d5c5-0a2a-4108-8a30-e980deaaae7b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.6333,
+            "lat": 46.4667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e6e36ccb-d6b3-4ded-9036-d8007bdffe08",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.9278,
+            "lat": 42.9634
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3440511e-9d53-48fe-9eba-a1cc7906e7ab",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.7,
+            "lat": 46.25
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "63652294-6589-41f5-a28d-428f1969fcb0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cabc54e7-2300-4b88-bdb3-c3d03f46b7f9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.371391,
+            "lat": 33.646389
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "949ff09b-7d86-4cd6-803f-d640b4722c4e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.980266,
+            "lat": 42.072418
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a4fb779f-9f0e-401d-b453-ef70f2bc6e6b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.5165075,
+            "lat": 36.61380764
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8878ae7b-48f1-4566-a4ab-a49a04414688",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.9802671,
+            "lat": 34.32554235
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "88c0f13c-3028-4ed2-910d-551708366302",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.638757,
+            "lat": 47.812111
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1a7ee4cb-3bfc-41ed-8f7e-53f8cc29e791",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.36599,
+            "lat": 38.27911
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4493e4b5-8e50-498d-8e4c-9b3de8c02a38",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.80493,
+            "lat": 38.26413
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b82d350d-0e0e-4576-abae-b6be2a46aee2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.10036,
+            "lat": 38.36833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "788a38f9-6c64-489d-9bf4-9f2a4ce427ed",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.81584,
+            "lat": 38.27669
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "abb3ec93-5ef1-45f7-ba76-ce0ace24cb05",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.14532,
+            "lat": 38.70966
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "410268c6-c222-4119-9b28-6469635e14e2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45699,
+            "lat": 31.84704
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8737e7d3-ceb6-4c54-96a5-48a5b3b32c37",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.4527048,
+            "lat": 31.862281
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "89687a6c-9c50-49fa-8876-2d803f28fd33",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.85455,
+            "lat": 34.56332
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3290828e-e796-4bda-8e14-dd2e1159dae8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45699,
+            "lat": 31.84704
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "452d4333-3cc1-4eee-959d-f50a84ed6184",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.85494719366714,
+            "lat": 34.136005696895964
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7416f7c9-b740-49ee-bd09-e8777dd555b7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.69464044233644,
+            "lat": 26.902984615965437
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a8cfc488-445f-44dd-b366-cb0ef7c706ab",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.42611562621818,
+            "lat": 31.391169068081208
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "17e2ad34-e9ec-4244-a0a3-5c4d82827532",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.99149672648753,
+            "lat": 47.20429803474714
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6adf8020-8673-4c73-833b-b6ec104baddd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.8167,
+            "lat": 44.3167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ba2eac48-ae43-472a-a656-7725a4eb1e1b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.928287,
+            "lat": 33.216822
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0377bda7-4d77-4dcb-b219-f556b01f4a07",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.00895,
+            "lat": 32.20008
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d2b41713-f0e7-4187-99f3-ea6622c2b2d1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.0302,
+            "lat": 38.40462
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "00c4c593-7ca6-4bd3-8c7c-09876986ab64",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.930399,
+            "lat": 34.007188
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "231ea4a4-8a03-4e57-bc7d-abdfda31374b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.7667,
+            "lat": 46.6667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "24594de0-9913-4dad-bd25-f172c6b191b6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8957343,
+            "lat": 36.4001229
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "25053e10-ea9a-4d5e-b8bf-9ca7a7a91bfc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.561397,
+            "lat": 42.248246
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "269e1237-3add-46d1-827a-57e1d6ccb033",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.8752406,
+            "lat": 32.74177948
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2c3a63db-f4d6-493f-a968-24634eafd06c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.186558,
+            "lat": 35.95853287
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3ed6b714-9025-4829-991d-2081136825e1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.4600536,
+            "lat": 32.95146251
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3fc166b8-53b9-4663-973c-3effc25c9837",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.85,
+            "lat": 46.3333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d019a432-d11c-4b2f-90bf-5308786bed93",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5167,
+            "lat": 46.8167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bc2ecc4e-f498-4144-a895-fc58634d3d04",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.127167,
+            "lat": 43.91853
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b0cbfb1d-f5e6-4514-a5b1-0f4719ee7657",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.515625,
+            "lat": 44.664062
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6d5997e9-96e9-4d83-b0f7-22162aef8e92",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.1753028,
+            "lat": 36.3858875
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "61960904-faf5-454e-a841-8e14a494c302",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.8667,
+            "lat": 41.7
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8bc080dd-b448-439d-92fe-1c6b4d35c6c4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.7279843004,
+            "lat": 31.8404445412
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7c408d83-6e8f-4f15-afb0-c2383b9b56a9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "347ce222-5bdc-4b51-bb93-1e81e9f0f60d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.6894489,
+            "lat": 33.55473024
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "84e87309-a894-447b-b877-10dc8ec91137",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.9833,
+            "lat": 41.4333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ebc192ef-3c16-41ef-95cb-ef8e329039aa",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.632402,
+            "lat": 43.373292
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c0a1ebfd-eabf-4a25-b5a4-d73b04bda913",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.10468,
+            "lat": 33.42485
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c2016bbe-2743-429f-b1f5-1d970e52fa25",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.676375,
+            "lat": 42.678524
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6f8df9b9-2282-4110-9fc1-cd7b164c5dba",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.70136792562936,
+            "lat": 33.18755451730115
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aba187ac-2f2f-45d7-ab04-054f0b11d498",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.0652778,
+            "lat": 16.7088889
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "566504fb-aa86-4b31-a220-cefbf0db3f17",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f6a28ff9-36b5-4844-90f6-d646c3fe37d7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "40181ebf-e5e7-4fc2-a9f9-e30c6479eaff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.399,
+            "lat": 47.3925
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7c6929fe-6fa5-4b08-aec2-354d0e300a55",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.9572222,
+            "lat": 34.5733333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "eb5e4be8-edd1-47e2-adaf-05bf8d39cf58",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.42614340128415,
+            "lat": 17.471761465164693
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4a8c2764-f55e-480e-bd2d-33260e756d16",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.08446,
+            "lat": 34.434365
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "829aa392-5f86-488f-bec5-72635712454c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.00542,
+            "lat": 34.10544
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4013e0a5-0e4f-47c5-ab08-1c39d87fa4ac",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.5151030141,
+            "lat": 31.89959
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "119d0f2b-cfc4-4c03-9f34-ac17109b8696",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.93061,
+            "lat": 32.05676
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5a91102c-1365-45be-9eb0-88e1ac09d5b6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5bf96646-8860-4d67-86fb-e3fe8a676031",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4235381,
+            "lat": 36.9188647
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4ef620b7-9035-4960-a529-04550b5cbe65",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0530009,
+            "lat": 33.19238112
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "72d362b7-00a1-4f55-bad7-8ab751e3144b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.012824,
+            "lat": 40.977423
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "765827e1-519f-4d22-a8e8-db569801b06c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.119714,
+            "lat": 42.131583
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "91c4b863-5e67-46e0-9c48-91d5032ec203",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.751261,
+            "lat": 45.122378
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b6c74cf7-4297-43d7-a84d-dac9da91a6cf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.186165,
+            "lat": 45.102615
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8b130567-959e-44de-a999-e1395efc08a4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.7322018,
+            "lat": 33.09368738
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a3a0c621-72e3-4514-8e68-584c72a54d5a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4815,
+            "lat": 32.3723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dcbcd22e-bd45-4ba6-81a3-b19c5b94ffe7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.412674,
+            "lat": 47.575193
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ebffcd19-4c30-4f79-b160-2ff8d73d17bb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.70534803117107,
+            "lat": 32.430375237105956
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "55a2fa38-4930-4294-b1fe-c14d850a585a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.63631602658984,
+            "lat": 48.0959373892604
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e9b28552-1945-4a61-a41b-c49341b8589d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.69464044233644,
+            "lat": 26.902984615965437
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "717c94b2-03e2-46b4-80db-9de3b47cc34d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.402,
+            "lat": 40.16329
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f9e288e2-2d98-45e1-ba2d-a3603728dbfd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.7,
+            "lat": 29.84
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d0230bfa-436f-469f-8f10-ad41701c7da1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.93333,
+            "lat": 2.58333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "996d4c05-8374-4927-9946-d7206c298bcc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.5,
+            "lat": 28.76
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8ea639c9-b355-4b57-b122-f540deb3da86",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ece8b75d-ead2-488e-b27c-6cfc1410bc41",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.0652778,
+            "lat": 16.7088889
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0be0aa0a-0d34-4d1f-a418-b2ea942d5bdd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4629567,
+            "lat": 36.68926527
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "06625189-a0ae-49c5-9b4f-7c79d708097b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.9167,
+            "lat": 42.7333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "08420f0e-ec94-462d-a990-190b3c5ba3c1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.330878,
+            "lat": 36.97136655
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "30b4da97-8f8f-48a7-8e0e-065418a7e69c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8307448,
+            "lat": 36.00451235
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6e5769cc-24fc-41bc-bf0a-06f679159f7f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.5,
+            "lat": 46.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6b5b7e9c-4a29-4412-b415-700ab0b9bce1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.75,
+            "lat": 44.9667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "655a3a8d-3d11-453b-905c-98dc873fdd03",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.044246,
+            "lat": 43.893791
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "67d18be1-4028-4909-85b4-5a1e95cb051a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3283997,
+            "lat": 33.7977993
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "77e4af69-ed74-4822-b7d4-2217e0bac4bc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.6167,
+            "lat": 46.7833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "558dfd33-25ba-4ce3-b08f-472a80f28d79",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.412674,
+            "lat": 47.575193
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "563c9d00-c1dd-4a7c-aef0-d507e275c833",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8719146,
+            "lat": 35.86865783
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4f35ba1b-6ea6-4ca9-a4c6-6e7877e38fc1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.5889628,
+            "lat": 33.32216539
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "48ecb6b4-a855-4608-a08d-906755be8390",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.8187677,
+            "lat": 34.0845659
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b6d820de-3d01-4956-80e6-e425c08ecf3f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.401033,
+            "lat": 48.656324
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e5462206-fc98-44a6-815c-88eb224e57d1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.240617,
+            "lat": 31.592321
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cb7a1e50-41f6-4523-8509-5135a4886f52",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.7,
+            "lat": 48.4167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ecab0aa1-3659-459a-9d90-da1ae51b3434",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5167,
+            "lat": 46.9167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8c205c15-e262-413b-82dd-0c5dbb590d5f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45,
+            "lat": 31.8333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bd0734aa-6c6d-4982-90e3-35f3c4d9f3d6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.675907,
+            "lat": 44.254635
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a1808fb8-7b8e-4317-9e8e-af11b59bb3fa",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.4553,
+            "lat": 48.1048
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8d56bbae-0ab4-4426-a4f5-469c74302435",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3283997,
+            "lat": 33.7977993
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9b8b1779-211e-4fa9-a724-ba90a5e7d3f2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5951281,
+            "lat": 35.0441862
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c2fed92c-21e0-4b93-8348-2e57687f4d41",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.228838,
+            "lat": 32.420674
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9a314016-71ef-4dcd-83bd-7d83a09bd423",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.4,
+            "lat": 47
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "94b17f2a-90d3-4ecc-be7d-f9fddf4b0d7a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.583333,
+            "lat": 49.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "14cdf49f-2d57-4206-a7e9-188531aa6fbd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4716035,
+            "lat": 33.300701
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "33e3e56e-b25d-4490-af3b-ec759e94822f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.6368231687,
+            "lat": 33.045015
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "482d5f43-bf64-4721-9f48-35a8f0fa71b3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.0141666667,
+            "lat": 31.7394444444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8e5d46e3-3cf1-4ed9-8acb-8eafdb98e019",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.19463967646935,
+            "lat": 35.22880270194663
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "59d731d9-287d-4b9c-b350-67ff64b85a83",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.038887,
+            "lat": 34.7777786
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6694e46a-44ca-48db-aa80-a440f7750e2e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.57184434571354,
+            "lat": 51.43505948090899
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c5e82b45-b59d-45bb-ad1b-43d817eb94cc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.2446518,
+            "lat": 29.3631592
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ddef5fe3-969b-4f18-87c3-14d0adf8baa7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.5022088,
+            "lat": 36.58913748
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e10b25ad-0dc3-4288-bdd0-46152d86c92e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1006,
+            "lat": 48.0797
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e1a533bb-e8cf-43fa-a160-7666b4f20a18",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.6197801,
+            "lat": 35.80051308
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e56d4d4d-83d9-4c6e-835a-d7e2b44d3f69",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.5667,
+            "lat": 47.85
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a10c5a42-4fda-4ef1-a869-67f0359f231c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.228838,
+            "lat": 32.420674
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a3332135-9725-4901-9f92-0430021a17fd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.297303,
+            "lat": 43.463785
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bcf62f2d-eca3-4e37-89dd-85d245173c54",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4894444444,
+            "lat": 32.5325
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b418adf9-ad6c-447f-bc37-8418eca74426",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.111577,
+            "lat": 42.098688
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b734a4e0-0962-4e66-91f8-b2208d5ea8b3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.98941,
+            "lat": 31.78605
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d6a0c232-ba09-45dc-8a8a-db354eced465",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.8343198,
+            "lat": 32.93148319
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d8484ef5-edc6-426d-9dec-91b7ef4c0ee3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.32556,
+            "lat": 45.41263
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ef4e76da-9f0e-4849-9bd2-ce270735f336",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.386267,
+            "lat": 34.67610615
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5dceb0cb-8e79-4a52-aa4c-7a473df4af7f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.201177,
+            "lat": 47.37235
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cbe3bab3-537b-4fd8-bfb2-97b62a07e739",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0758512,
+            "lat": 34.464825
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cde4fb79-acfa-4f66-b54e-9016e569f5a2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.49399,
+            "lat": 38.25271
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "578a1b06-bf2e-4cbb-9dbf-0e32fdf6d756",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.51666,
+            "lat": 2.83333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fcdec691-1910-4078-b28b-3f15b8e81f96",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.48,
+            "lat": 29.41
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ff2dc298-5f77-4fec-abdc-cca6feae98e6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0567057953,
+            "lat": 34.423206
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4f589d95-9435-4152-a123-fc61771fe535",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.008946,
+            "lat": 32.200082
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "65f73e97-3d20-406f-a8eb-d7ab2ffb6c73",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.9967684039,
+            "lat": 34.189772
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1f98f351-1c1c-47ae-9d91-d58eb52d0390",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.14,
+            "lat": 45.5451
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "39d90867-08d4-4902-a917-dd0e05752f04",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.578063,
+            "lat": 42.412688
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5de975a2-4b08-4bae-9eed-bd9b7a682c8a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.600088,
+            "lat": 42.283881
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "87cb3d47-5dd5-4c35-b5c7-cbed08732c36",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.600088,
+            "lat": 42.283881
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aec30f49-9c68-438a-af7d-6004e49aa43c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.583333,
+            "lat": 49.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8e619fae-e053-4198-bc1c-c25a7ee7686b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.16512,
+            "lat": 46.014636
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "92d29d48-e90f-42dd-8102-0dd4f5a7b4f3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.836547,
+            "lat": 44.941823
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8126e1a2-47dc-4b56-b979-bda08c771b6f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.284249,
+            "lat": 41.979667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "82d0cd2d-d27a-44c0-8b98-a97ca83884b3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.8333,
+            "lat": 45.5167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "83f31f4f-f0e9-49dc-b3a5-7c69584f65ac",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.2333,
+            "lat": 42.5667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "983d5aa0-5b57-4750-8954-bd1381e27f9d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.240617,
+            "lat": 31.592321
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a8c444b1-6311-4166-9730-0d16f24c1a78",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.119714,
+            "lat": 42.131583
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b023dd39-f913-45df-a1de-c5e6c05a5f0c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.083,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "13eba4e3-b56e-42e6-8de9-73ca35d7c448",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.4167,
+            "lat": 46.6833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "012a759d-8635-4aaa-add1-87917b6a524a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.942665,
+            "lat": 46.961838
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ea0052fa-3a50-4845-b5a9-23cbbf25d9e8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.4167,
+            "lat": 45.3167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fc27ad9e-4b8d-4c38-ba88-a249d9694bce",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0818641,
+            "lat": 36.41028167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cdcb5560-2a87-40b3-9ffe-48f7394cff31",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.7333,
+            "lat": 45.4833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e66949e2-cccc-488a-99e9-ac9260ad6b1e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.2667,
+            "lat": 43.6833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f3444ed1-c75e-44c3-a182-8302cdeb50c4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1535,
+            "lat": 43.5537
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "19a312f4-15ce-4dc8-99e5-3c03614c5e8f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4f34b4f0-6f16-4cbe-b5bd-777878774156",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.4667,
+            "lat": 42.2
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "835b0def-b95f-42c7-9544-d00581be7f0f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8481709d-494b-452f-adeb-ffb9618b1d0a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.091973,
+            "lat": 33.346183
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7930e63f-5018-439c-a48e-c23115216aae",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1153381,
+            "lat": 33.40545506
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6671f846-32ab-4afc-bdc5-d67ecd36b3c7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.2124,
+            "lat": 42.6743
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "59bcffab-0efe-41f7-9407-306f3ab9557b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.4333,
+            "lat": 45.4667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c1dd0b4b-6e27-4a28-b38b-89efa0bc4348",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.839157,
+            "lat": 32.064445
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9b82253b-f5db-4cf0-a3ff-21b14727b82e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.662,
+            "lat": 30.306
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5f47a532-4c15-401e-b52f-d621c12e98b7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.51666,
+            "lat": 2.83333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "49ebc0cc-7f92-4caf-a120-7be3597d7f89",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.084478,
+            "lat": 34.434229
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "09613ba2-8242-4aca-b25f-57acaf14e39c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.97402602,
+            "lat": 34.145057
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d9832dbb-3cdc-4f9c-b570-d4fa1c70ac01",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.999116,
+            "lat": 34.110751
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8ada5ef2-e93e-4199-8f12-0c3773607cb7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.005311,
+            "lat": 34.105622
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7782429e-8c6a-4f62-81f8-3fd6fd80bd2e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45,
+            "lat": 31.8333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "da0f6cdd-6a62-4c8b-b16f-46753e8b47f9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.8763,
+            "lat": 38.25538
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cfb7623b-523f-4605-9d28-6879fbad4556",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.83888,
+            "lat": 38.21945
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3896bc0e-0eca-4e4b-93eb-b8f7bcaa25dd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.660983,
+            "lat": 34.678735
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "39d3bbd9-087d-4586-9a26-e421bd3fbfbb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.57670559226793,
+            "lat": 33.76922795495304
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "036eb6e8-c4a6-4a66-bde2-f6835615149e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.9594444,
+            "lat": 34.5727778
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9455e763-44b9-4e34-a839-982e96195c9c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.2253579454,
+            "lat": 32.9595416107
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9ad53277-59a6-4626-896a-e41806e81516",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.023447,
+            "lat": 31.205281
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9fe2fb30-bf33-448c-b5a0-3ac7a38bc049",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1163888889,
+            "lat": 33.3308333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cbe21117-51eb-48b1-b50e-c51b13a5aabe",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.97402602,
+            "lat": 34.145057
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c5e3f6f8-1fa8-4939-b324-bb63f303963f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "73606500-c6fa-4e89-947c-03ad3095f05b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.8043,
+            "lat": 38.22658
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "820b0d2a-9ce0-46ad-ad77-05aecf9f2f25",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.79542,
+            "lat": 38.17156
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b675b68a-1c24-4c5a-8e53-83e8535ddbcd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.984703,
+            "lat": 39.739154
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e66dbe05-e1c4-4a11-ac1b-b11e3c90ab5b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -100.2769444,
+            "lat": 28.0769444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "10da513a-6075-45e5-b0f2-b39559c5854d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1359,
+            "lat": 43.6463
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "11c9534a-0970-4640-a130-a15ed7a6c2b1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.6201,
+            "lat": 44.894871
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "12a99758-3461-40b6-9b36-dad56fce2cf7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.062077,
+            "lat": 44.49517
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1cd0ef6f-0778-40cb-9b06-1f1518f1732d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.65,
+            "lat": 45.3167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1d2a72bb-48d4-45d3-8c5c-e4e85aaa1f4d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.7228809,
+            "lat": 36.09342829
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "73aa0613-fe0c-4aec-9ea2-1479098b20d4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1163888889,
+            "lat": 33.3308333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "60fdbb8b-a4d7-486a-92f4-b509e5cdbace",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.5421288,
+            "lat": 36.85675719
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5870c450-5a5f-460a-b954-58ee36e5dc3d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.414391,
+            "lat": 37.299671
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5d93e679-37ec-439e-a8eb-e97b4a244494",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.35,
+            "lat": 46.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "705e6112-73c7-4305-96de-8b2e6799ddaf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d2d263c2-cc21-41d3-8215-a2a8bd2e7a96",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.3,
+            "lat": 43.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c50f25c5-4953-41ad-bc65-2798bf4c897e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -97.145248,
+            "lat": 25.956192
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d571ceac-9d64-416a-bd83-570e41b667c6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.358505,
+            "lat": 43.889692
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "adf633a6-ea15-47dd-aec8-f58d85512596",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4320983,
+            "lat": 33.5285997
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bcff121d-d35a-4184-a4d5-eec43969a998",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.45,
+            "lat": 42.2833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2235ed3a-bb72-4ebc-944d-6fbd2997ba72",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.3252,
+            "lat": 31.60105
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "299b3228-ff6e-4c86-b779-84b331f84195",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.1667,
+            "lat": 44.0833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "318e97c2-a64d-431d-90da-d7539cfc4bd2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.4905229,
+            "lat": 32.75574484
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3f824013-d5dd-49e8-83f6-134fad89963e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.583333,
+            "lat": 49.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "388c2e48-00e8-427b-8d89-7f44733bb9d8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.7419,
+            "lat": 35.2672
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e2bbc357-e584-40fa-b177-20f1d776c755",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.652633,
+            "lat": 45.812124
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a9528189-86dc-4bd6-ab25-a53dd9646edd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.6520977,
+            "lat": 35.69214844
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "922f02a7-dddf-4dab-a6ca-37b75c3c7d10",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.49916,
+            "lat": 32.55842
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "933dd5f0-29ba-4813-9ac1-3b85754c6d64",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8841533,
+            "lat": 36.38227872
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f3ca36a7-95c5-407b-9da5-095a9146c3c6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.6555556,
+            "lat": 34.2722222
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "71dcbab3-8d6f-492d-b154-af550d76c976",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.321194,
+            "lat": 45.228806
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cd88ae0d-ac94-4c3a-8d00-57e74b526ff4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.4627778,
+            "lat": 34.6163889
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "71f67429-742b-4629-bf47-6985fd06c0b0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.083,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "735ba573-8e63-41ac-95f4-ee5c7661cd43",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -75.02184,
+            "lat": 44.479677
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "20c505d4-cc73-4a47-a12c-68c069add6ee",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.292468,
+            "lat": 42.395473
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1b71ad9f-69a7-418d-8848-e322022376b5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.633874,
+            "lat": 33.882056
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "18426a8e-3932-4a08-b097-9c5aff4b21a6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.5659798,
+            "lat": 32.72280989
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "00170cbf-5381-4d61-8cfe-85e101517e65",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.2487166,
+            "lat": 32.88261318
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d0f26ae0-d8ce-4a6f-9a6c-3040b0784a1f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "eec216a1-fb73-4bfd-bc80-b28423eb3465",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.55,
+            "lat": 44.2333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f01f344c-df8a-4d9b-af37-267796b22ee5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5333,
+            "lat": 44.4667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ec69813f-9d13-4fb4-ba4b-554f9470d587",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5132151,
+            "lat": 36.36268205
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f7b48cef-2316-4487-855f-4e30ef0e5586",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.770554,
+            "lat": 32.773888
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5ba176f4-8eb8-46f6-8fe4-b648b5ff667a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.8833,
+            "lat": 45.5333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "92fbca48-9cb3-44d0-933c-7799d2c5b4ae",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.89822,
+            "lat": 46.92156
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a7aa811a-f931-4741-829d-3895130160ed",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.407925,
+            "lat": 47.137142
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ac7d5f89-afc0-4f87-9ce9-f88ff0539d3d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.8333,
+            "lat": 47.2167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3aa4bb20-1a43-406e-9a82-2b16389e6939",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0207569,
+            "lat": 36.62619108
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ff9ca24c-0554-4a26-a0b8-1a39dbced23d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.685439,
+            "lat": 44.957319
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a0ec1b46-d673-4d95-a22e-8d180e1bdc81",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.008946,
+            "lat": 32.200082
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d4473657-a4c7-4889-8b45-1baa0ce00bb3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.35,
+            "lat": 31.6
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0048c521-16e5-4763-80e7-443c37f7a932",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.3903,
+            "lat": 42.1976
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aa8a5263-952c-4aab-8f5f-301511f38cd4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.83917,
+            "lat": 38.35783
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "785ef1fe-4c4a-4f02-bad6-8d5ed202a597",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.984703,
+            "lat": 39.739154
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ccf10c68-7fd3-4666-8c2e-8bfbd20dfa33",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.825508,
+            "lat": 32.114555
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b575b5c9-8131-449a-b1be-bc1449ab0fd5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0460495616,
+            "lat": 34.432401
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f3714f3d-2ab8-4481-b9f2-2f15d80165c7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.7679437,
+            "lat": 33.60786187
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f92fc094-15e5-4e4e-a556-3a4ca0002afc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.921,
+            "lat": 47.105
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "121787cd-cf18-4b73-883c-ccd58564ca18",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.024439,
+            "lat": 41.744369
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "08f17061-844d-4475-9ae0-cf80fb9b9814",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.8184586,
+            "lat": 37.2969437
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "03197478-b969-413d-bd4b-5c00feb6d995",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3,
+            "lat": 44.55
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "de237c51-47db-45e9-9a4b-054120a80bd9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.5667,
+            "lat": 47.85
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d872fbb4-ed44-4f5b-93fd-a28774af0a86",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.031824,
+            "lat": 47.252699
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "da8dbc78-a04e-4338-8d50-7cc68a95ad9d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.334944,
+            "lat": 35.92108499
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "59d85e3f-54fd-4a1d-ad64-fd6f1f36078b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.646393,
+            "lat": 33.080833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8ff882e4-d887-46a3-ad73-d8c982018b52",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.3612304,
+            "lat": 31.6035623
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aa4f85ee-4b4b-4f2b-8a14-146485028670",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.582892,
+            "lat": 44.468233
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ad9e348c-d61b-4e79-91b1-a20ef50b626c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.587784,
+            "lat": 32.934803
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b13a0f90-3d73-4473-96d8-35836984ffef",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.22239,
+            "lat": 47.548532
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c1a29a6d-2471-4921-92d2-cc4f4a686476",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.8125992,
+            "lat": 32.89554585
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4eaf50a8-a10b-4065-84d6-0b54a928baae",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9343ca9d-6a4e-4335-ab7f-07154e7f6bca",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.259753,
+            "lat": 44.698534
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "978a10c5-0f69-4aa4-aa7b-e6a0deddb768",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.996556,
+            "lat": 34.18074477
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6d0895d9-5207-40ff-9d40-bd99d1c791d5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.875,
+            "lat": 47.0004997253418
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "99e03792-681a-4bde-b6db-18d2e4fbfe29",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.43,
+            "lat": 25.57
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0e888de8-69a3-40f6-93e9-8703d13368a2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.78,
+            "lat": 29.96
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cfa25222-063e-4000-ad2e-95cf68a2f8eb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.069495,
+            "lat": 50.005021
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ebd99172-fb19-4614-b06a-9b137b82b059",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.663485,
+            "lat": 35.078382
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f093ae22-533c-4a2b-9649-e9359135d282",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.558184853,
+            "lat": 32.73515
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ae38d528-053a-486d-92de-062e675e21da",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f418346a-c41b-4dec-ba11-086a41968ae7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.82347,
+            "lat": 27.03037
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c72367d4-0db2-46b1-bbcd-a64648aa1b15",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.09944,
+            "lat": 38.39354
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7dde1912-3ae6-4eee-8bf5-f748d9b43120",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.98615,
+            "lat": 38.30474
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b5f4c300-c3d5-4041-a6a1-056bf6d77059",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.50616,
+            "lat": 49.458596
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bd5e35a7-fb36-4f17-822c-e1d41cb0b914",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.43,
+            "lat": 25.57
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f1c125d7-4f23-4d78-b4bb-f7a0ca2c21e2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.2710972,
+            "lat": 29.2735444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4f486049-9638-4b0b-a09f-eea01fd4daf8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -76.52,
+            "lat": 0.5
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "76c0f5f0-163d-4bf9-a999-4a96a9fd845c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.082324,
+            "lat": 44.911577
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1c213379-4605-4483-a33f-d754322e131f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.6450234,
+            "lat": 33.37458017
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "278185c6-c3cb-47e5-b2f7-dd00d131673c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1006,
+            "lat": 48.0797
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c3a2a667-9b9c-4d0e-b0ba-c6c507e2c25f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.52583,
+            "lat": 32.62175
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c980ccd3-4755-4145-80e9-be06b6ae14ed",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.3,
+            "lat": 42.6
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "55de6140-4789-4ba7-88f9-9773dde58235",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.646393,
+            "lat": 33.080833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a2e43d3-e25c-473d-8c18-510e4eda089f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.4043769,
+            "lat": 34.02822225
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "90cd8fbb-e98a-400f-a812-94e2597bbb30",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1228508,
+            "lat": 34.46935551
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "94ab6da9-e663-4d3b-be9a-08f608844f7d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.236109,
+            "lat": 42.597132
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "846508c8-473d-43e3-9f67-224fc1473867",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.407925,
+            "lat": 47.137142
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9c8a2e3c-be9e-4e7e-ac39-72e36dea7500",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.65,
+            "lat": 46.9
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ada27c57-5c72-4ab6-9122-b1ac4e3a8a1f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.5,
+            "lat": 44.55
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b8cb74e5-49c9-4cb2-ac25-fb38831c1916",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.077256,
+            "lat": 34.367841
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a31834c4-b069-4dcd-be1e-de1980547542",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.80364,
+            "lat": 38.26347
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "42e2cb40-63f1-40ba-b3a2-c71a80d19296",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.197133,
+            "lat": 38.538268
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f4733d56-8a80-4743-a0a4-fd9ae05ea236",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.55388,
+            "lat": 32.46175
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "db01e1cf-b84b-4a40-930e-3ea36428c598",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.167705,
+            "lat": 40.978566
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "16eec2bf-ed68-43c5-a6ea-da59106b94fc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.023447,
+            "lat": 31.205281
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "be60121c-a28b-44f0-bb9c-eaf6a741579b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -98.6833,
+            "lat": 33.6167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4a271537-8a0f-4ad5-ba07-651d96c36e2f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.433644,
+            "lat": 31.474494
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3f661b4b-a0cd-4679-97bc-4828d75edc9e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.943948,
+            "lat": 32.006756
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "eb5f2d9e-e7be-4586-901c-6e8280ea4a5a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0675816052,
+            "lat": 34.423023
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9d7b04e0-174a-4999-bbeb-2bb49e8e10c6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.53944,
+            "lat": 26.33583
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e158dfa5-787c-4085-a494-cec3cab843c1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0634510079,
+            "lat": 34.438672
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "756f89da-2de2-4def-9aa1-c5dc14ca5627",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.92302,
+            "lat": 37.693865
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d2f4fd3e-2e79-434b-b9e0-e956aa779c16",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.5,
+            "lat": 27.69
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "82e6224f-359d-46b8-b31e-73f7a75dfa4d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.1625,
+            "lat": 16.8125
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2326b114-d275-4e35-8a13-4e4f19008df3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.64935,
+            "lat": 35.4708
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2edb3928-5127-4943-ab07-744253c36dc1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.771556,
+            "lat": 44.967243
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5f0fa7d6-a8b8-42c8-8a15-cf8e8140dc2d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0833,
+            "lat": 33.3167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6a2895c3-8975-43f7-bfcb-e80b93000446",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.5667,
+            "lat": 42.9167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6b201010-93c1-4b2f-8f39-a9dd981a574e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.600088,
+            "lat": 42.283881
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "30175f46-5700-4a95-b1ef-6c6ac4651dd0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.386713,
+            "lat": 43.255182
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cc496b8c-5aa7-409a-b9b3-17173970c302",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5059371,
+            "lat": 36.65544902
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b834cd93-a2c9-4067-b31c-1cb010a5bb9c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.7106238,
+            "lat": 33.50951381
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "05fdc407-a136-4d83-b75e-633d4e4d8ff3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3333,
+            "lat": 40.3
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8d14a541-3a40-44c1-84ff-f68bac577938",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.980266,
+            "lat": 42.072418
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "87336274-1eb6-458d-8840-8dbb7eceb8cc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.50944,
+            "lat": 32.56814
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "89093e24-4480-4f73-ac15-217b7d03b047",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.10468,
+            "lat": 33.42485
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3dcf90c4-50f9-45f3-b251-3444cfc4c514",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4596660322,
+            "lat": 32.583002
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "28db33c5-ebb6-4542-b9c0-568f27f18e23",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.0191667,
+            "lat": 34.5883333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6da36cc2-9c3e-48e1-9cd6-35f5969ad5d4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.77239,
+            "lat": 38.29688
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6528660f-2f84-4ffa-a2b6-79aea3ce51b2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.745159,
+            "lat": 38.230954
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f843b8c2-1044-4314-a44c-e83ebed8234f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.5512,
+            "lat": 47.6509
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "049faa11-cb49-477c-9da9-ccf8704bbdd5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.745813,
+            "lat": 44.068202
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0fb6e543-3f0b-45a5-af1f-c0df39e9ebee",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.119,
+            "lat": 43.5719
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "13798251-57ac-4ba3-8e93-26bb01f8b0f1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.825508,
+            "lat": 32.114555
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "31582a50-cbf5-4f92-802d-109eab7c6f51",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.470155,
+            "lat": 46.800732
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2b22e4da-cf9f-4f99-9844-71d48ed18dd0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.70963,
+            "lat": 32.72195
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "da5e8648-249c-48c2-8d36-819deeb06514",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.5094578,
+            "lat": 33.3959339
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cc6337d7-2888-4e65-abc8-f612ea4aaf44",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.7331914,
+            "lat": 36.09739588
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "560e5178-9dc1-4a36-932a-16a8818e7e47",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.3323,
+            "lat": 44.0342
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "57cb91e3-fb9a-4dd6-81ba-65242f76ebd2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.933362,
+            "lat": 40.50728
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5d0e8201-01a3-4350-9cd4-80dfad3ef9a8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.670197,
+            "lat": 35.051358
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "39e2676b-f96e-4da9-8b45-ee330056c3e8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.0461673,
+            "lat": 32.8803531
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aa1b7883-4688-45a1-a8cc-d89d72eeec57",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.198354,
+            "lat": 39.546077
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "752a0c2d-3360-4931-8035-ae83924ee959",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1113105223,
+            "lat": 34.431291
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2be8ad34-d49b-4bf9-8a98-b2244fda0d36",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.824463,
+            "lat": 35.550313
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "857aa0af-c4d1-4031-baeb-2435ff81e585",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.42614340128415,
+            "lat": 17.471761465164693
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9086b8b2-f948-489e-b5cd-875a403e6453",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.6844444,
+            "lat": 34.9469444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "24fa75dc-5b96-46a4-bce5-d6582e56df4f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.15657750549326,
+            "lat": 47.916773045271675
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ce53e09b-e8fd-4866-89ad-4149e229618b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.008946,
+            "lat": 32.200082
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "41818727-4ff9-40f1-a43d-7e22b8177796",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.2471,
+            "lat": 44.3786
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8417840b-fc75-438e-a1e7-150d148d855c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.85,
+            "lat": 46.8
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "da649429-ffc8-46a4-8989-83be588e5aae",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.33996,
+            "lat": 38.21152
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cf30809d-d626-429c-b188-c73d046f74ef",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.71865,
+            "lat": 33.83834
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fd347d3a-3922-46ed-9391-966c40921609",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.05,
+            "lat": 43.5833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f6b312d6-5999-4466-a37e-43ab53c7f33a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.9711111,
+            "lat": 34.4455556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f2a511ed-1f78-4c10-a5b7-71d1b04e39f7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.2430860186517,
+            "lat": 50.01652199931778
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1949385d-5ddb-4a83-9a19-6bc2a579b2e3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.731787,
+            "lat": 44.970178
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "021f1a47-7043-439c-ac45-1199865373a7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.184723,
+            "lat": 34.048332
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5e485f51-74d2-4d53-9126-54a07bbdd870",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.9167,
+            "lat": 43.8167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "605e790f-524c-467c-bcd7-99e6e4a3373e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.7863362,
+            "lat": 36.49195201
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "91d51156-0763-4a0b-8f51-8c0a5ccf2cb2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5214699,
+            "lat": 36.47737501
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7857b49c-cf03-44ad-86be-7543a602b883",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8518749,
+            "lat": 35.99246858
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8846ad34-be95-4637-b9bb-667d0198c2d5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.583333,
+            "lat": 49.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4e0625ed-1fec-4e92-85e5-1ab60bdd30eb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.578063,
+            "lat": 42.412688
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5398822f-e1e6-4350-9998-3803ba319ca5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3681055a-fd1b-49a3-bb15-877efb95c826",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4565127,
+            "lat": 35.268304
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ae060d7c-ea69-4430-ba09-6bb6d79f285f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.0438,
+            "lat": 42.9634
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a08bac7b-fb8b-4c5a-8aa2-65a855da14af",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.55,
+            "lat": 45.3667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d0bf1c9f-09f5-466f-a0c9-a6fa12edd994",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.85,
+            "lat": 46.3333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d2ab1187-f1fe-40dd-adb8-7357be1d1090",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.0858494,
+            "lat": 33.08954897
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e67ce7f1-4052-4c27-8fd2-022b36283f21",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.082025,
+            "lat": 41.521018
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cc97fb56-cbc7-4604-9426-86acfba86daa",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.4167,
+            "lat": 44.35
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c3fb3fb4-d1bc-406e-b918-e9ae57fedd20",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.459169,
+            "lat": 42.517132
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c4f92d68-1bf6-49cd-a267-9d244b4ba45a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.3327093,
+            "lat": 35.96393964
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f1d5027e-5e9c-4af1-810e-477e8375ec78",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.4167,
+            "lat": 44.35
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "918c8e54-174c-44c3-8a80-60b2641f4382",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.130932,
+            "lat": 41.884915
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d1bb4565-bd19-43ff-bc9a-3d49ed7e13eb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.755893,
+            "lat": 35.454188
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4e6fdd31-adf9-485e-90a8-686423040c93",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.912882,
+            "lat": 39.563031
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5d669010-8e96-40a8-8302-8597e30d639a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.2251319553,
+            "lat": 32.950527
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8bac2759-88f2-4548-891e-3cbf139c2611",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.19102176326724,
+            "lat": 34.959318559172054
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1a1f3dc4-0b1f-4039-9f30-1b86e15f2dd6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.08275,
+            "lat": 39.000747
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d1014ef2-be29-4441-9266-1235da06d63c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.67220265053544,
+            "lat": 46.03989523116191
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4ff7eddb-4db0-4e48-a2db-47846defbcac",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "391ad707-8f84-49fc-b328-9a5659128906",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1113105223,
+            "lat": 34.431291
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1c8293f5-c596-4759-8f82-5be425f50b90",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.570178,
+            "lat": 41.792589
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "53cf32eb-d7ef-4fbc-999e-c74b7bb68605",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.776101,
+            "lat": 36.04139358
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d3a6359a-2e23-4cee-b922-9811598a10b4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.0864,
+            "lat": 47.8163
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d19de662-d63c-4b2d-89b5-9e87c8d6cc56",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.72227,
+            "lat": 47.881511
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d2d73817-749a-4836-841b-71bd708cc2cb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1106,
+            "lat": 43.9956
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bbcea426-2dd0-4131-bfcb-1dceac1b558a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4523486,
+            "lat": 36.54156288
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "91e05d84-4d71-4667-8dc9-86747fc9eea1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.596069,
+            "lat": 43.574915
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b5867c2e-cd43-4d42-8d08-aa9e954ad6b2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.398433,
+            "lat": 41.571013
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ab635026-5351-4f65-8fc5-3e06299932a7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.2570373,
+            "lat": 36.44814835
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f4391315-5057-4d7e-854b-adcc1fc6b8e6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.270627,
+            "lat": 44.713534
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "515bce42-4b1d-4a02-ace3-54a07ae906a5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.583333,
+            "lat": 49.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3f42edaf-d71b-4157-b371-515b7342218f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.8333,
+            "lat": 47.2167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "40324ae0-ba41-4ce2-8e85-7860bdfdaf9d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.7333,
+            "lat": 43.8333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1cdb9396-0833-47ec-bd6d-c95264f822f4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.023447,
+            "lat": 31.205281
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9d2be51d-4d19-446f-b78b-42bcb4d64c01",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.023447,
+            "lat": 31.205281
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "58ae45a3-172d-41af-84b0-bbc5b9af9fd4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.6838013854,
+            "lat": 32.750578
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4dcbb73d-5025-45e2-b062-658f4de75b45",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.449278,
+            "lat": 31.889969
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ec58b1bb-65ab-4a24-be2b-7c5d79d08059",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.0622222,
+            "lat": 34.5336111
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e1907d2c-5dfa-40f0-ad63-21ffe53ddc3e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.05281,
+            "lat": 38.36314
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ef9e6f14-4ad5-42a5-8ffe-8905fd259f73",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.533804,
+            "lat": 48.305481
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b0b8b996-d48d-4162-af4b-03a1554118d4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.6333,
+            "lat": 43.3167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fea55b85-03b5-45be-ad9a-90bc3e79040b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0675816052,
+            "lat": 34.423023
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dfbc2e8e-a50e-4702-844a-8ed226b1ac7c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d4733de6-e343-42f2-b673-8baac4784d22",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.491471,
+            "lat": 32.573609
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b8cb14fc-df3d-4087-8c15-00480df76776",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.3856309,
+            "lat": 31.617434
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ff7febc3-e019-453e-99f0-54e6f45bbccc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.284249,
+            "lat": 41.979667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2398ebe6-6f64-4e39-8211-e90c5a4f0f89",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.333997829,
+            "lat": 31.580295
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ee2bea61-8ea2-4f97-b77a-2e7b90afd2e6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.198354,
+            "lat": 39.546077
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c46b6ff5-6f37-4871-a602-af3057e7845a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.008946,
+            "lat": 32.200082
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "02f6edeb-a514-4d07-8d82-1187d0588091",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.48,
+            "lat": 29.41
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f67815d3-d24e-4233-b14f-21ea30dead74",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.628175,
+            "lat": 32.6931833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cf8d7451-1047-4ffc-ad7a-d48030ce37b2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1387,
+            "lat": 43.4113
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c3f29538-bfbc-4478-acbd-391115074936",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.65251,
+            "lat": 45.32323
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bb95e059-8c24-4572-89ed-82c1423e9322",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.0833,
+            "lat": 47.8333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0f9be454-792c-4fa5-b024-c24495b3ddc0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.2333,
+            "lat": 45.2333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "109508c5-66d5-4976-8b53-62dca5b91286",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "132fc73a-aecb-466e-b04e-8bbc91bea2cd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.945894,
+            "lat": 33.97641368
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3ed608c3-791f-45bc-af70-c7c650dd9726",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5951281,
+            "lat": 35.0441862
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "41a2852a-987f-4590-baa5-20d21fc9e9f1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.350254,
+            "lat": 47.66876
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6b5bf63e-de34-48a6-add2-bc4a3f586804",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.665047,
+            "lat": 42.037548
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "76f9957b-4b33-476a-afde-be4d7a667200",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.7232093,
+            "lat": 33.52234765
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "51b51c4e-27ef-44b7-b363-5436834c47be",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.8242,
+            "lat": 47.5289
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7fdd4efe-8bc4-47c9-b22c-a8d05d1d33f1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.192379,
+            "lat": 33.130491
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "93900a0e-96a0-4cb0-92a7-73c989555a32",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5777671,
+            "lat": 36.66616408
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "832fd93b-7f07-44f0-be27-b8d9b4b6c6f1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.5168438,
+            "lat": 36.7639687
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a6c12522-8856-4ada-ad7a-039f3123f127",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.452461,
+            "lat": 31.887368
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "678606cc-c4ec-4092-96c6-51a220efd507",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.73498213872537,
+            "lat": 39.54246590613516
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7af60aaa-5337-47bf-b778-caf8bb7440c4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2a416111-a768-486d-b62b-61d300f14dd3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.51666,
+            "lat": 2.83333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a70a06b4-ffce-4cf0-897c-a37215b92b88",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.069495,
+            "lat": 50.005021
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7aa93b06-9827-4b54-8f84-4fe56bc99658",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.58412001410656,
+            "lat": 37.10415089492064
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "86b787ca-bc5b-43be-b40e-d446399ba42a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -98.20829859656273,
+            "lat": 23.768450930116682
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e0520828-b09f-4766-a444-7846959e97a4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.498829,
+            "lat": 42.569645
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f7e2107d-39e3-4dc3-b4c5-69abd457f496",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.663485,
+            "lat": 35.078382
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "56d96ad7-5e32-4aac-aff4-3422e2446ba6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.35,
+            "lat": 44.2833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "919db7ca-91fa-4190-82a1-3e9f428febb9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.70963,
+            "lat": 32.72195
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8c8a5db4-1ea1-4759-a125-085b46a85850",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.6670405,
+            "lat": 36.13310831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0ba260c5-5550-456c-aa6a-58cc5e268812",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.883122,
+            "lat": 33.316729
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "06f3bf32-5279-4a01-a778-54bfc0f40d63",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.3903382,
+            "lat": 34.02535024
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "67fbc9e9-9f5f-4d22-8f90-31e572cf57fa",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.523449,
+            "lat": 32.81590709
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6a67d155-1ed9-41b3-bc8f-d59115233902",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.327337,
+            "lat": 41.951187
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6bfdf96b-3f88-4a41-8f78-dad20fb33c57",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.8,
+            "lat": 43.05
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "51a12fc6-4199-475b-a1d3-02f91f5d36b2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.215514,
+            "lat": 41.892425
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "47693a08-16d6-4850-ab3d-5a035e7e08b4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.6913951,
+            "lat": 33.79823614
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "478dad9c-188c-4687-8afa-1c193449dfec",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.3667,
+            "lat": 42.65
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cc916dec-950a-4b0f-8dca-3049f14d7b1a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e6cfd149-910b-4fec-a04f-7940028d19d3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.35,
+            "lat": 44.6667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ef273077-5cef-4fd4-b6ff-4ac6a78aca15",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0561111111,
+            "lat": 34.4580555556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2b7cecb8-2e6f-4e93-ac50-b8706dd09b8f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3814233,
+            "lat": 35.68598484
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2c0ea60f-a5ac-4c40-9544-cdd75dac8af8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.13902,
+            "lat": 33.31705
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ff6e037c-39d4-4148-bf20-03445423de52",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.124407,
+            "lat": 42.42853
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "05cf2eba-6c14-4958-975c-4d3f2d2311ec",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.433644,
+            "lat": 31.474494
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f93cabea-c1c5-448c-9da7-580608a43903",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3283995,
+            "lat": 33.711498
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fef5591b-5714-4728-a57d-6dfb12ae483a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.78699,
+            "lat": 38.2677
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a41a2e0-83d5-472f-82f3-5ccf883668c8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1976118178,
+            "lat": 34.402723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4181ab0b-2d18-424a-a1ba-258eb4705294",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.87143512551576,
+            "lat": 32.70176843296257
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0e005923-680d-4bb2-9d57-cc32fce0a1b8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.3660246433851,
+            "lat": 47.95761062251738
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cb30ad90-632d-43a3-bd89-793a15769f34",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.23673,
+            "lat": 47.88084
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ecde599a-329f-4304-9482-335354f954e7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.4628365,
+            "lat": 32.48072005
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d2274128-76f2-4798-9019-9816214b8daf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.008946,
+            "lat": 32.200082
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2d74af3f-deb7-42aa-a7e8-cd324e2cb63e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.023447,
+            "lat": 31.205281
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a5b6c91b-fcde-4246-9291-21fa5f5c1f92",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.433644,
+            "lat": 31.474494
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6826e2dc-eda9-4629-864a-37650aa4faff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7966250b-9741-4127-9145-d2d9ab91d165",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.03671,
+            "lat": 38.06358
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6f82246b-536f-4875-b44e-59a10de1e8a2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.80645,
+            "lat": 38.15794
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f8267c93-6c57-4d76-9027-fc9c5d600ef6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": 0,
+            "lat": 0
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1351af03-e457-4c0d-b19d-44cca89176aa",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.3086111,
+            "lat": 35.46810594
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1b0ad438-8a8d-4863-9a25-30971a4bbe57",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.905653,
+            "lat": 44.99158
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6e9e5cad-188c-4906-b558-d178111316ad",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.6667,
+            "lat": 46.1
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "73ab0f7c-3eee-4440-90b7-a4ea7abd42a5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.7333,
+            "lat": 46.6167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a31ffa1-2bc2-452b-8d3b-11ed9e5dfca2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.7667,
+            "lat": 42.6
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3c1d8f7c-c625-49e1-80cb-f1b4e73956b5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.2987208,
+            "lat": 36.66342036
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a69ba089-9e76-4618-a734-062234bb23c4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b23b12da-6cf9-44c8-960e-14e189855f9c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a20ef338-124f-43e9-876a-5611268b936b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a42cdbca-9aad-4cd6-9b49-36b8613e8415",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.7,
+            "lat": 42.4667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "962c80ed-ffcf-432a-a0c2-de4ddf9371f8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.927939,
+            "lat": 47.474094
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9d5ff059-1eeb-45c9-a8f2-6f6383f30361",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cf76f847-0dd1-4af3-bdae-2d0c7c323739",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e0369012-f5b9-4152-97ec-4ae95f2ccb85",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.7167,
+            "lat": 41.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "76bb7ee4-094f-4a49-83d3-25f38e61d977",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.51666,
+            "lat": 2.83333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f0e8df36-0b0f-4fb1-b268-52bd9d09ce88",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -126.6166666667,
+            "lat": 49.6
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "125d35bb-aa86-4d51-b416-9ab190ea0c7f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cfefd243-af48-4b57-9417-c7e672e5f1f1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.167,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e6c03f07-0796-444c-9ec7-00b31248855d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1153381192,
+            "lat": 33.405473
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "63cef536-1039-47b9-997f-152cd5138ace",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.05,
+            "lat": 29.22
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2a18e0c2-cc80-402e-8503-6f9227390191",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4177db9c-729f-4f81-ad4f-766f8114d54c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9951395614,
+            "lat": 31.700622
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "54f06f4b-6fdb-42b5-a14e-cffb9eb5f230",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.084478,
+            "lat": 34.434229
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "caae6bf5-d939-4a16-8ffb-bfacba2a1346",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.738111,
+            "lat": 32.686188
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0063683c-e70b-439d-929b-6ebe406c7cbc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.47036,
+            "lat": 38.32988
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7a568a26-e3ff-48b0-9ff8-b691b416ec37",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.23117,
+            "lat": 38.18206
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "27a95921-89a0-4dc9-a593-c5aafd80be7f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4815,
+            "lat": 32.3723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "62b7d65e-add6-43b0-92e3-518b82e44bd2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.75478977878544,
+            "lat": 48.555160343460685
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "36a97481-ce9e-46c5-984f-9403df4f9c73",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.75478977878544,
+            "lat": 48.555160343460685
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "672f85c0-2deb-4453-b401-f1c924502441",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": 0,
+            "lat": 0
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b02f4c7a-7abb-4a0b-8e32-f2efe82739a9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -90.95686068438015,
+            "lat": 16.892293676973885
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "11cace97-95a5-4245-acd0-0d6716bca341",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.284249,
+            "lat": 41.979667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "25b1b39c-2e73-494f-b9cd-cf2736e7a1cf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105,
+            "lat": 36.44222964
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "27571098-f51d-45df-a195-18a554ddb227",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.7,
+            "lat": 48.4167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "302300e2-4f72-4fec-886a-8fc24d258679",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.831828,
+            "lat": 44.855435
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5b9c9017-4689-429b-aed3-f4c10b15ca54",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.75,
+            "lat": 46.1833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6eb5b0eb-77d9-4f93-b5d9-aa5f71520afc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.7086111111,
+            "lat": 32.7141666667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "49b72545-a59d-4088-9f2d-1be932373b7a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.077789,
+            "lat": 41.021037
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3b247269-17cb-4a0b-8042-47a82731dad3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "767ee768-de29-4b7d-8781-7b715c46b86c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.95,
+            "lat": 44.6
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "da559347-c393-468b-b6b3-0d219e8bbe45",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.95,
+            "lat": 42
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c4f4350b-b032-402f-8cfa-47c3a68ead7c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.73318,
+            "lat": 43.016826
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8b146a50-85e1-4724-8896-9463ee0cdb54",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.881715,
+            "lat": 47.154141
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7ef58931-7a45-479d-a3ce-132d907e21f2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45699,
+            "lat": 31.84704
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f3d844fe-853a-414d-bf70-f08cd5ebdebe",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.7176163,
+            "lat": 32.72222581
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f67422ee-157b-4c04-b8fd-dbe8564095fb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.6667,
+            "lat": 43.15
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fdc862f8-a3e5-4378-84e6-136fd409b588",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0600411,
+            "lat": 36.94805121
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a16d0f81-2c1c-4d55-8e76-3367bae392ff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.5526297,
+            "lat": 35.69264625
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a34cc9a4-d633-4608-b292-7451179ccadb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.065821,
+            "lat": 34.41884
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "95c44fb1-379a-4444-96ba-44cc4d62540e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1981,
+            "lat": 43.3967
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9c4b49ae-05a1-412b-965c-97abe0a76a3b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.2327,
+            "lat": 43.5755
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "020a9228-dd1e-409c-91f2-bead30063db6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.5699508,
+            "lat": 36.81438428
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ea2aa0c8-9a33-40df-9840-6499c5874cc7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.70534803117107,
+            "lat": 32.430375237105956
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f933a08b-5af1-4208-84a1-b841538b2419",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.45221513580368,
+            "lat": 37.92968285761966
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d8b89122-6c01-4782-8bff-3a09470ff8c4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.4283,
+            "lat": 44.8749
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9d9fee3a-b4dc-40bc-abc4-827064dbe65a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.9963436042,
+            "lat": 34.171745
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1f836b44-7c3d-48d0-b879-042134a495c0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0ab7f914-bd1a-4d1b-a065-c2bed28cce25",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.185313,
+            "lat": 34.048398
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "54bb8de3-d7d4-4662-84e4-9f8ee54b30f1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "588d3b52-ccc1-493d-844d-3fd8c37bded6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3283995,
+            "lat": 33.711498
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dd0e0522-b527-49cc-a6c3-cd7949bab64d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0758512,
+            "lat": 34.46480911
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d1da45fe-f11a-420f-8437-ced462741fdf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.8626892,
+            "lat": 32.0450028
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cab3b721-f099-4395-9b58-11b081262cd7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.136938,
+            "lat": 42.312137
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ccbc5381-5354-4067-9058-927dc8927b76",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.403972,
+            "lat": 32.593401
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7372448f-ba5a-46dc-9af1-7235a7f11d58",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4689569,
+            "lat": 36.89209616
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "770a8850-5ba4-4678-a474-3b6f46bf41cd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.587784,
+            "lat": 32.934803
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2e871389-ad77-4746-83d5-716a2af6eceb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.203635,
+            "lat": 35.252542
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "acf19b8a-4782-4b84-8650-c264c8ab4127",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.0167,
+            "lat": 45.2333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a1941224-5608-45cc-85d6-a0e3ed55e6d1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.412674,
+            "lat": 47.575193
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "80860a61-093a-4dd0-b84d-0ff2a9ca36e4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.192379,
+            "lat": 33.130491
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bf1b6868-9413-438f-b2c7-980fce1ca395",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.6167,
+            "lat": 46.7833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3ba82aec-9374-44a3-9cf2-689581ad16d2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0567057953,
+            "lat": 34.423206
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "869a71d8-b2fa-4ffb-8be6-72a15b686b58",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5370013617,
+            "lat": 32.744431
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3099a2de-61c6-4a77-a739-8b13b61acb93",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.896972,
+            "lat": 34.155622
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a92d2805-4bfb-4ba6-9e0c-40ca950dca25",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.2432676797999,
+            "lat": 31.14081461087519
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5d7d4976-42e4-4920-b058-52928bcae052",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.5786111,
+            "lat": 34.5086111
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6881e547-2c81-4281-b006-dcff8c6fc89e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -79.7,
+            "lat": 0.9833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "240743b0-e883-489e-a8eb-68092a28e43a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.35,
+            "lat": 43.6333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0eb2c4ab-9d60-46f8-8d45-a12935d93264",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.5667,
+            "lat": 40.95
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "31edff14-6ad3-4a35-92ad-a9e08218b60c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.932916,
+            "lat": 46.495742
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "37b1ec0b-8e59-4cc5-98f8-483020e43b31",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.7818,
+            "lat": 47.4127
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "381e6959-80b3-4802-b0c0-28d759d6c3ab",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.000667,
+            "lat": 42.677419
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "17bfc126-b7f7-4489-b922-ef7c06c379d5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.3,
+            "lat": 43.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "81bd23c6-08e5-4224-915b-827b26242709",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.50098,
+            "lat": 31.84738
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5eaa4a8c-66a7-4c5c-941b-24a14dd0b93e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.284249,
+            "lat": 41.979667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3d51c9a0-eb67-4acd-925a-93b13f2cab96",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.7406253,
+            "lat": 33.36397848
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a6d54246-3411-48fb-bb4e-1cb6f22abe4b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.4,
+            "lat": 44.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a9dbac70-6c05-45f9-9185-5bce17704193",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.2593363,
+            "lat": 37.01567083
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9fe7ef6d-2bfe-47ea-bad4-adaab55ca5e1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.98991,
+            "lat": 32.1258
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9bec6300-c92a-4723-a0ce-ea1124993b61",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.646393,
+            "lat": 33.080833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "91c43161-a002-4d87-9a2b-b4f82f96e58c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.980266,
+            "lat": 42.072418
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b43957de-fc8d-4774-93b7-942df1075fa0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.839157,
+            "lat": 32.064445
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b6cc862c-5cd2-4772-be35-e0ee34caeb63",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.8744464,
+            "lat": 34.78906528
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c11b813c-bbe3-4c4e-a120-4db3ab5a3af7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.164046,
+            "lat": 40.428741
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "83dd869d-68c9-4bfd-abf6-d5f2a1b00d30",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.26,
+            "lat": 27.06
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1465e4aa-aa20-41a6-abdf-55db659d92ea",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.7833333333,
+            "lat": 49.0166666667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8f8ea932-e639-4757-95ea-4c42ba708f11",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.3,
+            "lat": 50.0333333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e5562e44-aa39-4fd6-ac6e-0ceb89d94e3a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0525768,
+            "lat": 36.55387834
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c6b38fe0-5172-479b-a86f-d9a4a386d8d5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.763331,
+            "lat": 42.538962
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d97c5dac-c33e-4e7a-96d5-8759fc51c314",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.9387,
+            "lat": 47.3758
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dc028723-22f3-4c7c-ace3-0684e622d0b3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.3882679,
+            "lat": 33.65525492
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dd78faca-f287-4211-86fe-666f47b17d50",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.65,
+            "lat": 44.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a65f39a-9b0a-46bf-a345-dc6db2681965",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b2493794-8af7-4242-a578-88c7cbf82bbc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.70963,
+            "lat": 32.72195
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "523d215c-63bf-46bd-94f7-8717c6374468",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.22239,
+            "lat": 47.548532
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d3603e77-6f09-43fb-a8ef-e625fcf951e4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.280416,
+            "lat": 45.63822
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4c014243-b866-477f-80ce-e515b9f1b32c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.77113,
+            "lat": 38.27467
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7d28c718-ec56-496f-90f5-781e00ef6dff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.38306,
+            "lat": 38.23842
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "88b5e77f-93f8-43e3-a686-b4c7607dc08a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.51442,
+            "lat": 34.542937
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e0da9acb-6a13-4ea9-899b-17d2523310f2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.031409,
+            "lat": 34.202531
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "60ec4324-ef58-4d9d-abc4-e3cd67753ea3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -88.18333,
+            "lat": 15.88379
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "76e8632f-827e-41cf-bcc2-d0861dd1ac72",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -93.83618140903317,
+            "lat": 32.333157161279885
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b145cb45-ee52-44c2-8b03-b6a351538e27",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.2430860186517,
+            "lat": 50.01652199931778
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6ec3c566-88ab-4e56-890a-f5a598ab3f85",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.27,
+            "lat": 33.227
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "234c2f46-68f5-459a-9d1c-88fe97b94d92",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.5667,
+            "lat": 40.95
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "287e2063-8be6-471a-84b0-8e3e5b7862ea",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5333,
+            "lat": 44.4667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0c75bbcd-f761-49a1-93a3-8c2c7b1d5840",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.65432,
+            "lat": 46.630449
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "423531d0-2eeb-44ea-bdfa-6ed0fb7a3537",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.424304,
+            "lat": 34.176978
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "67ba5a6e-0774-4324-9225-6d061e23fdff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4606399,
+            "lat": 36.38821714
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c35359b8-bb2b-4c5c-a3c0-293be58afc45",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.25,
+            "lat": 44.8333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c94a83be-a3bd-455d-8cda-8f94f3a0124e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.7076477,
+            "lat": 36.99411221
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ba285608-410a-4a84-bcb9-552f0fd5c208",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f09e9d56-c482-4305-abe1-1ee7278fa6e0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.0833,
+            "lat": 47.35
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f27e950a-8473-4bec-b2f7-e47a671b38f7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.35,
+            "lat": 44.6667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f6daa012-36b2-43aa-a72e-50edc8ddc6d9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.6770065,
+            "lat": 33.1247604
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e789bf3e-33d4-49d6-82b6-597fb41ba72d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5167,
+            "lat": 46.8167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "697043ad-c338-45f5-9e27-bc381893c5f6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4191041,
+            "lat": 34.75376904
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "60ee25d7-904e-4024-9c3b-18845b4717f6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.71892,
+            "lat": 48.14095
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "60f9e527-fd8f-4649-a643-451c47840cdb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.0128286,
+            "lat": 32.1030676
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b3d64660-f566-479d-9956-febb23806163",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.3010091,
+            "lat": 36.90671846
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7fa079e4-5a95-4cf4-8e21-9f28fc592de9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.5842,
+            "lat": 48.0619
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "36435d92-d906-4e1f-92d3-e3f0e54d94e0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.646393,
+            "lat": 33.080833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "364c97e1-185a-4c38-ab98-f1580dffc5e6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.600088,
+            "lat": 42.283881
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f18b6679-9776-404a-88f8-d345386c86fe",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9473736858,
+            "lat": 31.952407
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c4bfb105-981c-4e25-814f-a70d7c3ab87a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1603277079,
+            "lat": 32.924612
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fc20adb9-0778-42df-9e9e-027053df873b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4700231874,
+            "lat": 32.564842
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "76499958-76fa-402c-b8be-674348a1d23a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.8736306,
+            "lat": 33.208676
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "57f314ce-e4b7-47fa-8200-85aed1b75797",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1515597874,
+            "lat": 34.374789
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e9e8423e-8722-4c8f-9ac8-691c9150556a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.422543,
+            "lat": 31.721488
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ca9d8023-9a2f-4418-9f78-845305491471",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8d901366-eb51-4505-b9b8-18f8e9282b5b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.083,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6e2cd636-5455-49f3-bdfb-032bd5776404",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -100.4470627740817,
+            "lat": 25.337229522704224
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "75c3f214-70f3-43d9-aa3f-d3483d8fee6f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -90.98302803382234,
+            "lat": 16.882571960435143
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ee871d88-d85f-466e-be33-507dfd4ed320",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.239991,
+            "lat": 47.617351
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e5395e01-a496-4eb6-91eb-1e34d0dfefea",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.50944,
+            "lat": 32.56814
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "da1c3711-affb-4ff7-bc1c-b65e769061a4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.927462,
+            "lat": 43.060473
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ea0ab062-2502-4a48-9172-acfdad7914a6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1783,
+            "lat": 43.207
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "54ad1482-32cc-45e2-a9fa-8eaee669e052",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.116974,
+            "lat": 33.330905
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "55cd2bd3-b6f0-4fe6-897b-bc7726e42265",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.675307,
+            "lat": 45.365255
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7076d43d-5f7b-4604-b8ca-9378540a3372",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.3,
+            "lat": 43.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4659beb7-4259-4fa4-b360-24b4c6441cb5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.280416,
+            "lat": 45.63822
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cc2143a0-f82e-4377-8340-7d1ade616726",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.44,
+            "lat": 33.71
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a1cb86c6-fbf0-4633-9e89-d311729b36f9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.69783,
+            "lat": 45.244969
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bea85053-b338-42c8-b506-aa51e9868b52",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.778337,
+            "lat": 32.312316
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c031b886-3818-4e2f-bb9e-8185da0e59bf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.365749,
+            "lat": 32.841874
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c21fa52b-10e3-4be0-a2a2-5f8c10858954",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.930399,
+            "lat": 34.007188
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "abdce68a-3043-4a42-95a0-70f17dea594d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5075561,
+            "lat": 36.63003589
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8584c378-f888-4d63-8c65-689dc12536b3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.124407,
+            "lat": 42.42853
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0ceb7486-ea58-44c7-b80f-ccd0116e1d8e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.866137,
+            "lat": 34.275965
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "06e66484-121c-4599-8cf5-df442d972cf5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.5459136,
+            "lat": 34.06339024
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "51475d7d-1b73-4bb7-85ef-37ba0239e5f5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.6922222,
+            "lat": 34.8977778
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2d9a257a-3d32-464c-9c7c-c15ea455789d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.083,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1e15d781-1146-441f-92a0-720142c78810",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -60.2666667,
+            "lat": 6.3166667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0c626c5f-7725-483c-88b7-9e6b1b71baee",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "23e432c8-1280-4dc9-8a9c-02367d544110",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "64258c4e-b1fc-4140-836e-d9bc57828514",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.358505,
+            "lat": 43.889692
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7b9fd082-107c-435e-9900-a1531dddb5c8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.73336,
+            "lat": 34.806166
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "72c9fac3-6b15-4b5f-9ecd-06f592268e2e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.310349,
+            "lat": 47.42346
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c957433d-67a1-47dc-ba58-24a74b3ad5a8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1163888889,
+            "lat": 33.3308333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "26a1a4c1-342b-47f2-b951-89aac6273d54",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.433644,
+            "lat": 31.474494
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b26c2d07-fbc6-44aa-9cb3-8129cea75a45",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.198354,
+            "lat": 39.546077
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "63aefb24-c7b9-4a48-90bd-9eaca84bb428",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.40758376889995,
+            "lat": 35.510451198106274
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "006e4357-f5a7-44aa-8690-5dca005e9ce9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.875,
+            "lat": 34.5441667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1401ec8b-dc68-4e21-8bbe-549300bd949e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.6667,
+            "lat": 44.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "555cda54-6482-43a3-ac6a-41719563c039",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.3612304,
+            "lat": 31.6035623
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "799aabf3-75d9-44f2-aee5-13c99ac0b824",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.53927,
+            "lat": 32.62101
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "92a5deef-054a-4f1b-bb27-d9541539be59",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.412674,
+            "lat": 47.575193
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d3a5fb18-f6a4-4cb3-aceb-0c60379c8b88",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.1932,
+            "lat": 47.52371
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d3b6adc8-1eda-4719-bcf7-ddc6247332c4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.469279,
+            "lat": 37.247796
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d405a663-ea87-4ee3-939d-d6da2586da62",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3833,
+            "lat": 45.2167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e5a3c74a-c48a-48af-aec3-22fb3ef1db76",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.8629872,
+            "lat": 32.0380866
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6f359086-23f8-4152-81d1-7a001a5cf15f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.51527,
+            "lat": 32.45342
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0abad35b-4aa5-4d46-80f7-7bfe1a3de3db",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6d218f46-8890-4ed6-83fd-64afaaef4ce8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.2881806,
+            "lat": 29.2395111
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f2c375fe-2a41-4401-a472-7dd93c89baaf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.0652778,
+            "lat": 16.7088889
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2d4577af-eb45-4f77-8123-27324ff4aeb6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9096287344,
+            "lat": 33.347905
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6ecfa595-a6eb-45f8-a4f5-2726c93433c6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.439355,
+            "lat": 36.895431
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "27e7f020-2987-4546-87ba-cd931c11053d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "192636c3-4adc-45cd-aaad-75f02657ae05",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.37646,
+            "lat": 38.26476
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1413b32e-8390-4619-a933-117ca9ca0c07",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.03023,
+            "lat": 48.982402
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c251e83c-cc03-4e43-aa4a-0792e8721b44",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.75478977878544,
+            "lat": 48.555160343460685
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1a5d5532-53b7-463d-b987-ea9d2e416d52",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.654419,
+            "lat": 41.778534
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e0d72a74-5ddf-41bb-9350-1ba68593ef7d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.51782,
+            "lat": 32.46335
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d903bc0e-a367-421a-a942-3f31f90e95a7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4320983,
+            "lat": 33.6151996
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a32d4396-f753-4cc2-b6b8-ddf6bc1a218f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.6897481,
+            "lat": 35.65947114
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b884cc33-ff60-4428-86c5-9c2e75ee2aea",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.7389316,
+            "lat": 33.30992135
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a4ee3c85-4bcf-4516-bc83-937d9a96cf3b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7fa43205-f893-40c9-bd51-a205e1e5ba93",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1113105223,
+            "lat": 34.431291
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f84a0cc8-93fe-45a2-a0b7-1d60d079ba3b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.14,
+            "lat": 33.85
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ce5b3f72-055b-4992-9348-f0724165c20e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.0372,
+            "lat": 43.0123
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "702e8f8d-a525-4f25-9f13-8f8dbdbba04f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.433644,
+            "lat": 31.474494
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2fbbbb2d-3901-47f4-b536-8e81dc0e1840",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.3922,
+            "lat": 38.45099
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "18aa0dfe-822a-418e-a2dd-fbeb69bbe827",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3481e2c7-16b2-4107-b054-2e24441b006e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.51666,
+            "lat": 2.83333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "606ff421-dc1d-4087-846a-9b2a2b98e7dd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -126.75,
+            "lat": 49.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3f1738e2-9dee-4d9e-b678-266715d4cfd4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.726685,
+            "lat": 32.459236
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e6719235-0cba-4fea-ab6b-279c5c4b607d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0242955349,
+            "lat": 32.584192
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3c4d0de7-12c0-4991-b532-316af4672f56",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3946151,
+            "lat": 34.522723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dc3b4de6-7fba-40f4-adee-f525fd5249b7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.5,
+            "lat": 49.45
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a1c38ecf-2bfc-4399-b374-6a00d900f120",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.43,
+            "lat": 25.57
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2d83325c-79ee-468a-8baa-bc948f73dccf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.167,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "61c4ce44-a4ce-4391-a9ce-41bcb68110c3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.57306,
+            "lat": 28.51528
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "05d5accc-35ee-4d47-9db7-e88c2bd59c2c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.00895,
+            "lat": 32.20008
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "09dea49e-a36c-46a4-a3d7-8c11f279a06e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.5667,
+            "lat": 47.85
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "42348b59-45bb-4f79-b968-915f0fccbec9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.70671,
+            "lat": 32.73231
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "72199de4-a896-418f-a27c-fcc8aa4ffc1a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.67491,
+            "lat": 39.853797
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6d52f33c-29e1-44b2-9ef2-06a613bf1581",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.825508,
+            "lat": 32.114555
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8f1c4654-6315-424f-9426-2c65396e4cf3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.4,
+            "lat": 47
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "93012582-9456-4a56-852c-03b6a83a0e5c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.565284,
+            "lat": 42.484354
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "80a125ff-e50f-43da-a32d-3d83f9d5d30f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.932916,
+            "lat": 46.495742
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "00913971-0f25-4ed9-9120-03fe570db0e9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5669444444,
+            "lat": 32.7830555556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7afd0d9d-4967-46c2-bf9a-710cecbeb54a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.39433536871483,
+            "lat": 36.29748102582919
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "38bd4937-707f-4c12-906d-6fc746c40d7f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.99149672648753,
+            "lat": 47.20429803474714
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9585b844-4b3b-497c-b7a6-c640b11d46b3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.904944,
+            "lat": 31.401806
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1a55469f-9f10-4bc4-9006-b5a240110c3e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.70963,
+            "lat": 32.72195
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0c3f1521-f8ff-42f7-8746-ba643463f1e6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.5350553,
+            "lat": 33.68392792
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "07c120f9-bd74-4906-a922-c09e5f7b9141",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.9833,
+            "lat": 42.2333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cd61f674-4574-40bc-aa5c-d56ef7899b02",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.36365,
+            "lat": 31.61538
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bed1113f-92de-4004-beae-6a5f250d92ff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.453883,
+            "lat": 44.889588
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "56fce736-60da-4f42-ac72-ec3ab5a0ca10",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.52972,
+            "lat": 32.62675
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2e4ca3eb-2993-4a7f-b58a-0e1f7c50ccd6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.89822,
+            "lat": 46.92156
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ae0400ee-c11d-4fb3-ba2b-9729a4e15231",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.420118,
+            "lat": 32.58101222
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9f9efe9c-4b6c-40b4-99b5-e371ecb42761",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.078847,
+            "lat": 42.081867
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9777b47c-0692-4781-83e6-432101b2d341",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.25524,
+            "lat": 41.972701
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d9ca5d2b-9e80-4f37-afcc-15d3eada18c0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.85,
+            "lat": 47.55
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f4dffc93-b87b-4d72-befb-f229a3c15c8f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.25323,
+            "lat": 47.200723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f1013d2d-6b6e-41fd-bcb4-962083dc865e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3833,
+            "lat": 47.2833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f179071d-f1f4-428d-94fc-87e95a55aabb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.00901,
+            "lat": 31.73518
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b1a5ddf1-41e5-422e-80dc-d3155fbabd0d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0777883964,
+            "lat": 34.395801
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "628c4aff-3c84-4e63-b778-51eb3344488d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "94d1b078-3f2f-403e-9600-70b03f79e937",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.999116,
+            "lat": 34.110751
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ecc9eb51-d299-487d-9307-9667416fdc5c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4815,
+            "lat": 32.3723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6b55b4e8-dcde-451d-be06-b63135a09104",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.0786562,
+            "lat": 38.0242904
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9bbe536f-c841-4224-a562-d151397dc58e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.48428,
+            "lat": 38.48878
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "99c94f85-8861-47fb-9b0c-ef5226e51880",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "95dd1c91-51ad-4f04-9e1a-85140010fae5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0049895199,
+            "lat": 34.107036
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "17bd90e0-bf15-4b2f-b162-691a391ad254",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -88.18333,
+            "lat": 15.88379
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8cbf4d51-d96e-4821-a6d6-c8b52c5e2b26",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -101.11635635181848,
+            "lat": 21.841533217999967
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6bd64686-0a03-484c-ac56-32e7b0f03ece",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.3333,
+            "lat": 42.5333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "eaa59fb6-de18-4d72-a7b8-9e873c2ec498",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.510465,
+            "lat": 47.787685
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "004fec34-b1eb-4f0c-b2ac-9d52c27cf4d2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4889985,
+            "lat": 33.3007011
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "04bbbb36-9fc4-4b50-94b4-3f92f22fe731",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.6530903,
+            "lat": 33.36796269
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5a7da387-8fbb-4811-9885-25c7639c4f65",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -97.145248,
+            "lat": 25.956192
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6e707b3c-21c4-4e62-bbb0-9b605d7f9c3b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8892102,
+            "lat": 36.12980468
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "72cd862a-f521-4149-a576-4559da9db014",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.578063,
+            "lat": 42.412688
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "17ed7c9a-3fc5-4258-8d9a-35480d998a27",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.207183,
+            "lat": 41.975479
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1af703e9-2c89-4f0b-92fd-ef699eb85e43",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.9333,
+            "lat": 42.3833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a680361-c2bb-4913-8451-c8f47eac3441",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.6833,
+            "lat": 38.1
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a3b50ba9-49e2-4ada-8be5-77167890b699",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.7230936,
+            "lat": 32.63665025
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aaba3f9e-4f9f-47be-884a-8680d1faa900",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.6983398,
+            "lat": 33.32017397
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9939d966-4d1b-4fb5-b166-4e54d8440ae8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -133.4308333333,
+            "lat": 56.4688888889
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3ca9b452-1282-41be-ac54-ce73f3aefb99",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.034706,
+            "lat": 49.023421
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e0bf0a1e-5494-4d09-9961-28c16e8c316b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.00895,
+            "lat": 32.20008
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fe9f40eb-680b-4334-aa77-ccb9c97c1d68",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fb6d0912-e57a-4685-9f40-d8747c000742",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.05,
+            "lat": 49.6833333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f2c4bc04-81b9-432e-9ffe-91f60c746b1e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.46,
+            "lat": 29.42
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b2fc118e-07c3-498b-a070-a6ba24a8ccd1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.26,
+            "lat": 27.06
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f9b7f5dd-a857-4f74-abd7-14bce785b360",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.7667,
+            "lat": 47.2167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bba14292-8f24-4dcf-92a5-3aa262754dd6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.510465,
+            "lat": 47.787685
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2d60c831-49e4-4f06-9eff-ab0c2c609bbd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.412674,
+            "lat": 47.575193
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6e238c00-4210-4071-9b3d-d09f93c1ae6b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1976118178,
+            "lat": 34.402723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "72efa99d-44c7-4122-9e17-2dbf53918b9d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.82347,
+            "lat": 27.03037
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "16c5e8d3-ff27-4767-ba09-64f867bd71d1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.9452072805286,
+            "lat": 35.8427289587811
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2ec5104d-4406-4c62-9313-31d6d9aa303c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.19463967646945,
+            "lat": 35.22880280194262
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9faa4b4d-a262-443b-bfc4-b432172a3042",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.40018538933144,
+            "lat": 47.39232589102222
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f6bc0e19-3ede-4e3f-b562-adbbbee3f160",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5454953311,
+            "lat": 32.618054
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1f92915a-7407-42bf-bd10-ca071513bd19",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9412125584,
+            "lat": 31.75388
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bd2423f6-218a-4e77-9873-57b5a0be0640",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.00895,
+            "lat": 32.20008
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a71667ae-8e71-4566-b801-4b953e145e80",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3fda62e7-fcb4-4633-9975-861149deb8dd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0397b86b-7003-4054-be89-63f1d42fb746",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.51666,
+            "lat": 2.83333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4ff9ba24-8fa8-4116-9a17-a0ac37670c8c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.417,
+            "lat": 52.3333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "eb2c2e49-4aaf-4a2c-99ee-4d33404fc079",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.418566,
+            "lat": 45.182989
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fb34a8cc-eb28-41c2-b49e-9a79dba23999",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1981,
+            "lat": 43.3967
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2059e4d4-d99f-4eca-97a9-156ace24bf31",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.4,
+            "lat": 44.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "095d6419-e7d1-41e9-80b7-464fa9015a90",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.7,
+            "lat": 46.25
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "099e4996-09a3-4d8d-8749-48a74cbe2e6a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2b830c71-9187-45bd-bb4a-1c65de4b8adf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4606399,
+            "lat": 36.38821714
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "62a278ba-2e95-4562-861b-f54387499f9a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.270627,
+            "lat": 44.713534
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "53ed4d81-3372-4e2f-b6a4-9d357238531a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5828831,
+            "lat": 36.36862917
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e1fe71fa-2675-4f61-bfd1-544d29db17da",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.15,
+            "lat": 44.1167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "be51aa3b-0985-483e-a0de-3f4d8c7e1310",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.771556,
+            "lat": 44.967243
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7f91c416-9626-4a7f-98b6-548a32a81b95",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.52751,
+            "lat": 32.62054
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "88776a09-52f3-4176-8326-9c252d746359",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.765570825,
+            "lat": 36.886564128
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bed23781-736b-44f2-a3df-8b0582f77658",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4815,
+            "lat": 32.3723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9d1ea493-3c13-4718-ba66-0834d8d831ef",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.730672,
+            "lat": 42.833014
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e147d20c-56f7-4381-bac4-61aa67f4e9ef",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.198684,
+            "lat": 34.406259
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "10a03b0a-c9ac-42bb-95b1-f0de80824452",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.83322773499071,
+            "lat": 45.55931441052632
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b219fa12-1e1d-46cb-be76-3894996b9cff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.3538889,
+            "lat": 34.5394444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6f991fcb-e931-47fa-807f-c71d87c47551",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a1b1d4b7-7864-4d2d-b2e1-55c0f32b7428",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.26079,
+            "lat": 3.09061
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "00c0cf9d-80f1-48be-ab1f-adac6d35c6be",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.6539656,
+            "lat": 34.0420392
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "01aba6fa-4f4d-4a6a-b2cc-ef001f96dd18",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.245407,
+            "lat": 44.008779
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ca17ca85-eec1-4236-a41d-a0d042ca0072",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.6167,
+            "lat": 45.95
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d46959fd-fa66-4e47-852a-518f1fa423d2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5a54881e-5a05-4dc3-bb50-3d72568eed7d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.25,
+            "lat": 48.1333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2af7d42d-5887-4e3f-bc33-3ece95ce19e9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.7167,
+            "lat": 41.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3e3b74fc-d9d2-49e5-a8ed-54b693496258",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.837393,
+            "lat": 47.240458
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6cafd866-5e28-4925-823f-8c73e7d7ac14",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0336111111,
+            "lat": 34.4172222222
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "38eb53ee-5925-471b-87ad-e765235bb023",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.646393,
+            "lat": 33.080833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "91b3732c-d91a-4b43-98ab-552afa1faf01",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.25,
+            "lat": 44.8333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b0371791-a856-4dd6-bb48-c7e76da9bdb8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.084478,
+            "lat": 34.434229
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a40236b0-cfab-4cff-bce6-226a50106b8a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4298f133-ebc2-43b2-b12a-47bf1985a0dd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "58c3dafc-7364-41e4-b462-f775cc3d55f5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 32.759892
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8fee9de5-f4da-453c-9d87-dd02ea2434db",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.6266667,
+            "lat": 19.5294444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fd012d38-b181-4f5a-b600-3dd738488027",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -73.7834,
+            "lat": 44.328
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d380436b-ef09-4392-9e09-8e476193c101",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.14,
+            "lat": 33.85
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "11eff5d1-5e00-4346-96b6-e3a400eab50b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.82477,
+            "lat": 38.2245
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ef974d9c-cfba-4811-ab93-386034ef19b4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.89839,
+            "lat": 38.41026
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ce436044-2ce0-45c6-bc8d-5cf96d03b307",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.53,
+            "lat": 27.4
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "450d74e2-ff09-4d3c-85a9-a84ded2fce00",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.24090689809088,
+            "lat": 34.04001250669102
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "28729140-81bc-4acc-97e7-46bebac4a60f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.485,
+            "lat": 47.488
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "13b77bad-7b47-462c-8d8a-050fd2e25b41",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.83999,
+            "lat": 42.591858
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1d01dcd5-f347-4ed1-a88a-cbb2c6b28a2a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.239805,
+            "lat": 45.427139
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1d76020a-bdb4-4398-8f23-f74064724781",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.65,
+            "lat": 45.2333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e3293acf-eaaf-42f4-a330-1d95d40da5e6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.8998,
+            "lat": 47.337
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d645ac74-5bee-477e-bcef-7632a5758150",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.1833,
+            "lat": 44.2833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "da187485-6268-4bfb-8f44-3f024776a033",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.825508,
+            "lat": 32.114555
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "669ecde5-6fdd-4c61-b6c7-28cd046cdb73",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.2333,
+            "lat": 42.5833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "68739eb0-7023-4c28-8841-6f45c64a1c26",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.4,
+            "lat": 37.3667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "70bcc0d4-3a40-4559-8284-dfc996185965",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.771556,
+            "lat": 44.967243
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a8487ec4-1b67-453d-891c-43fcd53f0bc3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.890907,
+            "lat": 45.501586
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4c88ea5b-734c-4b27-bc99-f50b0a81c848",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.51527,
+            "lat": 32.45342
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "448b6f07-dd1e-402f-9598-4996d77c140b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3940806,
+            "lat": 36.40704246
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "37841b77-59a0-4bb3-82e1-577af7170014",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.7886392,
+            "lat": 33.86299525
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "391b681a-96ee-43f5-b35a-d7dee511d3c8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.7161509,
+            "lat": 34.34135796
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "74f65ab7-9494-46d2-9032-4aa45c283bde",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.991976,
+            "lat": 34.393953
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "94878f43-b271-40d1-92e4-deb36aa7a4a5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8727938,
+            "lat": 36.37344375
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "03a4d66b-a161-47fa-8e19-304e235753d4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.000667,
+            "lat": 42.677419
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d21c7257-2d1f-40c5-b609-0666470a338b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.3776405,
+            "lat": 33.69136513
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fed3c6e7-4de3-42ac-9553-76298733a82b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5167,
+            "lat": 46.9167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a07891c4-6d0b-4b36-9d73-6c0ca6e8ebf9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.75478977878544,
+            "lat": 48.555160343460685
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "459351a8-4891-4df9-beac-29d7e7e4acd6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.7482186,
+            "lat": 49.2678238
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "70a16040-14df-4778-a6b0-180262e0aad7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.8,
+            "lat": 46.0667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a37f9a94-208f-4a7d-a3b0-946802246546",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.412674,
+            "lat": 47.575193
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a3f74eb1-5d8b-42d4-9e74-90516e69bec1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.198354,
+            "lat": 39.546077
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dd22ae5c-b8c3-4bc6-8cbe-a56287c32a54",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0678549435,
+            "lat": 34.4372098533
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ff092ac7-a90a-49c4-8ce5-8885efa9e811",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.498829,
+            "lat": 42.569645
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5639fabc-8b75-4b56-8ec6-003cf6bc0590",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.53659,
+            "lat": 38.27014
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3765ab00-dc14-4ff8-a1d5-60d7ca575b78",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.4270163778,
+            "lat": 31.922716
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cf5e8200-233e-41fd-b7bc-6ebeb1ed7f24",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.183253,
+            "lat": 39.327962
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2a2be65f-a511-4319-bd52-f0b8e5dce62c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.73498213872537,
+            "lat": 39.54246590613516
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "205250c2-025a-45d7-a78f-91e2f5a6526d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1163888889,
+            "lat": 33.3308333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "04ff4725-19c5-4055-a5dc-a09ee1fe7404",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4393758,
+            "lat": 36.81953754
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "07256534-9814-4656-8066-dd389f786687",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.5505582,
+            "lat": 36.30810222
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2aeb71e1-636b-48de-9e1a-4fedd273152e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.7532982,
+            "lat": 33.46416479
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2e515573-dd85-40ab-9649-dfd5c85ccdae",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.638757,
+            "lat": 47.812111
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "63b34700-f708-48a5-913a-cdeeaa9820bf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.273631,
+            "lat": 41.667696
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "69e59d55-6f94-47c4-89d1-06a782acb3f5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.8333,
+            "lat": 47.2167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7883c8ba-f70d-4b59-90e9-f4d1bfb28550",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.231731,
+            "lat": 44.504644
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8338dbaf-a6f4-4e65-bb67-ea7811402fe7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3496374,
+            "lat": 36.41656808
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "afb9c80f-83b6-483f-8ed6-7b63834b3de7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.825158,
+            "lat": 47.430762
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f8572d54-6059-48db-b781-09dd33edff8b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f9add2e8-da82-455f-a97b-9cfb047120be",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3283995,
+            "lat": 33.711498
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "df9a5a97-9742-4001-ad1d-1f1af55f8d42",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.124407,
+            "lat": 42.42853
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "adb96e83-b7f9-4d16-b396-4458a24b5d97",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.3167,
+            "lat": 42.6833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d24760fb-6e3d-465b-bb36-6c5cda14032c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.949196,
+            "lat": 43.287405
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "41eb7c18-23c2-4462-bf9d-b440667eb29d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.65861,
+            "lat": 37.461354
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2df8efc7-5b97-4b39-884d-26c2e7c26202",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.2028078296838,
+            "lat": 48.86600632064929
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a855723a-c12f-462d-9ae0-234da6b645d5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.9711111,
+            "lat": 34.4455556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3bee7b26-0633-456a-8d45-7cb36ff4aa58",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.083,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "01f526cf-c706-4804-bfe0-75a1acb9e2fb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.083,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ba4cf6d2-8719-48e2-873f-7e9c0bc639bc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.514,
+            "lat": 38.94021
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7492bb26-eb24-4a4a-a206-ae4dbc39dbb8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c11ba700-e914-4f68-bc52-374f57dd06dc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.9172211,
+            "lat": 34.3991661
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f5c7e6be-6fec-4fd5-8589-86338808130c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -75.02184,
+            "lat": 44.479677
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ca3f0017-3339-4ae1-ae3e-8eefe9dfc43c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -93.1,
+            "lat": 16.7269444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9541031a-46ca-4e5c-b83e-ed10aa296b82",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.670051,
+            "lat": 32.880785
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "36f25435-9d14-4edb-9714-da860dbba687",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.8563163341,
+            "lat": 33.367591
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9dba9494-7719-4184-9434-6f69296d0409",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0567057953,
+            "lat": 34.423206
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "77a07df0-aa9b-44fc-af1c-614c52d53837",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.99482,
+            "lat": 34.243781
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "21337767-ad37-4c9c-9f3b-23f6c623e892",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.24090689809088,
+            "lat": 34.04001250669102
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "db86092f-1382-4122-9afd-416c323258a8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0bbdf384-b006-467c-9b1d-1ed41a9ee626",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.0824109,
+            "lat": 27.0541522
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "eea004c2-60b0-4e9d-a8f0-a4ffe3dfe7d7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.10468,
+            "lat": 33.42485
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ddb888d4-256d-446d-971b-df08d14f1f56",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.89822,
+            "lat": 46.92156
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "df1e0d4c-a92d-458d-8a6d-1ef3df997674",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.111577,
+            "lat": 42.098688
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d9161366-571f-4089-adc4-554862f9f5cd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.4511091,
+            "lat": 33.00036666
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "db7ae43e-0112-460b-964d-2a87a274cfec",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.9114251,
+            "lat": 36.12945157
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4b946c13-6589-4e37-b158-ddcab9694a85",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.4566805,
+            "lat": 36.30612669
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a097e77-d7f7-4a80-940e-838a1b6badc8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.646393,
+            "lat": 33.080833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a4907321-e3bd-4ead-b845-601223fba3a9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.8333,
+            "lat": 45.5167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "af60ecaa-fa9d-467c-9fa7-8c0ca9982c5d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "17f328c8-ad0e-44f8-a86c-db1bf4cf2213",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.663485,
+            "lat": 35.078382
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6eaadfc8-91ce-4886-8a8e-f2cc486dfa1f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.893402,
+            "lat": 45.24242
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7150de5b-f0be-4aee-9bf5-71c50977bd6a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.5910931,
+            "lat": 36.37400298
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "94195471-4d68-4427-a8db-9226163afe5c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.1833,
+            "lat": 42.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9436e8ce-69cd-4062-8496-46f462855ac5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.7667,
+            "lat": 42.6
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b6e43c52-aac6-4bc0-9209-9c71abd11a88",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.708352,
+            "lat": 48.0097
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "16dbbb3e-586c-4431-8d9a-60f12d660aed",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.155519,
+            "lat": 40.884235
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "261bb151-adb3-4ab8-8862-fec0d758349e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.023447,
+            "lat": 31.205281
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "975a1a03-a728-4a19-88cc-c3c5b2c9178e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.19284763681591,
+            "lat": 47.870705824169896
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7781a4aa-1518-4bb5-9d41-b3786811b60a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.6971257966153,
+            "lat": 33.22812018644003
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0430b4cd-6357-4e20-9d52-b3d63468b03f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.5786111,
+            "lat": 34.5086111
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ce04a61d-ec06-4639-a1ff-b438dd971558",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.1666666667,
+            "lat": 33.0333333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f1bd6c61-b029-438b-a827-e4cab4ab6620",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.54599,
+            "lat": 46.848509
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "640d12f3-0559-4572-86d8-ad1a49f10148",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.350254,
+            "lat": 47.66876
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "676d9915-5e04-4ec3-b70e-ee4f6a3bb715",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.36983,
+            "lat": 31.59696
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "51124b4b-95ef-4687-a893-2b3943fd2a54",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.879841,
+            "lat": 48.610556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "52a45d04-de87-4d1d-8372-6b939ca7fd6b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.600088,
+            "lat": 42.283881
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "606f6947-dc32-4b21-a2d6-7247523ef97c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.510465,
+            "lat": 47.787685
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "47b95342-54d9-4715-ac64-0fa0866060b6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.587784,
+            "lat": 32.934803
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8511ac1b-e65a-477c-99dc-7e0b77766099",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.1221332,
+            "lat": 36.05449795
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9c2659e3-8a2a-4a7f-871d-472b8bda8f0c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.220508,
+            "lat": 36.66490827
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9f04dbfd-63cf-429a-a55d-e161284bb023",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.26856,
+            "lat": 39.983892
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a0e5eb61-538c-41ae-b137-c6514c41fd08",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5951281,
+            "lat": 35.0441862
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aa8b3616-5ba6-480d-98a9-3c112ae1e948",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.2575,
+            "lat": 43.3821
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "11139993-7f96-4fce-a776-078b5373d06f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.71306,
+            "lat": 32.73621
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e4fe74c1-2ef4-4207-bc04-811ed6a8023a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.4166666667,
+            "lat": 52.3333333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "02a4a1ba-3665-4198-b28e-b914342bbbdc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.23,
+            "lat": 47.62
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7344b864-7af0-49f4-aebd-c09876679c79",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2e06beff-375b-4f04-b16e-30e3eefafd38",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.986655,
+            "lat": 38.075006
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ffeac222-5261-4165-ac01-f0ce08829461",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.270627,
+            "lat": 44.713534
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5ec494ee-bda9-446b-96d3-d4b6e033efa1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.04598,
+            "lat": 38.11669
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4ea4703b-65f4-4981-85fc-dacd0a11e67f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9076726868,
+            "lat": 33.21434
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "94b260ef-8efd-4e8e-989b-1abac6e35ad0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.071944,
+            "lat": 52.116944
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a69f2dd2-e8c5-4b26-b1b1-d2e4c6d62787",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.682766,
+            "lat": 46.187649
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5769112d-3a0a-4755-846a-5faa6610c363",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.02394436384505,
+            "lat": 33.364254310375294
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ba7fcea7-bcfb-48cb-a476-960da6010b44",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.82422348578524,
+            "lat": 34.4369250201946
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2df0801d-6447-45bb-8d10-d06219dbfbda",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.23673,
+            "lat": 47.88084
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1ad25a3b-a633-4404-ae14-56c1e5b1c4b8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.6369941,
+            "lat": 35.75489861
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0ad20910-109b-4586-b2ce-6df04331ed4f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.350254,
+            "lat": 47.66876
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0f0ea85a-acfb-479b-a1b8-842232d78ed4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.215514,
+            "lat": 41.892425
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "021a81ef-12dc-4223-952a-cb4e6c780ca7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.646393,
+            "lat": 33.080833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a4e4d459-2d9e-46ea-85da-72adfa69adfd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.426067,
+            "lat": 37.277133
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "88489836-0a8e-42b4-8341-d894a762d1bf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.980266,
+            "lat": 42.072418
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "97e66fb4-c57c-4877-9c50-2cd46c6afe53",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.26856,
+            "lat": 39.983892
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "99003ebd-ec29-444d-8ef4-f77ca68d4ab2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bb0ccd2d-052f-4120-b99f-7aef9922dda8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.9409,
+            "lat": 47.7385
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bb625ef0-bd32-4348-8c66-e9d02274cd75",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.663485,
+            "lat": 35.078382
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "beb15036-3247-474f-becc-88abcb5397c6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.324733,
+            "lat": 41.284424
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9ecc2f15-4178-4a7d-859e-ae8ca2138153",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.8590515,
+            "lat": 32.0150703
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b0d50c37-73f4-4a00-b1a6-183a7c02b73d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.9167,
+            "lat": 46.6833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "40ba1153-e8f3-42fb-93cc-40e997ef6be1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4815,
+            "lat": 32.3723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "756c5884-8788-4511-8974-33f16610f2d0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4815,
+            "lat": 32.3723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "51a03897-6ff6-4fb7-b4e2-a2ce45df2e2a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.78,
+            "lat": 31.59
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0c906b71-f42a-476e-8f56-2f6b7c136bf2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9076726868,
+            "lat": 33.21434
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a2128579-b7ca-478c-b833-3a3553336216",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.12123,
+            "lat": 48.83251
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5ee056c0-77ef-48f9-b919-53c52642e0cd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "346d925f-4deb-4d58-8c6a-0fe392cf3139",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.15,
+            "lat": 43.05
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fb041a89-d403-45be-b9cf-9514acf51a06",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.404754,
+            "lat": 36.059742
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a7bdcf07-4865-4d85-afc8-e3651a529fff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.00171,
+            "lat": 38.39718
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "708e4ec7-8bc6-41f4-a83d-3830a1e28015",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.22933,
+            "lat": 38.5072
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c8e7073a-3f0c-4730-9bb3-2cb29feceeb1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0569444444,
+            "lat": 34.4575
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "93e8bb96-4a26-4822-a892-74340ce948f7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.94517417960488,
+            "lat": 35.842732158964004
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "90cad20a-91b3-4f02-8e12-f48fdf4e88a6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.9586111,
+            "lat": 34.5730556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2fe8912e-ce63-4895-afd4-5a170a1ff491",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.2028078296838,
+            "lat": 48.86600632064929
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4767686d-f005-483d-b508-e0fd86cce19b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.43607643608719,
+            "lat": 45.57039959394705
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1d898733-9d2e-4991-8e8e-015fb514b13a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.3435895,
+            "lat": 34.13612141
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "baf31429-45cd-40f6-9bf8-168a5fe68f08",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.5592865,
+            "lat": 33.77358509
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "771e63dc-030f-497e-b0c9-0f52d876b861",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.7276593,
+            "lat": 32.96823056
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9118283e-988e-45df-9348-2f962b4909b6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.062077,
+            "lat": 44.49517
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f7008861-ede4-408e-b581-7977a852562f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.7798,
+            "lat": 47.4114
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ebfd8ffd-4018-4bb7-a084-f384482729d6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.761654,
+            "lat": 33.70846
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6d5cae49-6fac-49e7-a5a8-5f0d2296d8b0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.124407,
+            "lat": 42.42853
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "667531c1-9e4b-45e9-817f-0d34a418592b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.401033,
+            "lat": 48.656324
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "50217576-49b4-4c3a-a54c-74e7485b436e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.9167,
+            "lat": 46.6833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "570c0344-a33a-4d78-8aea-71322372263f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.3833,
+            "lat": 45.35
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "873ae180-6c31-469d-8e07-b9bed86f3465",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.6323069,
+            "lat": 36.06460715
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9021bfd8-eef2-44b1-b755-a1ffb21a7197",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1329136,
+            "lat": 32.6725591
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2cbdaa1b-580d-4f18-8a1d-22e1baf8b2fe",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9833,
+            "lat": 31.77838
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3c96c31b-05c8-475c-aa84-dad129b39961",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.044246,
+            "lat": 43.893791
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "318ee504-d968-482c-a925-ca63ecba08b1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.6167,
+            "lat": 44.4833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2c0d6ec8-0d74-4a7a-87be-4dcc15537711",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "709a7d62-f787-4530-86f2-331f11199989",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "606dfa99-f7e8-42a2-a3d2-15d75f7a6421",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.43,
+            "lat": 25.57
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f0b2e570-6208-4600-a9ab-7d58af6df1ff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.92151,
+            "lat": 48.942913
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "38168fcd-a0ac-4b30-8c27-52db5c7907eb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -93.1,
+            "lat": 16.7269444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "57e045a4-5826-4b56-b505-437ea5071535",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -93.1,
+            "lat": 16.7269444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "69fb80cd-ece3-4c3d-b03a-d04be29a14ba",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.69043585143505,
+            "lat": 34.41272378698258
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2dae6610-7c63-4c8f-9103-3674e1e0cf19",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.95012934843614,
+            "lat": 19.444813451237142
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "19e9ae46-6b30-4ab8-ab6a-4ddadd2020df",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.63787776171154,
+            "lat": 48.26280969118889
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2b0c0d6e-6842-4447-8720-5c76675284fd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.73498213872537,
+            "lat": 39.54246590613516
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "33fe7584-5091-4bed-a263-f3947b670fcb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -126.5666666667,
+            "lat": 49.6
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "824c0e0c-e0d7-4953-b6c3-8d2bade75dae",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4691222526,
+            "lat": 34.422661
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "18ea92ea-e225-4b70-b9d1-5d61cf74ed77",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.35,
+            "lat": 31.6
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "997870b1-d456-4d3d-8b85-6e5cc43440ca",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "49e7fea4-4814-42c4-8887-05e901e27382",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.8,
+            "lat": 46.0667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2a1c6863-2718-4a9e-bacc-d3dfd375c634",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "23d383c0-ab69-4758-b642-8c42d1be24fb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.949196,
+            "lat": 43.287405
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2abb64ce-ef8f-485d-b80c-4fa61a6b96c4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.077878,
+            "lat": 42.54795
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "06b5f5f5-1a58-4c3f-9f04-b48bfae3853e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.375808,
+            "lat": 42.802514
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2ed37c4b-0ed7-4ba2-a823-d595bc668b33",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.7667,
+            "lat": 47.2167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6ce1cee5-71a3-461c-b7c0-8ca526024e37",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "56af5d09-fb9a-4b21-9897-b06c68577e37",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.6031162,
+            "lat": 33.40033066
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "74bfa810-324f-4aad-9bb7-0430aa041fda",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.412674,
+            "lat": 47.575193
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6e31b349-b637-4a51-bc72-f4913d48257f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.663485,
+            "lat": 35.078382
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "490b3062-fc48-445c-842f-cfdfb2cc85d8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "33c1e43c-d90e-4f4f-b611-90be88801fbd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.654419,
+            "lat": 41.778534
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d5b112c6-743f-4621-8d1c-c40bb822348b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8738301,
+            "lat": 36.87818886
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ac7010f1-8988-48c2-9ce2-40e68f36803e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.839157,
+            "lat": 32.064445
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7b70a2d9-2337-472b-b91c-76f8198dbb59",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.2,
+            "lat": 45.4167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "827dbc45-a7f9-46e8-b266-08e02a81d230",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3667,
+            "lat": 46.65
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f9af5b55-209b-4df3-bbb6-4689b0634bac",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.588315,
+            "lat": 42.624914
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "842a02b8-e101-4ed4-8658-9c505fbf646f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9631704979,
+            "lat": 33.134101
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0ab6c85d-1b11-4700-ba1e-e91094a4bb6d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6b2cddd2-cbd1-4243-9abd-782882afc2ca",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.133538,
+            "lat": 40.448657
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a88676eb-2fac-45fa-be1f-81ccb0f3ed04",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1153381192,
+            "lat": 33.405473
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "84277c57-182e-46fa-97fb-ee2c81a38bfb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.433644,
+            "lat": 31.474494
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9d982f3c-434e-4f86-932e-59b66fbfbd84",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4815,
+            "lat": 32.3723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2587133b-65a4-4cca-9b63-8ac8bb1227ec",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.117111,
+            "lat": 47.543256
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2dc58331-820c-4745-8dd9-19e3259e6d85",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.812797,
+            "lat": 33.87438261
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2f7cb916-74ff-4d22-9c69-d0927489f0c0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.3387405,
+            "lat": 36.67165176
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "36a2cbf1-8901-472a-a849-de288a93fc4d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.5476967,
+            "lat": 33.02069445
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "370b744e-5348-4c93-85fb-9ac5c30a3ab6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.7106238,
+            "lat": 33.50951381
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "19246392-3430-4674-a495-d288b0b52a2c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3333,
+            "lat": 44.5
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1943f221-19d4-43d0-88a6-17e18db71add",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.0167,
+            "lat": 44.55
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1f934623-e700-44fb-9bf2-ff4780f8d432",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.55,
+            "lat": 45.3667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1fefff6d-59b1-4c56-b83d-cd0b1ddda866",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.843887,
+            "lat": 32.019165
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "103be7c9-c077-47a2-b109-e5120fd2e2a5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45699,
+            "lat": 31.84704
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "12a0ac63-9743-4c06-8d66-511b5047d49a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.3612304,
+            "lat": 31.6035623
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d12267dc-b9d1-47f4-83f9-c69afc9d0b16",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d58b5765-64d2-4495-9808-fd0b8da8abf5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.1833,
+            "lat": 42.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b9b6523a-2b97-424f-9772-174100a01c9b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.426067,
+            "lat": 37.277133
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e06cf918-bf83-490b-8e10-62d238492645",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.458487,
+            "lat": 46.772398
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "93222516-bf93-4459-8ea9-69ee0866686b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.1327776,
+            "lat": 34.306118
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c36daac5-8cdb-44be-be49-384844ac9b38",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b3b9c55e-e7de-4031-8c6c-27a70987fcf9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5167,
+            "lat": 46.9167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bf1662d4-4989-4105-81cb-2a844985bff5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3,
+            "lat": 47.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "40cd7dd6-dd6e-4857-af1b-d5a64919ec47",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.2754062,
+            "lat": 33.40210799
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "17295a66-eb1f-470b-8a7a-014b16d2038d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.51666,
+            "lat": 2.83333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5555f841-ff87-4981-9792-b97f91c200df",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.36306,
+            "lat": 48.285
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1ec7dcc7-1e73-4bb2-a425-56c9013d5d5c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -132.25,
+            "lat": 56.4166666667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "29e5772a-52f8-4efd-8290-84117d38f2c1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.9470905,
+            "lat": 35.91470284
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0105abf9-7ed8-4b40-be21-e6ee646108f2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.357701,
+            "lat": 41.145783
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "20b4b02d-cf06-4203-9678-b289b1e2fe64",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.612653,
+            "lat": 44.709328
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "97bc8635-a311-4915-8bc2-144d4ca09f4a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.608717,
+            "lat": 43.985452
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a8bae4d6-dc4c-4f6d-8e2d-4f5f476fa4e4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.905653,
+            "lat": 44.99158
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dbaaf299-238a-49b8-8be5-bfca64ac7839",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8357727,
+            "lat": 36.22077975
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e66998f6-5382-4f81-8102-8cc7207135ba",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.0667,
+            "lat": 40.9833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ca8c675e-8679-4f52-859b-bfaf7eb36d05",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.70614,
+            "lat": 32.91702
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cce50188-4f20-4c3a-a1a3-c65d8a919fc5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3283997,
+            "lat": 33.7977993
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bd7d4cfd-cefb-4176-acb3-ecf779b31668",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.608717,
+            "lat": 43.985452
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6e896033-a23d-485c-a1e5-faef2f6ea1b3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.5,
+            "lat": 43.8667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "863a2496-d2d3-4b98-a5bb-939f69de91e0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.7708315,
+            "lat": 34.22163936
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2e6fd1ff-ae17-4323-988e-49c00b0a740a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.0927777778,
+            "lat": 40.0094444444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "41bffb07-3a12-4c29-adb4-2c51a69151d6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.9333,
+            "lat": 47.6167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fa469176-f879-40b5-a7a2-7ddafd5a080a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.295649,
+            "lat": 48.3098987
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bf478cd6-cff3-4a94-9da6-f3026ca7572c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.840656,
+            "lat": 42.693656
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b3001abb-119b-4b7f-8465-29c096f5fe59",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.36365,
+            "lat": 31.61538
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4869d84d-fa73-4f74-a19f-b4354a615c90",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.10718,
+            "lat": 38.35372
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5e816ee9-309c-4812-b31e-4de409f4163b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.612491,
+            "lat": 41.454838
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "783a8a85-6034-434b-b3f7-84cb30863c0d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.730672,
+            "lat": 42.833014
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ac2ab6e1-6687-404a-9c7a-fe6fe6ba36d6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.82422348578524,
+            "lat": 34.4369250201946
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "055f71ec-3c6e-452c-9249-776da207ce3b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.69259670879347,
+            "lat": 47.154031312747314
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2cda3033-ccd8-4fe1-ad9f-ec9e736620d5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.2427778,
+            "lat": 34.875
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1061f394-c1e1-4f67-a036-9de994e2c17f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.402,
+            "lat": 40.16329
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3bf126f0-8c60-402e-b876-75a9360d0aba",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -60.2666667,
+            "lat": 6.3166667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cf263780-f4c6-4bb5-ba83-6e6505dfa0fc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.496714,
+            "lat": 31.898705
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dd611cfa-ae49-4272-ad6f-afe013a7401d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -90.98302803382234,
+            "lat": 16.882571960435143
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2f0ab7ce-f1b4-4178-9385-222e50558573",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a07bc9f-cd9f-4b35-8385-a50c1d4852cc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.35,
+            "lat": 44.2833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e2bc6ad8-ec80-459d-8f66-bc0361d0fe54",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.728206,
+            "lat": 44.942853
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e790139e-3cb2-41c0-9a8f-c9f3cee607d5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.5833,
+            "lat": 44.0167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cbdd5b69-041d-49b4-a19c-9e65cf8fa8a0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4320983,
+            "lat": 33.5285997
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cdae998a-f006-4db7-a58e-b9f69af7e1ba",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.215514,
+            "lat": 41.892425
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "724957cc-f0e5-4de7-add4-0341fc64ad32",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.276012,
+            "lat": 47.803527
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "53a5163d-ab6c-4822-bc13-081c30eb9699",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.8557818,
+            "lat": 32.69942049
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4ca07116-b695-4425-98a7-b03eed446a82",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.8451115,
+            "lat": 33.195911
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4d37c20c-ea82-442f-8eb6-17202b4fef15",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.1381464,
+            "lat": 36.9235171
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "88d53b35-0a3b-4cf4-a37d-353e3932ca1c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.3199,
+            "lat": 45.4343
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "983d4304-5436-4439-b1ee-69d1aa1d51a4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.8497003,
+            "lat": 36.84600531
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cfc68794-0336-415b-b9cc-c3091676d1d3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1153381192,
+            "lat": 33.405473
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d15f9ed9-85f4-4bdc-a160-c0591bc0d946",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0675816052,
+            "lat": 34.423023
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e5487eab-6389-4fbe-b0f3-eb7ed877dcf0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.433644,
+            "lat": 31.474494
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d1b776e3-e00d-4ed8-830d-93f94dfd282a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.89839,
+            "lat": 38.41026
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "af7e7b80-c145-4068-95d6-7bf96674aa12",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.2042309659,
+            "lat": 32.910372
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3917f6a3-6302-4d6f-952d-3cbbae54f020",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.122,
+            "lat": 46.7578
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cecbfd32-86ab-4d2e-ab50-31b91af768a1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5667,
+            "lat": 43.6333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9b116659-edbd-494e-b177-d0a83c437a9f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.465376,
+            "lat": 31.813188
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e01de566-9e14-4277-b1d5-f0000f33417f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -93.1,
+            "lat": 16.7269444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "86179189-d89c-4f93-bf3e-8a4a88d48005",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.1625,
+            "lat": 16.8125
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9b21b92d-1ddc-4f65-a7c0-904e32162866",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -74.448633,
+            "lat": 42.057137
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5039448d-126f-4bf7-8865-790b66f19811",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.083,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7325caa5-e250-47f1-9441-72d6f4b41d0d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "302e283b-1ff2-4673-9cf4-f07b56a9d641",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.21,
+            "lat": 29.41
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "16e70b6c-d547-4a51-be85-128a70db1d99",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.583333,
+            "lat": 49.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c87f6859-0fe5-4ad7-b747-6f12a0cd4b28",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.65,
+            "lat": 47.85
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ddc72f73-f807-4c16-9d58-41b582de7dd0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.124407,
+            "lat": 42.42853
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ae192194-b8b9-43ac-853e-941f7391f736",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "66231d3a-4ffb-4c80-93bb-cbd9ac599d45",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.4,
+            "lat": 37.3667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8b4cbf71-d554-4ed9-963d-7e9a78c42c38",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.1765382,
+            "lat": 34.92388008
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "760c6d02-59c4-4691-a40f-34a724efdda1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.45,
+            "lat": 47.6833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "24f4389e-f949-4bd2-a4b2-7a81e6d3c193",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a84970a-74d6-4b18-b1a7-6f47351b6eea",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.799562,
+            "lat": 46.65603
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9dc0ae7b-b6ca-4924-b390-1a7e1a98c03d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.840656,
+            "lat": 42.693656
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f365f4f7-f4f7-4a37-b120-6398f2538b5e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.240617,
+            "lat": 31.592321
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fa228820-032c-4453-b84d-40328bb6937d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.15973,
+            "lat": 33.03485
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b55d45c1-1f96-4742-88ad-145079603126",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.950044,
+            "lat": 40.96048
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1c84fae2-43ea-477a-93d9-4aa23b2a52ab",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.70963,
+            "lat": 32.72195
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "43ea233e-075a-4a18-9382-6502c5550de2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4815,
+            "lat": 32.3723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2566a9b8-9aed-4a7c-9e5f-bac6193b5178",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.412674,
+            "lat": 47.575193
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "122b2672-1282-4016-99ce-4c3b3c709ea4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.994714,
+            "lat": 31.694212
+          },
+          "scientificname": "puma concolor"
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "gstyle": {
+      "doc_count": 137283704,
+      "f": {
+        "doc_count": 1322,
+        "style": {
+          "doc_count_error_upper_bound": 0,
+          "sum_other_doc_count": 0,
+          "buckets": [
+            {
+              "key": "puma concolor",
+              "doc_count": 1322
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/__tests__/mock/search-905e2b45c97ff92e3f18070c2ef6a7aa.json
+++ b/__tests__/mock/search-905e2b45c97ff92e3f18070c2ef6a7aa.json
@@ -1,0 +1,2786 @@
+{
+  "timed_out": false,
+  "_shards": {
+    "total": 48,
+    "successful": 48,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1801893,
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1c3df9cd-e986-43aa-b692-de05893a98d1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lat": 11.61667,
+            "lon": 1.98333
+          },
+          "family": "combretaceae",
+          "recordset": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+          "dqs": 0.2028985507246377,
+          "stateprovince": "tapoa",
+          "phylum": "tracheophyta",
+          "catalognumber": "p00519347",
+          "startdayofyear": 188,
+          "taxonrank": "species",
+          "specificepithet": "aculeatum",
+          "verbatimlocality": "gourma, de konkobiri à diapaga, env. de compongou",
+          "uuid": "1c3df9cd-e986-43aa-b692-de05893a98d1",
+          "basisofrecord": "preservedspecimen",
+          "collector": "chevalier, a.j.b.",
+          "institutioncode": "mnhn",
+          "mediarecords": [
+            "f497509d-afbd-416e-a6da-6334071bc3fa",
+            "9fc7408a-ef29-4f51-8ebc-ce4a3f1c183b"
+          ],
+          "datemodified": "2021-04-19T22:06:14.550973+00:00",
+          "datecollected": "1910-07-07T00:00:00+00:00",
+          "etag": "0539ff6461acf9d21f9920b5951ea6f19ecd30d5",
+          "flags": [
+            "geopoint_datum_missing",
+            "dwc_taxonrank_added",
+            "dwc_multimedia_added",
+            "gbif_reference_added",
+            "dwc_specificepithet_added",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_parentnameusageid_added",
+            "dwc_taxonid_added",
+            "gbif_canonicalname_added",
+            "dwc_phylum_added",
+            "gbif_taxon_corrected",
+            "dwc_order_added",
+            "dwc_class_added",
+            "dwc_kingdom_added"
+          ],
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "taxonid": "3698905",
+          "scientificname": "combretum aculeatum vent.",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "idigbio:dateModified": "2021-04-19T22:06:14.550973",
+            "dwc:countryCode": "bf",
+            "dwc:kingdom": "plantae",
+            "dwc:recordedBy": "Chevalier, A.J.B.",
+            "idigbio:uuid": "1c3df9cd-e986-43aa-b692-de05893a98d1",
+            "flag_dwc_multimedia_added": true,
+            "dwc:fieldNumber": "24372",
+            "gbif:canonicalname": "combretum aculeatum",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "Vent.",
+            "idigbio:recordIds": [
+              "616857b7-f952-44ef-9b6f-576dc1e65b51\\http://coldb.mnhn.fr/catalognumber/mnhn/p/p00519347"
+            ],
+            "dwc:occurrenceID": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00519347",
+            "flag_dwc_specificepithet_added": true,
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "id": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00519347",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+            "dwc:stateProvince": "Tapoa",
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dwc:eventDate": "1910-7",
+            "dwc:country": "Soudan Français",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "creative commons attribution share alike 3.0 unported",
+                "dcterms:title": "combretum aculeatum auf einem termitenhügel im nationalpark w, burkina faso.",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:combretum_aculeatum_ms_6409.jpg",
+                "coreid": "3698905",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/2/24/combretum_aculeatum_ms_6409.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:created": "2007-01-01",
+                "dcterms:description": "combretum aculeatum on a termite mound in w national park, burkina faso",
+                "dcterms:creator": "marco schmidt [1]",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "0539ff6461acf9d21f9920b5951ea6f19ecd30d5",
+            "dwc:collectionCode": "P",
+            "dwc:decimalLatitude": "11.61667",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Combretum",
+            "dwc:preparations": "hb",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_taxonid_added": true,
+            "idigbio:siblings": {
+              "mediarecord": [
+                "f497509d-afbd-416e-a6da-6334071bc3fa",
+                "9fc7408a-ef29-4f51-8ebc-ce4a3f1c183b"
+              ]
+            },
+            "dwc:order": "myrtales",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_phylum_added": true,
+            "gbif:genericname": "combretum",
+            "dwc:locality": "Kompongou",
+            "dwc:specificepithet": "aculeatum",
+            "dwc:institutionCode": "MNHN",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "2986357",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "P00519347",
+            "dwc:taxonid": "3698905",
+            "gbif:Identifier": [
+              {
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00519347",
+                "dcterms:identifier": "F85DD33194B84BDAB9E6622ED6FC3220",
+                "dcterms:subject": "e-recolnat"
+              }
+            ],
+            "dwc:taxonrank": "species",
+            "dwc:Identification": [
+              {
+                "dwc:taxonID": "SONNERAT|73218",
+                "dwc:identificationVerificationStatus": "1",
+                "dwc:specificEpithet": "aculeatum",
+                "dwc:scientificNameAuthorship": "Vent.",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00519347",
+                "dwc:identificationID": "SONNERAT|587422",
+                "dwc:genus": "Combretum",
+                "dwc:scientificName": "Combretum aculeatum Vent.",
+                "dwc:higherClassification": "Combretum;Combretaceae",
+                "dwc:family": "Combretaceae"
+              },
+              {
+                "dwc:taxonID": "SONNERAT|73218",
+                "dwc:identificationRemarks": "operation de numerisation 2010-2012",
+                "dwc:specificEpithet": "aculeatum",
+                "dwc:identificationID": "SONNERAT|6887464",
+                "dwc:identificationVerificationStatus": "0",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00519347",
+                "dwc:scientificNameAuthorship": "Vent.",
+                "dwc:genus": "Combretum",
+                "dwc:scientificName": "Combretum aculeatum Vent.",
+                "dwc:higherClassification": "Combretum;Combretaceae",
+                "dwc:family": "Combretaceae"
+              }
+            ],
+            "dwc:month": "7",
+            "dwc:decimalLongitude": "1.98333",
+            "flag_dwc_order_added": true,
+            "dwc:verbatimLocality": "Gourma, de Konkobiri à Diapaga, env. de Compongou",
+            "dwc:phylum": "tracheophyta",
+            "dwc:family": "Combretaceae",
+            "flag_dwc_class_added": true,
+            "dcterms:modified": "2015-09-04 23:23:13.0",
+            "dwc:scientificName": "Combretum aculeatum Vent.",
+            "gbif:reference": [
+              {
+                "coreid": "3698905",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "vent. (1808) in: choix, 58"
+              }
+            ],
+            "flag_dwc_kingdom_added": true,
+            "dwc:year": "1910"
+          },
+          "data": {
+            "dwc:countryCode": "bf",
+            "dwc:recordedBy": "Chevalier, A.J.B.",
+            "dwc:fieldNumber": "24372",
+            "dwc:scientificNameAuthorship": "Vent.",
+            "dwc:occurrenceID": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00519347",
+            "id": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00519347",
+            "dwc:stateProvince": "Tapoa",
+            "dwc:eventDate": "1910-7",
+            "dwc:country": "Soudan Français",
+            "dwc:collectionCode": "P",
+            "dwc:decimalLatitude": "11.61667",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Combretum",
+            "dwc:preparations": "hb",
+            "dwc:locality": "Kompongou",
+            "dwc:institutionCode": "MNHN",
+            "dwc:catalogNumber": "P00519347",
+            "gbif:Identifier": [
+              {
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00519347",
+                "dcterms:identifier": "F85DD33194B84BDAB9E6622ED6FC3220",
+                "dcterms:subject": "e-recolnat"
+              }
+            ],
+            "dwc:Identification": [
+              {
+                "dwc:taxonID": "SONNERAT|73218",
+                "dwc:identificationVerificationStatus": "1",
+                "dwc:specificEpithet": "aculeatum",
+                "dwc:scientificNameAuthorship": "Vent.",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00519347",
+                "dwc:identificationID": "SONNERAT|587422",
+                "dwc:genus": "Combretum",
+                "dwc:scientificName": "Combretum aculeatum Vent.",
+                "dwc:higherClassification": "Combretum;Combretaceae",
+                "dwc:family": "Combretaceae"
+              },
+              {
+                "dwc:taxonID": "SONNERAT|73218",
+                "dwc:identificationRemarks": "operation de numerisation 2010-2012",
+                "dwc:specificEpithet": "aculeatum",
+                "dwc:scientificNameAuthorship": "Vent.",
+                "dwc:identificationVerificationStatus": "0",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00519347",
+                "dwc:identificationID": "SONNERAT|6887464",
+                "dwc:genus": "Combretum",
+                "dwc:scientificName": "Combretum aculeatum Vent.",
+                "dwc:higherClassification": "Combretum;Combretaceae",
+                "dwc:family": "Combretaceae"
+              }
+            ],
+            "dwc:month": "7",
+            "dwc:decimalLongitude": "1.98333",
+            "dwc:verbatimLocality": "Gourma, de Konkobiri à Diapaga, env. de Compongou",
+            "dwc:family": "Combretaceae",
+            "dcterms:modified": "2015-09-04 23:23:13.0",
+            "dwc:scientificName": "Combretum aculeatum Vent.",
+            "dwc:year": "1910"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00519347",
+          "country": "soudan français",
+          "locality": "kompongou",
+          "collectioncode": "p",
+          "canonicalname": "combretum aculeatum",
+          "eventdate": "1910-7",
+          "fieldnumber": "24372",
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "616857b7-f952-44ef-9b6f-576dc1e65b51\\http://coldb.mnhn.fr/catalognumber/mnhn/p/p00519347"
+          ],
+          "genus": "combretum",
+          "order": "myrtales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "974a6340-8d6a-42bd-b1d8-2ecac901815e",
+        "_score": 1,
+        "_source": {
+          "family": "onagraceae",
+          "recordset": "76fd34da-4892-4821-858d-98fe9e28ba8b",
+          "stateprovince": "alabama",
+          "institutioncode": "vsc",
+          "county": "covington county",
+          "phylum": "tracheophyta",
+          "catalognumber": "vsc0000123",
+          "startdayofyear": 232,
+          "taxonrank": "species",
+          "specificepithet": "biennis",
+          "continent": "north america",
+          "uuid": "974a6340-8d6a-42bd-b1d8-2ecac901815e",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "r. kral",
+          "commonnames": [
+            "largeflower evening-primrose"
+          ],
+          "mediarecords": [
+            "bd70007d-f2be-4eee-a304-f03f302380da"
+          ],
+          "datemodified": "2015-03-10T17:31:50.281000+00:00",
+          "datecollected": "1981-08-20T00:00:00+00:00",
+          "etag": "54a0713b4f8f5cd8f7c2abc363d6fe47a779a28a",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "commonname": "largeflower evening-primrose",
+          "taxonid": "3188924",
+          "scientificname": "oenothera grandiflora",
+          "indexData": {
+            "dwc:specificEpithet": "biennis",
+            "idigbio:dateModified": "2015-03-10T17:31:50.281000",
+            "dwc:county": "Covington County",
+            "dwc:recordedBy": "R. Kral",
+            "idigbio:uuid": "974a6340-8d6a-42bd-b1d8-2ecac901815e",
+            "dwc:order": "Myrtales",
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "flag_gbif_reference_added": true,
+            "dcterms:accessRights": "CC BY",
+            "flag_dwc_taxonid_replaced": true,
+            "dwc:occurrenceID": "urn:uuid:00f2d181-3b3e-43db-b6f0-34510fd2a50a",
+            "flag_dwc_taxonrank_replaced": true,
+            "flag_dwc_specificepithet_replaced": true,
+            "dcterms:language": "en",
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "dcterms:rightsHolder": "Valdosta State University Herbarium",
+            "dwc:taxonID": "3188924",
+            "idigbio:parent": "76fd34da-4892-4821-858d-98fe9e28ba8b",
+            "dwc:stateProvince": "Alabama",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:eventDate": "1981-08-20",
+            "flag_dwc_scientificnameauthorship_replaced": true,
+            "dwc:country": "United States",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "public domain",
+                "dcterms:title": "rosette",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:oenothera_biennis_rosette.jpg",
+                "coreid": "3188924",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/0/00/oenothera_biennis_rosette.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "rosette von oenothera biennis (gemeine nachtkerze)",
+                "dcterms:creator": "noebse",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "creative commons attribution share alike 3.0 unported",
+                "dcterms:title": "primrose moth (schinia florida) in flower",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:primrose_moth.jpg",
+                "coreid": "3188924",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/0/03/primrose_moth.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "english: primrose moth (schinia florida) on evening-primrose, mer bleue conservation area, ottawa, ontario",
+                "dcterms:creator": "d. gordon e. robertson",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "creative commons attribution share alike 3.0 unported",
+                "dcterms:title": "flowers and fruit capsules",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:nachtkerze_mit_samenständen_und_blüten.jpg",
+                "coreid": "3188924",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/3/32/nachtkerze_mit_samenst%c3%a4nden_und_bl%c3%bcten.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "nachtkerze mit samenständen",
+                "dcterms:creator": "noebse",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "cc-by-sa-4.0",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:oenothera_biennis,_vic-la-gardiole_01.jpg",
+                "coreid": "3188924",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/4/40/oenothera_biennis%2c_vic-la-gardiole_01.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "français : oenothera biennis (onagre bisannuelle). fleurs et boutons. cette plante a été identifié avec l'aide d'Éric pensa ici : [1]. english: oenothera biennis (common evening primrose). flowers and buds. this plant have been identified with the help of Éric pensa here : [2]. deutsch: oenothera biennis (gemeine nachtkerze). blüten und knospen.",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "creative commons attribution share alike",
+                "dcterms:title": "gemeine nachtkerze (oenothera biennis)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:oenothera_biennis_uppsala.jpg",
+                "coreid": "3188924",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/b/b0/oenothera_biennis_uppsala.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "oenothera biennis",
+                "dcterms:creator": "udo schröter",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "gnu free documentation license",
+                "dcterms:title": "habitat, dry and sunny",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:oenothera_biennis_enbla02.jpeg",
+                "coreid": "3188924",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/f/f4/oenothera_biennis_enbla02.jpeg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:created": "2006-11-02",
+                "dcterms:description": "italiano: oenothera_biennis (enagra comune) località : praloran, limana (bl), 319 m s.l.m.",
+                "dcterms:creator": "enrico blasutto",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "54a0713b4f8f5cd8f7c2abc363d6fe47a779a28a",
+            "dwc:collectionCode": "Herb",
+            "id": "urn:uuid:00f2d181-3b3e-43db-b6f0-34510fd2a50a",
+            "dwc:identificationID": "61307",
+            "dwc:locationID": "urn:uuid:933fb41f-2ac6-413e-9d5f-17c861080fe7",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Oenothera",
+            "dwc:continent": "North America",
+            "dwc:family": "Onagraceae",
+            "idigbio:isocountrycode": "usa",
+            "dwc:identifiedBy": "R. Kral",
+            "flag_dwc_datasetid_added": true,
+            "dwc:kingdom": "Plantae",
+            "idigbio:recordIds": [
+              "76fd34da-4892-4821-858d-98fe9e28ba8b\\urn:uuid:00f2d181-3b3e-43db-b6f0-34510fd2a50a"
+            ],
+            "idigbio:siblings": {
+              "mediarecord": [
+                "bd70007d-f2be-4eee-a304-f03f302380da"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:vernacularName": "largeflower evening-primrose",
+            "gbif:canonicalname": "oenothera biennis",
+            "dwc:eventID": "51257",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "oenothera",
+            "flag_dwc_multimedia_added": true,
+            "dwc:institutionID": "urn:lsid:biocol.org:col:15754",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "VSC",
+            "dwc:taxonRank": "species",
+            "dwc:parentnameusageid": "3188799",
+            "dwc:class": "Magnoliopsida",
+            "dwc:catalogNumber": "VSC0000123",
+            "flag_dwc_phylum_replaced": true,
+            "dcterms:type": "PhysicalObject",
+            "flag_gbif_canonicalname_added": true,
+            "dwc:scientificNameAuthorship": "l.",
+            "dwc:higherGeographyID": "8697",
+            "dcterms:rights": "http://creativecommons.org/licenses/by/4.0/",
+            "flag_dwc_parentnameusageid_added": true,
+            "dcterms:modified": "2013-11-12 13:11:51.0",
+            "dwc:scientificName": "Oenothera grandiflora",
+            "gbif:reference": [
+              {
+                "coreid": "3188924",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "l. (1753) in: sp. pl.: 346"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "gbif:vernacularname": [
+              {
+                "coreid": "3188924",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "candlestick"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "common evening primrose"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "common evening primrose",
+                "coreid": "3188924",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "common evening primrose"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:language": "en",
+                "dcterms:source": "english wikipedia - species pages",
+                "dwc:vernacularname": "common evening primrose"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "common evening-primrose"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "common evening primrose"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "common evening-primrose"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "common eveningprimrose"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "evening primrose (common)"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "evening-primrose"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "gemeine nachtkerze",
+                "coreid": "3188924",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "gemeine nachtkerze"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "german rampion"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "german-rampion"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "gewöhnliche nachtkerze"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "herbe aux ânes"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "hoary evening primrose"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "hoary eveningprimrose"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "king's cureall"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "king's-cureall"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:source": "korean peninsula flora",
+                "dwc:vernacularname": "달맞이꽃"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "me-matsuyoigusa"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "middelste teunisbloem",
+                "coreid": "3188924",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "middelste teunisbloem"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "nattljus"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "onagre bisannuelle",
+                "coreid": "3188924",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "onagre bisannuelle"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "onagre de victorin"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "oslennik dvuchletnyj"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "pricknattljus"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "wild evening primrose"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "yellow evening primrose"
+              },
+              {
+                "coreid": "3188924",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "yue jian cao"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "zweijährige nachtkerze",
+                "coreid": "3188924",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              }
+            ]
+          },
+          "data": {
+            "dwc:specificEpithet": "grandiflora",
+            "dwc:county": "Covington County",
+            "dwc:recordedBy": "R. Kral",
+            "dwc:order": "Myrtales",
+            "dcterms:accessRights": "CC BY",
+            "dwc:occurrenceID": "urn:uuid:00f2d181-3b3e-43db-b6f0-34510fd2a50a",
+            "dcterms:language": "en",
+            "id": "urn:uuid:00f2d181-3b3e-43db-b6f0-34510fd2a50a",
+            "dwc:taxonID": "38678",
+            "dwc:stateProvince": "Alabama",
+            "dwc:eventDate": "1981-08-20",
+            "dwc:identificationID": "61307",
+            "dwc:country": "United States",
+            "dwc:collectionCode": "Herb",
+            "dcterms:rightsHolder": "Valdosta State University Herbarium",
+            "dwc:kingdom": "Plantae",
+            "dwc:locationID": "urn:uuid:933fb41f-2ac6-413e-9d5f-17c861080fe7",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Oenothera",
+            "dwc:continent": "North America",
+            "dwc:family": "Onagraceae",
+            "dwc:identifiedBy": "R. Kral",
+            "dwc:vernacularName": "largeflower evening-primrose",
+            "dwc:eventID": "51257",
+            "dwc:phylum": "Magnoliophyta",
+            "dwc:institutionID": "urn:lsid:biocol.org:col:15754",
+            "dwc:institutionCode": "VSC",
+            "dwc:taxonRank": "Species",
+            "dwc:class": "Magnoliopsida",
+            "dwc:catalogNumber": "VSC0000123",
+            "dcterms:type": "PhysicalObject",
+            "dwc:scientificNameAuthorship": "L'Hér. ex Ait.",
+            "dwc:higherGeographyID": "8697",
+            "dcterms:rights": "http://creativecommons.org/licenses/by/4.0/",
+            "dcterms:modified": "2013-11-12 13:11:51.0",
+            "dwc:scientificName": "Oenothera grandiflora"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:00f2d181-3b3e-43db-b6f0-34510fd2a50a",
+          "institutionid": "urn:lsid:biocol.org:col:15754",
+          "country": "united states",
+          "dqs": 0.2318840579710145,
+          "collectioncode": "herb",
+          "canonicalname": "oenothera biennis",
+          "eventdate": "1981-08-20",
+          "flags": [
+            "gbif_reference_added",
+            "dwc_taxonid_replaced",
+            "dwc_taxonrank_replaced",
+            "dwc_specificepithet_replaced",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "gbif_taxon_corrected",
+            "dwc_scientificnameauthorship_replaced",
+            "dwc_datasetid_added",
+            "idigbio_isocountrycode_added",
+            "dwc_multimedia_added",
+            "gbif_vernacularname_added",
+            "dwc_phylum_replaced",
+            "gbif_canonicalname_added",
+            "dwc_parentnameusageid_added"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "76fd34da-4892-4821-858d-98fe9e28ba8b\\urn:uuid:00f2d181-3b3e-43db-b6f0-34510fd2a50a"
+          ],
+          "genus": "oenothera",
+          "order": "myrtales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cea33619-4047-4c3c-bfaf-39d7c4d1d36c",
+        "_score": 1,
+        "_source": {
+          "family": "onagraceae",
+          "recordset": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+          "phylum": "tracheophyta",
+          "catalognumber": "p04890182",
+          "taxonrank": "species",
+          "specificepithet": "parviflorum",
+          "continent": "europe",
+          "uuid": "cea33619-4047-4c3c-bfaf-39d7c4d1d36c",
+          "countrycode": "fra",
+          "basisofrecord": "preservedspecimen",
+          "institutioncode": "mnhn",
+          "mediarecords": [
+            "05b5dd67-93f5-4359-ae73-01e87960954e",
+            "49769f9c-dccf-4132-9094-ba170bfa5b7b"
+          ],
+          "datemodified": "2021-04-19T22:06:14.550973+00:00",
+          "etag": "854c12e3c095356ec098b2c7d586d0a3d40c8020",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "taxonid": "3189157",
+          "scientificname": "epilobium hirsutum l.",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "flag_dwc_country_replaced": true,
+            "idigbio:dateModified": "2021-04-19T22:06:14.550973",
+            "dwc:countryCode": "fr",
+            "dwc:kingdom": "plantae",
+            "idigbio:uuid": "cea33619-4047-4c3c-bfaf-39d7c4d1d36c",
+            "gbif:canonicalname": "epilobium parviflorum",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "schreb.",
+            "idigbio:recordIds": [
+              "616857b7-f952-44ef-9b6f-576dc1e65b51\\http://coldb.mnhn.fr/catalognumber/mnhn/p/p04890182"
+            ],
+            "dwc:occurrenceID": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p04890182",
+            "flag_dwc_specificepithet_added": true,
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "id": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p04890182",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "flag_dwc_scientificnameauthorship_replaced": true,
+            "dwc:country": "france",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "creative commons attribution share alike 3.0 unported",
+                "dcterms:title": "kleinblütiges weidenröschen (epilobium parviflorum)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:onagraceae_-_epilobium_parviflorum-3.jpg",
+                "coreid": "3189157",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/0/03/onagraceae_-_epilobium_parviflorum-3.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "english: epilobium parviflorum - parco dell'antola, genova, italy",
+                "dcterms:creator": "hectonichus",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "creative commons attribution share alike 3.0 unported",
+                "dcterms:title": "flowers",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:onagraceae_-_epilobium_parviflorum-2.jpg",
+                "coreid": "3189157",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/a/ab/onagraceae_-_epilobium_parviflorum-2.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "english: epilobium parviflorum - parco dell'aveto, genova, italy",
+                "dcterms:creator": "hectonichus",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "854c12e3c095356ec098b2c7d586d0a3d40c8020",
+            "dwc:collectionCode": "P",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Epilobium",
+            "dwc:continent": "europe",
+            "dwc:family": "Onagraceae",
+            "flag_dwc_continent_added": true,
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "fra",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "05b5dd67-93f5-4359-ae73-01e87960954e",
+                "49769f9c-dccf-4132-9094-ba170bfa5b7b"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:order": "myrtales",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_phylum_added": true,
+            "gbif:genericname": "epilobium",
+            "flag_dwc_multimedia_added": true,
+            "dwc:specificepithet": "parviflorum",
+            "dwc:institutionCode": "MNHN",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189067",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "P04890182",
+            "dwc:taxonid": "3189157",
+            "gbif:Identifier": [
+              {
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p04890182",
+                "dcterms:identifier": "74B7CDC327364305954F34D7167A22F6",
+                "dcterms:subject": "e-recolnat"
+              }
+            ],
+            "dwc:taxonrank": "species",
+            "dwc:Identification": [
+              {
+                "dwc:taxonID": "SONNERAT|11319",
+                "dwc:identificationRemarks": "operation de numerisation 2010-2012",
+                "dwc:specificEpithet": "hirsutum",
+                "dwc:identificationID": "SONNERAT|7189377",
+                "dwc:identificationVerificationStatus": "1",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p04890182",
+                "dwc:scientificNameAuthorship": "L.",
+                "dwc:genus": "Epilobium",
+                "dwc:scientificName": "Epilobium hirsutum L.",
+                "dwc:higherClassification": "Epilobium;Onagraceae",
+                "dwc:family": "Onagraceae"
+              }
+            ],
+            "flag_dwc_order_added": true,
+            "dwc:phylum": "tracheophyta",
+            "dwc:preparations": "hb",
+            "flag_dwc_class_added": true,
+            "dcterms:modified": "2015-09-05 07:10:14.0",
+            "dwc:scientificName": "Epilobium hirsutum L.",
+            "gbif:reference": [
+              {
+                "coreid": "3189157",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "schreb. (1771) in: spic. fl. lips.: 146"
+              },
+              {
+                "coreid": "3189157",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "flag_dwc_kingdom_added": true,
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189157",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "bach-weidenröschen"
+              },
+              {
+                "dwc:countrycode": "dk",
+                "dwc:country": "denmark",
+                "dwc:vernacularname": "dunet dueurt",
+                "coreid": "3189157",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "da"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "dunmjølke",
+                "coreid": "3189157",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nb"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "dunmjølke",
+                "coreid": "3189157",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nn"
+              },
+              {
+                "coreid": "3189157",
+                "dcterms:language": "no",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "dunmjølke"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "epilobe à petites fleurs",
+                "coreid": "3189157",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3189157",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "épilobe à petites fleurs"
+              },
+              {
+                "coreid": "3189157",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "hoary willowherb"
+              },
+              {
+                "coreid": "3189157",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "kleinblütiges weidenröschen"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "kleinblütiges weidenröschen",
+                "coreid": "3189157",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189157",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "kleinblütiges weidenröschen"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "kleinblütiges weidenröschen",
+                "coreid": "3189157",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189157",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "kleinblütiges weidenröschen"
+              },
+              {
+                "coreid": "3189157",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "luddunört"
+              },
+              {
+                "dwc:countrycode": "se",
+                "dwc:country": "sweden",
+                "dwc:vernacularname": "luddunört",
+                "coreid": "3189157",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "nukkahorsma",
+                "coreid": "3189157",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "fi"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "nukkahorsma",
+                "coreid": "3189157",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "coreid": "3189157",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "small-flowered hairy willowherb"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "small-flowered willowherb",
+                "coreid": "3189157",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189157",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "small-flowered willowherb"
+              },
+              {
+                "coreid": "3189157",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "smallflower hairy willowherb"
+              },
+              {
+                "coreid": "3189157",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "small-flower willowherb"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "viltige basterdwederik",
+                "coreid": "3189157",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3189157",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "viltige basterdwederik"
+              }
+            ]
+          },
+          "data": {
+            "gbif:Identifier": [
+              {
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p04890182",
+                "dcterms:identifier": "74B7CDC327364305954F34D7167A22F6",
+                "dcterms:subject": "e-recolnat"
+              }
+            ],
+            "dcterms:modified": "2015-09-05 07:10:14.0",
+            "dwc:Identification": [
+              {
+                "dwc:taxonID": "SONNERAT|11319",
+                "dwc:identificationRemarks": "operation de numerisation 2010-2012",
+                "dwc:specificEpithet": "hirsutum",
+                "dwc:scientificNameAuthorship": "L.",
+                "dwc:identificationVerificationStatus": "1",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p04890182",
+                "dwc:identificationID": "SONNERAT|7189377",
+                "dwc:genus": "Epilobium",
+                "dwc:scientificName": "Epilobium hirsutum L.",
+                "dwc:higherClassification": "Epilobium;Onagraceae",
+                "dwc:family": "Onagraceae"
+              }
+            ],
+            "dwc:countryCode": "fr",
+            "dwc:country": "[France]",
+            "dwc:collectionCode": "P",
+            "dwc:scientificNameAuthorship": "L.",
+            "dwc:occurrenceID": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p04890182",
+            "dwc:preparations": "hb",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:institutionCode": "MNHN",
+            "dwc:genus": "Epilobium",
+            "dwc:scientificName": "Epilobium hirsutum L.",
+            "id": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p04890182",
+            "dwc:family": "Onagraceae",
+            "dwc:catalogNumber": "P04890182"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p04890182",
+          "country": "france",
+          "dqs": 0.043478260869565216,
+          "collectioncode": "p",
+          "canonicalname": "epilobium parviflorum",
+          "flags": [
+            "dwc_taxonrank_added",
+            "dwc_country_replaced",
+            "gbif_reference_added",
+            "dwc_specificepithet_added",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_scientificnameauthorship_replaced",
+            "gbif_vernacularname_added",
+            "dwc_continent_added",
+            "dwc_parentnameusageid_added",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "gbif_canonicalname_added",
+            "dwc_phylum_added",
+            "dwc_multimedia_added",
+            "gbif_taxon_corrected",
+            "dwc_order_added",
+            "dwc_class_added",
+            "dwc_kingdom_added"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "616857b7-f952-44ef-9b6f-576dc1e65b51\\http://coldb.mnhn.fr/catalognumber/mnhn/p/p04890182"
+          ],
+          "genus": "epilobium",
+          "order": "myrtales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "97e21169-89b9-438e-ba49-ebdc4431b107",
+        "_score": 1,
+        "_source": {
+          "family": "onagraceae",
+          "recordset": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "stateprovince": "new jersey",
+          "collectioncode": "yu",
+          "phylum": "tracheophyta",
+          "catalognumber": "yu.075139",
+          "startdayofyear": 252,
+          "taxonrank": "species",
+          "specificepithet": "fruticosa",
+          "continent": "north america",
+          "uuid": "97e21169-89b9-438e-ba49-ebdc4431b107",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "d. c. eaton",
+          "institutioncode": "yale peabody museum of natural history",
+          "mediarecords": [
+            "e482ee21-790c-4369-958e-56163ef1c6f8"
+          ],
+          "datemodified": "2016-01-27T21:25:22.884015+00:00",
+          "datecollected": "1862-09-09T00:00:00+00:00",
+          "etag": "376c005a7a63f232491deb4ba53d839e7bf595dd",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "collectionid": "urn:lsid:biocol.org:col:14791",
+          "taxonid": "7884360",
+          "scientificname": "oenothera fruticosa ssp. glauca",
+          "indexData": {
+            "dwc:startDayOfYear": "252",
+            "flag_dwc_country_replaced": true,
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "gnu free documentation license",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:oenothera_fruticosa0.jpg",
+                "coreid": "7884360",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/2/29/oenothera_fruticosa0.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:created": "2004-01-01",
+                "dcterms:description": "species: oenothera fruticosa family: onagraceae image no. 1",
+                "dcterms:creator": "kurt stüber [1]",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "dwc:specificEpithet": "fruticosa",
+            "idigbio:dateModified": "2016-01-27T21:25:22.884015",
+            "dwc:kingdom": "Plantae",
+            "dwc:recordedBy": "D. C. Eaton",
+            "idigbio:uuid": "97e21169-89b9-438e-ba49-ebdc4431b107",
+            "dwc:order": "Myrtales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807147",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "l.",
+            "idigbio:recordIds": [
+              "urn:uuid:8d9b91f1-405f-4e90-8292-8329e7eac9c3",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\urn:uuid:95f58b12-944d-46eb-90d9-6b864f7999f5",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\807147"
+            ],
+            "dwc:occurrenceID": "urn:uuid:95f58b12-944d-46eb-90d9-6b864f7999f5",
+            "flag_dwc_taxonrank_replaced": true,
+            "id": "807147",
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "symbiota:recordEnteredBy": "Bob Swerling",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+            "dwc:stateProvince": "New Jersey",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:eventDate": "1862-09-09",
+            "flag_dwc_scientificnameauthorship_replaced": true,
+            "dwc:collectionID": "urn:lsid:biocol.org:col:14791",
+            "dwc:country": "united states",
+            "idigbio:recordId": "urn:uuid:8d9b91f1-405f-4e90-8292-8329e7eac9c3",
+            "idigbio:etag": "376c005a7a63f232491deb4ba53d839e7bf595dd",
+            "dwc:collectionCode": "YU",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Oenothera",
+            "dwc:continent": "north america",
+            "dwc:family": "Onagraceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_phylum_replaced": true,
+            "gbif:canonicalname": "oenothera fruticosa",
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "usa",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "e482ee21-790c-4369-958e-56163ef1c6f8"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:infraspecificEpithet": "glauca",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "oenothera",
+            "flag_dwc_multimedia_added": true,
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "dwc:taxonRank": "species",
+            "dwc:parentnameusageid": "3188799",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "YU.075139",
+            "dwc:taxonid": "7884360",
+            "flag_gbif_canonicalname_added": true,
+            "dwc:Identification": [
+              {
+                "coreid": "807147",
+                "dwc:identificationRemarks": "0",
+                "idigbio:recordId": "urn:uuid:7be182d1-08a7-4d67-8974-38f2a827bcb9",
+                "dwc:scientificName": "Oenothera fruticosa subspecies glauca (Michx.) Straley",
+                "dwc:scientificNameAuthorship": "(Michx.) Straley"
+              }
+            ],
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "gbif:vernacularname": [
+              {
+                "coreid": "7884360",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "common sundrops"
+              },
+              {
+                "coreid": "7884360",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "gullnattljus"
+              },
+              {
+                "coreid": "7884360",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "narrowleaf evening primrose"
+              },
+              {
+                "coreid": "7884360",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "narrow-leaf evening-primrose"
+              },
+              {
+                "coreid": "7884360",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "narrowleaf evening-primrose"
+              },
+              {
+                "coreid": "7884360",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "narrow-leaved evening primrose"
+              },
+              {
+                "coreid": "7884360",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "narrow-leaved sundrops"
+              },
+              {
+                "coreid": "7884360",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "onagre frutescente"
+              },
+              {
+                "coreid": "7884360",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "shrubby evening primrose"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "sonnentropfen-nachtkerze",
+                "coreid": "7884360",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "7884360",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "southern sundrops"
+              },
+              {
+                "coreid": "7884360",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "southern sundrops"
+              },
+              {
+                "coreid": "7884360",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sundrops"
+              },
+              {
+                "coreid": "7884360",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "yellow sundrops"
+              }
+            ],
+            "dwc:month": "9",
+            "flag_dwc_class_replaced": true,
+            "gbif:reference": [
+              {
+                "coreid": "3188799",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "flag_dwc_continent_added": true,
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "flag_taxon_match_failed": true,
+            "dcterms:modified": "2015-08-12 11:04:07",
+            "dwc:scientificName": "Oenothera fruticosa ssp. glauca",
+            "dwc:day": "9",
+            "dwc:year": "1862"
+          },
+          "data": {
+            "dwc:startDayOfYear": "252",
+            "dwc:specificEpithet": "fruticosa",
+            "dwc:kingdom": "Plantae",
+            "dwc:recordedBy": "D. C. Eaton",
+            "dwc:order": "Myrtales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807147",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:occurrenceID": "urn:uuid:95f58b12-944d-46eb-90d9-6b864f7999f5",
+            "dwc:scientificNameAuthorship": "(Michx.) Straley",
+            "id": "807147",
+            "symbiota:recordEnteredBy": "Bob Swerling",
+            "dwc:stateProvince": "New Jersey",
+            "dwc:eventDate": "1862-09-09",
+            "dwc:collectionID": "urn:lsid:biocol.org:col:14791",
+            "dwc:country": "United States of America",
+            "idigbio:recordId": "urn:uuid:8d9b91f1-405f-4e90-8292-8329e7eac9c3",
+            "dwc:collectionCode": "YU",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Oenothera",
+            "dwc:family": "Onagraceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:infraspecificEpithet": "glauca",
+            "dwc:phylum": "Charophyta",
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "dwc:taxonRank": "ssp.",
+            "dwc:class": "Equisetopsida",
+            "dwc:catalogNumber": "YU.075139",
+            "dwc:Identification": [
+              {
+                "coreid": "807147",
+                "dwc:identificationRemarks": "0",
+                "idigbio:recordId": "urn:uuid:7be182d1-08a7-4d67-8974-38f2a827bcb9",
+                "dwc:scientificName": "Oenothera fruticosa subspecies glauca (Michx.) Straley",
+                "dwc:scientificNameAuthorship": "(Michx.) Straley"
+              }
+            ],
+            "dwc:month": "9",
+            "dcterms:modified": "2015-08-12 11:04:07",
+            "dwc:scientificName": "Oenothera fruticosa ssp. glauca",
+            "dwc:day": "9",
+            "dwc:year": "1862"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:95f58b12-944d-46eb-90d9-6b864f7999f5",
+          "country": "united states",
+          "dqs": 0.17391304347826086,
+          "infraspecificepithet": "glauca",
+          "canonicalname": "oenothera fruticosa",
+          "eventdate": "1862-09-09",
+          "flags": [
+            "dwc_country_replaced",
+            "gbif_reference_added",
+            "dwc_taxonrank_replaced",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "gbif_taxon_corrected",
+            "dwc_scientificnameauthorship_replaced",
+            "dwc_parentnameusageid_added",
+            "dwc_phylum_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "dwc_multimedia_added",
+            "gbif_vernacularname_added",
+            "gbif_canonicalname_added",
+            "dwc_class_replaced",
+            "dwc_continent_added",
+            "taxon_match_failed"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "urn:uuid:8d9b91f1-405f-4e90-8292-8329e7eac9c3",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\urn:uuid:95f58b12-944d-46eb-90d9-6b864f7999f5",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\807147"
+          ],
+          "genus": "oenothera",
+          "order": "myrtales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "98555225-1646-4104-91e0-d687449b20f5",
+        "_score": 1,
+        "_source": {
+          "family": "onagraceae",
+          "recordset": "76fd34da-4892-4821-858d-98fe9e28ba8b",
+          "stateprovince": "georgia",
+          "institutioncode": "vsc",
+          "county": "thomas county",
+          "phylum": "tracheophyta",
+          "catalognumber": "vsc0031938",
+          "startdayofyear": 242,
+          "taxonrank": "species",
+          "specificepithet": "decurrens",
+          "continent": "north america",
+          "uuid": "98555225-1646-4104-91e0-d687449b20f5",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "wayne r. faircloth",
+          "commonnames": [
+            "wingleaf primrose-willow"
+          ],
+          "mediarecords": [
+            "5145968a-feed-451b-b6af-34ec1583a4f0"
+          ],
+          "datemodified": "2015-03-10T17:59:41.052000+00:00",
+          "datecollected": "1965-08-30T00:00:00+00:00",
+          "etag": "c952b6ce3b053e41fd5fd6a42bd20173cac23a07",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "commonname": "wingleaf primrose-willow",
+          "taxonid": "5421002",
+          "scientificname": "ludwigia decurrens",
+          "indexData": {
+            "dwc:specificEpithet": "decurrens",
+            "idigbio:dateModified": "2015-03-10T17:59:41.052000",
+            "dwc:county": "Thomas County",
+            "dwc:recordedBy": "Wayne R. Faircloth",
+            "idigbio:uuid": "98555225-1646-4104-91e0-d687449b20f5",
+            "dwc:order": "Myrtales",
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "flag_gbif_reference_added": true,
+            "dcterms:accessRights": "CC BY",
+            "flag_dwc_taxonid_replaced": true,
+            "dwc:occurrenceID": "urn:uuid:520d4ed0-36fc-4a09-81a5-78166af93ae6",
+            "dwc:dateIdentified": "1999-01-01",
+            "flag_dwc_taxonrank_replaced": true,
+            "dcterms:language": "en",
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "dcterms:rightsHolder": "Valdosta State University Herbarium",
+            "dwc:taxonID": "5421002",
+            "idigbio:parent": "76fd34da-4892-4821-858d-98fe9e28ba8b",
+            "dwc:stateProvince": "Georgia",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:eventDate": "1965-08-30",
+            "flag_dwc_scientificnameauthorship_replaced": true,
+            "dwc:country": "United States",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "public domain mark 1.0",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:ludwigia_decurrens.jpg",
+                "coreid": "5421002",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/5/54/ludwigia_decurrens.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "english: ludwigia decurrens",
+                "dcterms:creator": "clarence a. rechenthin. courtesy of usda nrcs texas state office.",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "c952b6ce3b053e41fd5fd6a42bd20173cac23a07",
+            "dwc:collectionCode": "Herb",
+            "id": "urn:uuid:520d4ed0-36fc-4a09-81a5-78166af93ae6",
+            "dwc:identificationID": "60830",
+            "dwc:locationID": "urn:uuid:053929dc-91ab-48c5-91d3-eb8bf67383f3",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Ludwigia",
+            "dwc:continent": "North America",
+            "dwc:family": "Onagraceae",
+            "idigbio:isocountrycode": "usa",
+            "dwc:identifiedBy": "R. Carter",
+            "flag_dwc_datasetid_added": true,
+            "dwc:kingdom": "Plantae",
+            "idigbio:recordIds": [
+              "76fd34da-4892-4821-858d-98fe9e28ba8b\\urn:uuid:520d4ed0-36fc-4a09-81a5-78166af93ae6"
+            ],
+            "idigbio:siblings": {
+              "mediarecord": [
+                "5145968a-feed-451b-b6af-34ec1583a4f0"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:vernacularName": "wingleaf primrose-willow",
+            "gbif:canonicalname": "ludwigia decurrens",
+            "dwc:eventID": "50804",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "ludwigia",
+            "flag_dwc_multimedia_added": true,
+            "dwc:institutionID": "urn:lsid:biocol.org:col:15754",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "VSC",
+            "dwc:taxonRank": "species",
+            "dwc:parentnameusageid": "3189286",
+            "dwc:class": "Magnoliopsida",
+            "dwc:catalogNumber": "VSC0031938",
+            "flag_dwc_phylum_replaced": true,
+            "dcterms:type": "PhysicalObject",
+            "flag_gbif_canonicalname_added": true,
+            "dwc:scientificNameAuthorship": "walt.",
+            "dwc:higherGeographyID": "25767",
+            "dcterms:rights": "http://creativecommons.org/licenses/by/4.0/",
+            "flag_dwc_parentnameusageid_added": true,
+            "dcterms:modified": "2013-11-08 13:02:51.0",
+            "dwc:scientificName": "Ludwigia decurrens",
+            "gbif:reference": [
+              {
+                "coreid": "5421002",
+                "dcterms:source": "brazilian flora 2020 project - projeto flora do brasil 2020",
+                "dcterms:bibliographiccitation": "flora brasiliensis,vol.13, part. 2, tab. 31:p13p2n0031;vol.13, part. 2,"
+              },
+              {
+                "coreid": "5421002",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "walt. (1788) in: fl. carol. 89"
+              }
+            ],
+            "gbif:vernacularname": [
+              {
+                "coreid": "5421002",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "winged water-primrose"
+              },
+              {
+                "coreid": "5421002",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "wingleaf primrose-willow"
+              },
+              {
+                "coreid": "5421002",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "wingleaf primrose-willow"
+              },
+              {
+                "coreid": "5421002",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "wingleaf waterprimrose"
+              }
+            ]
+          },
+          "data": {
+            "dwc:specificEpithet": "decurrens",
+            "dwc:county": "Thomas County",
+            "dwc:recordedBy": "Wayne R. Faircloth",
+            "dwc:order": "Myrtales",
+            "dcterms:accessRights": "CC BY",
+            "dwc:occurrenceID": "urn:uuid:520d4ed0-36fc-4a09-81a5-78166af93ae6",
+            "dwc:dateIdentified": "1999-01-01",
+            "dcterms:language": "en",
+            "id": "urn:uuid:520d4ed0-36fc-4a09-81a5-78166af93ae6",
+            "dwc:taxonID": "18905",
+            "dwc:stateProvince": "Georgia",
+            "dwc:eventDate": "1965-08-30",
+            "dwc:identificationID": "60830",
+            "dwc:country": "United States",
+            "dwc:collectionCode": "Herb",
+            "dcterms:rightsHolder": "Valdosta State University Herbarium",
+            "dwc:kingdom": "Plantae",
+            "dwc:locationID": "urn:uuid:053929dc-91ab-48c5-91d3-eb8bf67383f3",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Ludwigia",
+            "dwc:continent": "North America",
+            "dwc:family": "Onagraceae",
+            "dwc:identifiedBy": "R. Carter",
+            "dwc:vernacularName": "wingleaf primrose-willow",
+            "dwc:eventID": "50804",
+            "dwc:phylum": "Magnoliophyta",
+            "dwc:institutionID": "urn:lsid:biocol.org:col:15754",
+            "dwc:institutionCode": "VSC",
+            "dwc:taxonRank": "Species",
+            "dwc:class": "Magnoliopsida",
+            "dwc:catalogNumber": "VSC0031938",
+            "dcterms:type": "PhysicalObject",
+            "dwc:scientificNameAuthorship": "Walt.",
+            "dwc:higherGeographyID": "25767",
+            "dcterms:rights": "http://creativecommons.org/licenses/by/4.0/",
+            "dcterms:modified": "2013-11-08 13:02:51.0",
+            "dwc:scientificName": "Ludwigia decurrens"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:520d4ed0-36fc-4a09-81a5-78166af93ae6",
+          "institutionid": "urn:lsid:biocol.org:col:15754",
+          "country": "united states",
+          "dqs": 0.2463768115942029,
+          "collectioncode": "herb",
+          "canonicalname": "ludwigia decurrens",
+          "eventdate": "1965-08-30",
+          "flags": [
+            "gbif_reference_added",
+            "dwc_taxonid_replaced",
+            "dwc_taxonrank_replaced",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "gbif_taxon_corrected",
+            "dwc_scientificnameauthorship_replaced",
+            "dwc_datasetid_added",
+            "idigbio_isocountrycode_added",
+            "dwc_multimedia_added",
+            "gbif_vernacularname_added",
+            "dwc_phylum_replaced",
+            "gbif_canonicalname_added",
+            "dwc_parentnameusageid_added"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "76fd34da-4892-4821-858d-98fe9e28ba8b\\urn:uuid:520d4ed0-36fc-4a09-81a5-78166af93ae6"
+          ],
+          "genus": "ludwigia",
+          "order": "myrtales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9888e17c-d100-49d3-8942-ac063b4112c0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lat": 25.77527,
+            "lon": -80.20972
+          },
+          "family": "myrtaceae",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.37681159420289856,
+          "stateprovince": "florida",
+          "municipality": "miami",
+          "county": "miami-dade county",
+          "catalognumber": "conn00127238",
+          "startdayofyear": 301,
+          "specificepithet": "garberi",
+          "continent": "north america",
+          "uuid": "9888e17c-d100-49d3-8942-ac063b4112c0",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "\"carter, j.j.; small, j.k.\"",
+          "institutioncode": "uconn",
+          "mediarecords": [
+            "53096349-eb00-40e5-9cea-a8fb13158501"
+          ],
+          "datecollected": "2003-10-28T00:00:00+00:00",
+          "etag": "d6edb8084c13205103606216159d775e97ee6d68",
+          "hasMedia": true,
+          "minelevation": 2,
+          "hasImage": true,
+          "kingdom": "dicotyledonae",
+          "maxelevation": 2,
+          "highertaxon": "plantae; dicotyledonae; myrtales; myrtaceae",
+          "scientificname": "eugenia garberi sarq.",
+          "indexData": {
+            "dwc:specificEpithet": "garberi",
+            "dwc:countryCode": "US",
+            "dwc:county": "Miami-Dade County",
+            "dwc:recordedBy": "\"Carter, J.J.; Small, J.K.\"",
+            "idigbio:uuid": "9888e17c-d100-49d3-8942-ac063b4112c0",
+            "dwc:locationAccordingTo": "seconds added from gazetteer",
+            "dwc:order": "Myrtales",
+            "dwc:habitat": "In hammocks.",
+            "idigbio:isocountrycode": "usa",
+            "dwc:locality": "Miami",
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00127238"
+            ],
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00127238",
+            "dwc:scientificName": "Eugenia garberi Sarq.",
+            "dwc:verbatimElevation": "7 FT",
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dwc:stateProvince": "Florida",
+            "dwc:eventDate": "2003-10-28",
+            "dwc:country": "united states",
+            "idigbio:etag": "d6edb8084c13205103606216159d775e97ee6d68",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "25°46' 31\" N",
+            "dwc:kingdom": "Dicotyledonae",
+            "dwc:decimalLatitude": "25.77527",
+            "dwc:maximumElevationInMeters": "2",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:genus": "Eugenia",
+            "dwc:continent": "north america",
+            "dwc:family": "Myrtaceae",
+            "flag_dwc_continent_added": true,
+            "flag_dwc_country_replaced": true,
+            "dwc:municipality": "Miami",
+            "dwc:previousIdentifications": "Eugenia garberi Sarq.",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "53096349-eb00-40e5-9cea-a8fb13158501"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "idigbio:dateModified": "2014-09-12T19:41:55.414000",
+            "dwc:georeferenceSources": "no date. USGS Geographic Names Information System (GNIS). U. S. Geological Survey.",
+            "dwc:institutionCode": "UConn",
+            "dwc:reproductiveCondition": "fruiting",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Myrtales; Myrtaceae",
+            "dwc:catalogNumber": "CONN00127238",
+            "dwc:higherGeography": "USA; Florida; Miami-Dade County; Miami",
+            "dwc:month": "10",
+            "dwc:decimalLongitude": "-80.20972",
+            "dwc:verbatimLongitude": "80°12' 35\" W",
+            "dwc:verbatimEventDate": "28-Oct-03",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "flag_taxon_match_failed": true,
+            "dwc:minimumElevationInMeters": "2",
+            "dcterms:modified": "2012-03-01T00:00-0500",
+            "dwc:coordinateUncertaintyInMeters": "5000",
+            "dwc:day": "28",
+            "dwc:datasetID": "137124",
+            "dwc:year": "1903"
+          },
+          "coordinateuncertainty": 5000,
+          "data": {
+            "dwc:specificEpithet": "garberi",
+            "dwc:countryCode": "US",
+            "dwc:county": "Miami-Dade County",
+            "dwc:recordedBy": "\"Carter, J.J.; Small, J.K.\"",
+            "dwc:georeferenceSources": "no date. USGS Geographic Names Information System (GNIS). U. S. Geological Survey.",
+            "dwc:order": "Myrtales",
+            "dwc:habitat": "In hammocks.",
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00127238",
+            "dwc:verbatimElevation": "7 FT",
+            "dwc:stateProvince": "Florida",
+            "dwc:eventDate": "2003-10-28",
+            "dwc:country": "USA",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "25°46' 31\" N",
+            "dwc:kingdom": "Dicotyledonae",
+            "dwc:decimalLatitude": "25.77527",
+            "dwc:maximumElevationInMeters": "2",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:genus": "Eugenia",
+            "dwc:family": "Myrtaceae",
+            "dwc:coordinateUncertaintyInMeters": "5000",
+            "dwc:municipality": "Miami",
+            "dwc:previousIdentifications": "Eugenia garberi Sarq.",
+            "dwc:locationAccordingTo": "seconds added from gazetteer",
+            "dwc:locality": "Miami",
+            "dwc:institutionCode": "UConn",
+            "dwc:reproductiveCondition": "fruiting",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Myrtales; Myrtaceae",
+            "dwc:catalogNumber": "CONN00127238",
+            "dwc:higherGeography": "USA; Florida; Miami-Dade County; Miami",
+            "dwc:month": "10",
+            "dwc:decimalLongitude": "-80.20972",
+            "dwc:verbatimLongitude": "80°12' 35\" W",
+            "dwc:verbatimEventDate": "28-Oct-03",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "dwc:minimumElevationInMeters": "2",
+            "dcterms:modified": "2012-03-01T00:00-0500",
+            "dwc:scientificName": "Eugenia garberi Sarq.",
+            "dwc:day": "28",
+            "dwc:datasetID": "137124",
+            "dwc:year": "1903"
+          },
+          "datemodified": "2014-09-12T19:41:55.414000+00:00",
+          "occurrenceid": "urn:catalog:uconn:conn:conn00127238",
+          "country": "united states",
+          "locality": "miami",
+          "collectioncode": "conn",
+          "eventdate": "2003-10-28",
+          "flags": [
+            "geopoint_datum_missing",
+            "dwc_continent_added",
+            "dwc_country_replaced",
+            "idigbio_isocountrycode_added",
+            "taxon_match_failed"
+          ],
+          "verbatimeventdate": "28-oct-03",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00127238"
+          ],
+          "genus": "eugenia",
+          "order": "myrtales",
+          "datasetid": "137124"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a28aa867-64fa-4a6b-9f59-f0caf3826ef4",
+        "_score": 1,
+        "_source": {
+          "family": "lythraceae",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.2318840579710145,
+          "stateprovince": "connecticut",
+          "municipality": "suppressed",
+          "county": "new london",
+          "phylum": "tracheophyta",
+          "catalognumber": "conn00125092",
+          "startdayofyear": 224,
+          "taxonrank": "species",
+          "specificepithet": "ramosior",
+          "continent": "north america",
+          "uuid": "a28aa867-64fa-4a6b-9f59-f0caf3826ef4",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "k.p. jansson",
+          "institutioncode": "uconn",
+          "mediarecords": [
+            "40353e12-422d-41ed-a50c-184ec69d0392"
+          ],
+          "datemodified": "2014-09-12T19:32:37.640000+00:00",
+          "datecollected": "1938-08-12T00:00:00+00:00",
+          "etag": "decb79d7fd60a09c4c60b95b52337b27f9f420a1",
+          "hasMedia": true,
+          "minelevation": 47,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "maxelevation": 47,
+          "highertaxon": "plantae; dicotyledonae; myrtales; lythraceae",
+          "taxonid": "7727923",
+          "scientificname": "rotala ramosior (l.) koehne",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "dwc:specificEpithet": "ramosior",
+            "idigbio:dateModified": "2014-09-12T19:32:37.640000",
+            "dwc:countryCode": "US",
+            "dwc:county": "New London",
+            "dwc:recordedBy": "K.P. Jansson",
+            "idigbio:uuid": "a28aa867-64fa-4a6b-9f59-f0caf3826ef4",
+            "dwc:locationAccordingTo": "seconds added from gazetteer",
+            "dwc:order": "Myrtales",
+            "dwc:habitat": "muddy shore",
+            "flag_gbif_reference_added": true,
+            "idigbio:isocountrycode": "usa",
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00125092"
+            ],
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00125092",
+            "gbif:vernacularname": [
+              {
+                "coreid": "7727923",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "lowland rotala"
+              },
+              {
+                "coreid": "7727923",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "lowland rotala"
+              },
+              {
+                "coreid": "7727923",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "lowland rotala"
+              },
+              {
+                "coreid": "7727923",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "lowland toothcup"
+              },
+              {
+                "coreid": "7727923",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "lowland toothcup"
+              },
+              {
+                "coreid": "7727923",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "rotala"
+              },
+              {
+                "coreid": "7727923",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "rotala rameux"
+              },
+              {
+                "coreid": "7727923",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "toothcup"
+              },
+              {
+                "coreid": "7727923",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "yerba de cancer"
+              }
+            ],
+            "dwc:verbatimElevation": "157 FT",
+            "flag_dwc_kingdom_replaced": true,
+            "flag_gbif_genericname_added": true,
+            "flag_dwc_parentnameusageid_added": true,
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dwc:stateProvince": "Connecticut",
+            "flag_dwc_originalnameusageid_added": true,
+            "dwc:parentnameusageid": "3188668",
+            "dwc:eventDate": "1938-08-12",
+            "dwc:country": "united states",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "pd usda nrcs",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:rotala_ramosior_nrcs-1.jpg",
+                "coreid": "7727923",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/4/4f/rotala_ramosior_nrcs-1.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:created": "1989-01-01",
+                "dcterms:description": "english: rotala ramosior from robert h. mohlenbrock. usda scs. 1989. midwest wetland flora: field office illustrated guide to plant species. midwest national technical center, lincoln. courtesy of usda nrcs wetland science institute.",
+                "dcterms:creator": "robert h. mohlenbrock",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "decb79d7fd60a09c4c60b95b52337b27f9f420a1",
+            "dwc:collectionCode": "CONN",
+            "flag_dwc_multimedia_added": true,
+            "gbif:reference": [
+              {
+                "coreid": "7727923",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "koehne (1877) in: c.f.p. mart., fl. bras. 13(2): 194"
+              }
+            ],
+            "dwc:kingdom": "plantae",
+            "dwc:maximumElevationInMeters": "47",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Rotala",
+            "dwc:continent": "north america",
+            "dwc:family": "Lythraceae",
+            "flag_dwc_continent_added": true,
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_scientificnameauthorship_added": true,
+            "dwc:georeferenceSources": "no date. USGS Geographic Names Information System (GNIS). U. S. Geological Survey.",
+            "dwc:municipality": "SUPPRESSED",
+            "flag_dwc_taxonid_added": true,
+            "dwc:previousIdentifications": "Rotala ramosior (L.) Koehne",
+            "dwc:class": "magnoliopsida",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "40353e12-422d-41ed-a50c-184ec69d0392"
+              ]
+            },
+            "flag_dwc_class_added": true,
+            "flag_idigbio_isocountrycode_added": true,
+            "gbif:canonicalname": "rotala ramosior",
+            "dwc:scientificnameauthorship": "koehne (l.)",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_phylum_added": true,
+            "gbif:genericname": "rotala",
+            "dwc:locality": "SUPPRESSED",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "UConn",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:reproductiveCondition": "fruiting",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Myrtales; Lythraceae",
+            "dwc:catalogNumber": "CONN00125092",
+            "dwc:taxonid": "7727923",
+            "dwc:taxonrank": "species",
+            "dwc:higherGeography": "USA; Connecticut; New London; SUPPRESSED",
+            "dwc:month": "8",
+            "dwc:scientificName": "Rotala ramosior (L.) Koehne",
+            "dwc:verbatimEventDate": "12-Aug-38",
+            "dwc:originalnameusageid": "3988852",
+            "dwc:phylum": "tracheophyta",
+            "flag_dwc_taxonomicstatus_added": true,
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "flag_dwc_datasetid_replaced": true,
+            "flag_taxon_match_failed": true,
+            "dwc:minimumElevationInMeters": "47",
+            "dcterms:modified": "2014-04-17T00:00-0500",
+            "dwc:coordinateUncertaintyInMeters": "5000",
+            "dwc:day": "12",
+            "dwc:datasetID": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dwc:year": "1938"
+          },
+          "coordinateuncertainty": 5000,
+          "data": {
+            "dwc:specificEpithet": "ramosior",
+            "dwc:countryCode": "US",
+            "dwc:county": "New London",
+            "dwc:recordedBy": "K.P. Jansson",
+            "dwc:georeferenceSources": "no date. USGS Geographic Names Information System (GNIS). U. S. Geological Survey.",
+            "dwc:order": "Myrtales",
+            "dwc:habitat": "muddy shore",
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00125092",
+            "dwc:verbatimElevation": "157 FT",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1938-08-12",
+            "dwc:country": "USA",
+            "dwc:collectionCode": "CONN",
+            "dwc:kingdom": "Dicotyledonae",
+            "dwc:maximumElevationInMeters": "47",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:genus": "Rotala",
+            "dwc:family": "Lythraceae",
+            "dwc:municipality": "SUPPRESSED",
+            "dwc:previousIdentifications": "Rotala ramosior (L.) Koehne",
+            "dwc:locationAccordingTo": "seconds added from gazetteer",
+            "dwc:locality": "SUPPRESSED",
+            "dwc:institutionCode": "UConn",
+            "dwc:reproductiveCondition": "fruiting",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Myrtales; Lythraceae",
+            "dwc:catalogNumber": "CONN00125092",
+            "dwc:higherGeography": "USA; Connecticut; New London; SUPPRESSED",
+            "dwc:month": "8",
+            "dwc:coordinateUncertaintyInMeters": "5000",
+            "dwc:verbatimEventDate": "12-Aug-38",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "dwc:minimumElevationInMeters": "47",
+            "dcterms:modified": "2014-04-17T00:00-0500",
+            "dwc:scientificName": "Rotala ramosior (L.) Koehne",
+            "dwc:day": "12",
+            "dwc:datasetID": "132325",
+            "dwc:year": "1938"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:catalog:uconn:conn:conn00125092",
+          "country": "united states",
+          "locality": "suppressed",
+          "collectioncode": "conn",
+          "canonicalname": "rotala ramosior",
+          "eventdate": "1938-08-12",
+          "flags": [
+            "dwc_taxonrank_added",
+            "gbif_reference_added",
+            "dwc_kingdom_replaced",
+            "gbif_genericname_added",
+            "dwc_parentnameusageid_added",
+            "dwc_originalnameusageid_added",
+            "dwc_multimedia_added",
+            "dwc_continent_added",
+            "dwc_country_replaced",
+            "dwc_scientificnameauthorship_added",
+            "dwc_taxonid_added",
+            "dwc_class_added",
+            "idigbio_isocountrycode_added",
+            "gbif_canonicalname_added",
+            "dwc_phylum_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_taxonomicstatus_added",
+            "dwc_datasetid_replaced",
+            "taxon_match_failed"
+          ],
+          "verbatimeventdate": "12-aug-38",
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00125092"
+          ],
+          "genus": "rotala",
+          "order": "myrtales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "51e0c9f3-1b61-45f6-a537-39db94d2e60a",
+        "_score": 1,
+        "_source": {
+          "family": "melastomataceae",
+          "recordset": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+          "phylum": "tracheophyta",
+          "catalognumber": "p00245311",
+          "startdayofyear": 93,
+          "taxonrank": "species",
+          "specificepithet": "imbricata",
+          "verbatimlocality": "de biribiry à diamantina (minas)",
+          "uuid": "51e0c9f3-1b61-45f6-a537-39db94d2e60a",
+          "basisofrecord": "preservedspecimen",
+          "collector": "glaziou, a.",
+          "institutioncode": "mnhn",
+          "mediarecords": [
+            "fca4b77b-06cf-4968-95de-b44ba348bbd1",
+            "0c289a76-6137-46a3-99be-0bf090712522"
+          ],
+          "datemodified": "2021-04-19T22:06:14.550973+00:00",
+          "datecollected": "1892-04-02T00:00:00+00:00",
+          "etag": "433065942bb6f590478e479a7a333cc4fbe61865",
+          "flags": [
+            "dwc_taxonrank_added",
+            "gbif_reference_added",
+            "dwc_specificepithet_added",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_scientificnameauthorship_replaced",
+            "dwc_parentnameusageid_added",
+            "dwc_taxonid_added",
+            "gbif_canonicalname_added",
+            "dwc_phylum_added",
+            "gbif_taxon_corrected",
+            "dwc_order_added",
+            "dwc_class_added",
+            "dwc_kingdom_added"
+          ],
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "taxonid": "3867806",
+          "scientificname": "lavoisiera imbricata (thunb.) dc.",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "idigbio:dateModified": "2021-04-19T22:06:14.550973",
+            "dwc:countryCode": "br",
+            "dwc:kingdom": "plantae",
+            "dwc:recordedBy": "Glaziou, A.",
+            "idigbio:uuid": "51e0c9f3-1b61-45f6-a537-39db94d2e60a",
+            "dwc:fieldNumber": "19257",
+            "gbif:canonicalname": "lavoisiera imbricata",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "dc.",
+            "idigbio:recordIds": [
+              "616857b7-f952-44ef-9b6f-576dc1e65b51\\http://coldb.mnhn.fr/catalognumber/mnhn/p/p00245311"
+            ],
+            "dwc:occurrenceID": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00245311",
+            "flag_dwc_specificepithet_added": true,
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "id": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00245311",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dwc:eventDate": "1892-4-2",
+            "flag_dwc_scientificnameauthorship_replaced": true,
+            "dwc:country": "Brésil",
+            "idigbio:etag": "433065942bb6f590478e479a7a333cc4fbe61865",
+            "dwc:collectionCode": "P",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Lavoisiera",
+            "dwc:family": "Melastomataceae",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_taxonid_added": true,
+            "idigbio:siblings": {
+              "mediarecord": [
+                "fca4b77b-06cf-4968-95de-b44ba348bbd1",
+                "0c289a76-6137-46a3-99be-0bf090712522"
+              ]
+            },
+            "dwc:order": "myrtales",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_phylum_added": true,
+            "gbif:genericname": "lavoisiera",
+            "dwc:specificepithet": "imbricata",
+            "dwc:institutionCode": "MNHN",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3867023",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "P00245311",
+            "dwc:taxonid": "3867806",
+            "gbif:Identifier": [
+              {
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00245311",
+                "dcterms:identifier": "C7C5C4D4FAB54ED1AD768C820368B94A",
+                "dcterms:subject": "e-recolnat"
+              }
+            ],
+            "dwc:taxonrank": "species",
+            "dwc:Identification": [
+              {
+                "dwc:taxonID": "SONNERAT|49417",
+                "dwc:identificationRemarks": "Ok, A.B Martins & F. Almeda, 2003",
+                "dwc:specificEpithet": "imbricata",
+                "dwc:identificationID": "SONNERAT|273712",
+                "dwc:identificationVerificationStatus": "1",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00245311",
+                "dwc:scientificNameAuthorship": "(Thunb.) DC.",
+                "dwc:genus": "Lavoisiera",
+                "dwc:scientificName": "Lavoisiera imbricata (Thunb.) DC.",
+                "dwc:higherClassification": "Lavoisiera;Melastomataceae",
+                "dwc:family": "Melastomataceae"
+              }
+            ],
+            "dwc:month": "4",
+            "flag_dwc_order_added": true,
+            "dwc:verbatimLocality": "de Biribiry à Diamantina (Minas)",
+            "gbif:reference": [
+              {
+                "coreid": "3867806",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "dc. (1828) in: prod. 3: 103"
+              },
+              {
+                "coreid": "3867806",
+                "dcterms:source": "brazilian flora 2020 project - projeto flora do brasil 2020",
+                "dcterms:bibliographiccitation": "diss. plant. bras. decas prima,1: 10, t. 2, fig. 2,1817"
+              },
+              {
+                "coreid": "3867806",
+                "dcterms:source": "brazilian flora 2020 project - projeto flora do brasil 2020",
+                "dcterms:bibliographiccitation": "prodr.,3: 103,1828"
+              }
+            ],
+            "dwc:phylum": "tracheophyta",
+            "dwc:preparations": "hb",
+            "flag_dwc_class_added": true,
+            "dcterms:modified": "2015-01-08 15:54:38.0",
+            "dwc:scientificName": "Lavoisiera imbricata (Thunb.) DC.",
+            "dwc:day": "2",
+            "flag_dwc_kingdom_added": true,
+            "dwc:year": "1892"
+          },
+          "data": {
+            "dwc:countryCode": "br",
+            "dwc:recordedBy": "Glaziou, A.",
+            "dwc:fieldNumber": "19257",
+            "dwc:scientificNameAuthorship": "(Thunb.) DC.",
+            "dwc:occurrenceID": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00245311",
+            "id": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00245311",
+            "dwc:eventDate": "1892-4-2",
+            "dwc:country": "Brésil",
+            "dwc:collectionCode": "P",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Lavoisiera",
+            "dwc:preparations": "hb",
+            "dwc:institutionCode": "MNHN",
+            "dwc:catalogNumber": "P00245311",
+            "gbif:Identifier": [
+              {
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00245311",
+                "dcterms:identifier": "C7C5C4D4FAB54ED1AD768C820368B94A",
+                "dcterms:subject": "e-recolnat"
+              }
+            ],
+            "dwc:Identification": [
+              {
+                "dwc:taxonID": "SONNERAT|49417",
+                "dwc:identificationRemarks": "Ok, A.B Martins & F. Almeda, 2003",
+                "dwc:specificEpithet": "imbricata",
+                "dwc:scientificNameAuthorship": "(Thunb.) DC.",
+                "dwc:identificationVerificationStatus": "1",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00245311",
+                "dwc:identificationID": "SONNERAT|273712",
+                "dwc:genus": "Lavoisiera",
+                "dwc:scientificName": "Lavoisiera imbricata (Thunb.) DC.",
+                "dwc:higherClassification": "Lavoisiera;Melastomataceae",
+                "dwc:family": "Melastomataceae"
+              }
+            ],
+            "dwc:month": "4",
+            "dwc:verbatimLocality": "de Biribiry à Diamantina (Minas)",
+            "dwc:family": "Melastomataceae",
+            "dcterms:modified": "2015-01-08 15:54:38.0",
+            "dwc:scientificName": "Lavoisiera imbricata (Thunb.) DC.",
+            "dwc:day": "2",
+            "dwc:year": "1892"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00245311",
+          "country": "brésil",
+          "dqs": 0.17391304347826086,
+          "collectioncode": "p",
+          "canonicalname": "lavoisiera imbricata",
+          "eventdate": "1892-4-2",
+          "fieldnumber": "19257",
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "616857b7-f952-44ef-9b6f-576dc1e65b51\\http://coldb.mnhn.fr/catalognumber/mnhn/p/p00245311"
+          ],
+          "genus": "lavoisiera",
+          "order": "myrtales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "993f6141-fe53-454d-b735-8b4d80e6d43d",
+        "_score": 1,
+        "_source": {
+          "family": "onagraceae",
+          "recordset": "76fd34da-4892-4821-858d-98fe9e28ba8b",
+          "stateprovince": "oklahoma",
+          "institutioncode": "vsc",
+          "county": "woods county",
+          "phylum": "tracheophyta",
+          "catalognumber": "vsc0031845",
+          "startdayofyear": 149,
+          "taxonrank": "genus",
+          "specificepithet": "longiflora",
+          "continent": "north america",
+          "uuid": "993f6141-fe53-454d-b735-8b4d80e6d43d",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "p. nighswonger",
+          "commonnames": [
+            "longflower beeblossom"
+          ],
+          "mediarecords": [
+            "9c8d66c6-cee7-4dd4-928b-0afcfee0b817"
+          ],
+          "datemodified": "2015-03-10T17:33:45.181000+00:00",
+          "datecollected": "1972-05-28T00:00:00+00:00",
+          "etag": "fa827383c26ee1d8120ecf98a0c26523bcafb6ce",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "commonname": "longflower beeblossom",
+          "taxonid": "9191626",
+          "scientificname": "gaura longiflora",
+          "indexData": {
+            "dwc:specificEpithet": "longiflora",
+            "idigbio:dateModified": "2015-03-10T17:33:45.181000",
+            "dwc:county": "Woods County",
+            "dwc:recordedBy": "P. Nighswonger",
+            "idigbio:uuid": "993f6141-fe53-454d-b735-8b4d80e6d43d",
+            "dwc:order": "Myrtales",
+            "dwc:datasetid": "a6c6cead-b5ce-4a4e-8cf5-1542ba708dec",
+            "dcterms:accessRights": "CC BY",
+            "flag_dwc_taxonid_replaced": true,
+            "dwc:occurrenceID": "urn:uuid:fd6a166b-5093-4712-8bff-0b335a94aa23",
+            "flag_dwc_taxonrank_replaced": true,
+            "dcterms:language": "en",
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "dcterms:rightsHolder": "Valdosta State University Herbarium",
+            "dwc:taxonID": "9191626",
+            "idigbio:parent": "76fd34da-4892-4821-858d-98fe9e28ba8b",
+            "dwc:stateProvince": "Oklahoma",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:eventDate": "1972-05-28",
+            "dwc:country": "United States",
+            "idigbio:etag": "fa827383c26ee1d8120ecf98a0c26523bcafb6ce",
+            "dwc:collectionCode": "Herb",
+            "id": "urn:uuid:fd6a166b-5093-4712-8bff-0b335a94aa23",
+            "dwc:identificationID": "60737",
+            "dwc:locationID": "urn:uuid:a98b01b3-3f7f-4dc1-90b6-75b63567d9fd",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Gaura",
+            "dwc:continent": "North America",
+            "dwc:family": "Onagraceae",
+            "idigbio:isocountrycode": "usa",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_datasetid_added": true,
+            "dwc:kingdom": "Plantae",
+            "idigbio:recordIds": [
+              "76fd34da-4892-4821-858d-98fe9e28ba8b\\urn:uuid:fd6a166b-5093-4712-8bff-0b335a94aa23"
+            ],
+            "idigbio:siblings": {
+              "mediarecord": [
+                "9c8d66c6-cee7-4dd4-928b-0afcfee0b817"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:vernacularName": "longflower beeblossom",
+            "gbif:canonicalname": "gaura",
+            "dwc:eventID": "50715",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "gaura",
+            "dwc:institutionID": "urn:lsid:biocol.org:col:15754",
+            "dwc:institutionCode": "VSC",
+            "dwc:taxonRank": "genus",
+            "dwc:parentnameusageid": "2430",
+            "dwc:class": "Magnoliopsida",
+            "dwc:catalogNumber": "VSC0031845",
+            "flag_dwc_phylum_replaced": true,
+            "dcterms:type": "PhysicalObject",
+            "flag_gbif_canonicalname_added": true,
+            "dwc:scientificNameAuthorship": "Spach",
+            "dwc:higherGeographyID": "27115",
+            "dcterms:rights": "http://creativecommons.org/licenses/by/4.0/",
+            "flag_taxon_match_failed": true,
+            "dcterms:modified": "2013-11-08 11:28:10.0",
+            "dwc:scientificName": "Gaura longiflora"
+          },
+          "data": {
+            "dwc:specificEpithet": "longiflora",
+            "dwc:county": "Woods County",
+            "dwc:recordedBy": "P. Nighswonger",
+            "dwc:order": "Myrtales",
+            "dcterms:accessRights": "CC BY",
+            "dwc:occurrenceID": "urn:uuid:fd6a166b-5093-4712-8bff-0b335a94aa23",
+            "dcterms:language": "en",
+            "id": "urn:uuid:fd6a166b-5093-4712-8bff-0b335a94aa23",
+            "dwc:taxonID": "18420",
+            "dwc:stateProvince": "Oklahoma",
+            "dwc:eventDate": "1972-05-28",
+            "dwc:identificationID": "60737",
+            "dwc:country": "United States",
+            "dwc:collectionCode": "Herb",
+            "dcterms:rightsHolder": "Valdosta State University Herbarium",
+            "dwc:kingdom": "Plantae",
+            "dwc:locationID": "urn:uuid:a98b01b3-3f7f-4dc1-90b6-75b63567d9fd",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Gaura",
+            "dwc:continent": "North America",
+            "dwc:family": "Onagraceae",
+            "dwc:vernacularName": "longflower beeblossom",
+            "dwc:eventID": "50715",
+            "dwc:phylum": "Magnoliophyta",
+            "dwc:institutionID": "urn:lsid:biocol.org:col:15754",
+            "dwc:institutionCode": "VSC",
+            "dwc:taxonRank": "Species",
+            "dwc:class": "Magnoliopsida",
+            "dwc:catalogNumber": "VSC0031845",
+            "dcterms:type": "PhysicalObject",
+            "dwc:scientificNameAuthorship": "Spach",
+            "dwc:higherGeographyID": "27115",
+            "dcterms:rights": "http://creativecommons.org/licenses/by/4.0/",
+            "dcterms:modified": "2013-11-08 11:28:10.0",
+            "dwc:scientificName": "Gaura longiflora"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:fd6a166b-5093-4712-8bff-0b335a94aa23",
+          "institutionid": "urn:lsid:biocol.org:col:15754",
+          "country": "united states",
+          "dqs": 0.2898550724637681,
+          "collectioncode": "herb",
+          "canonicalname": "gaura",
+          "eventdate": "1972-05-28",
+          "flags": [
+            "dwc_taxonid_replaced",
+            "dwc_taxonrank_replaced",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "gbif_taxon_corrected",
+            "dwc_parentnameusageid_added",
+            "dwc_datasetid_added",
+            "idigbio_isocountrycode_added",
+            "dwc_phylum_replaced",
+            "gbif_canonicalname_added",
+            "taxon_match_failed"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "76fd34da-4892-4821-858d-98fe9e28ba8b\\urn:uuid:fd6a166b-5093-4712-8bff-0b335a94aa23"
+          ],
+          "genus": "gaura",
+          "order": "myrtales",
+          "datasetid": "a6c6cead-b5ce-4a4e-8cf5-1542ba708dec"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "99956371-4209-4c03-b002-71393948f859",
+        "_score": 1,
+        "_source": {
+          "family": "lythraceae",
+          "recordset": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "dqs": 0.18840579710144928,
+          "stateprovince": "connecticut",
+          "municipality": "suffield",
+          "county": "hartford county",
+          "phylum": "tracheophyta",
+          "catalognumber": "yu.056580",
+          "taxonrank": "species",
+          "specificepithet": "verticillatus",
+          "continent": "north america",
+          "uuid": "99956371-4209-4c03-b002-71393948f859",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "alexander william evans",
+          "institutioncode": "yale peabody museum of natural history",
+          "mediarecords": [
+            "588b34b9-8a1c-4cf3-8be5-dfec232f5f39"
+          ],
+          "datemodified": "2016-01-27T21:25:22.884015+00:00",
+          "etag": "35d595bf0d18b9e520fa634fe85ee792096d659a",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "collectionid": "urn:lsid:biocol.org:col:14791",
+          "taxonid": "5420916",
+          "scientificname": "decodon verticillatus",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "dwc:specificEpithet": "verticillatus",
+            "idigbio:dateModified": "2016-01-27T21:25:22.884015",
+            "dwc:county": "Hartford County",
+            "dwc:recordedBy": "Alexander William Evans",
+            "idigbio:uuid": "99956371-4209-4c03-b002-71393948f859",
+            "dwc:order": "Myrtales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=225110",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "ell. (l.)",
+            "idigbio:recordIds": [
+              "urn:uuid:3cb1e17a-6c0c-41bf-b3ef-f5f451ceaa33",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\urn:uuid:75ec3fe3-d886-4f2e-bceb-390b436d3072",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\225110"
+            ],
+            "dwc:occurrenceID": "urn:uuid:75ec3fe3-d886-4f2e-bceb-390b436d3072",
+            "flag_gbif_canonicalname_added": true,
+            "gbif:vernacularname": [
+              {
+                "coreid": "5420916",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "décadent verticillé"
+              },
+              {
+                "coreid": "5420916",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "décodon verticillé"
+              },
+              {
+                "coreid": "5420916",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "hairy swamp loosestrife"
+              },
+              {
+                "coreid": "5420916",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "quirlblättriger wasserweiderich"
+              },
+              {
+                "coreid": "5420916",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "swamp loosestrife"
+              },
+              {
+                "coreid": "5420916",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "swamp loosestrife"
+              },
+              {
+                "coreid": "5420916",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "swamp-loosestrife"
+              },
+              {
+                "coreid": "5420916",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "swamp loosestrife"
+              },
+              {
+                "coreid": "5420916",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "swamp willowherb"
+              },
+              {
+                "coreid": "5420916",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "water oleander"
+              },
+              {
+                "coreid": "5420916",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "water-willow"
+              },
+              {
+                "coreid": "5420916",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "water-willow"
+              },
+              {
+                "coreid": "5420916",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "whorled loosestrife"
+              }
+            ],
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+            "dwc:stateProvince": "Connecticut",
+            "flag_dwc_originalnameusageid_added": true,
+            "flag_dwc_scientificnameauthorship_replaced": true,
+            "dwc:collectionID": "urn:lsid:biocol.org:col:14791",
+            "dwc:country": "united states",
+            "idigbio:recordId": "urn:uuid:3cb1e17a-6c0c-41bf-b3ef-f5f451ceaa33",
+            "idigbio:etag": "35d595bf0d18b9e520fa634fe85ee792096d659a",
+            "dwc:collectionCode": "YU",
+            "id": "225110",
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "41.9945",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Decodon",
+            "dwc:continent": "north america",
+            "dwc:family": "Lythraceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_phylum_replaced": true,
+            "dwc:municipality": "Suffield",
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "usa",
+            "dwc:geodeticDatum": "WGS84",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "588b34b9-8a1c-4cf3-8be5-dfec232f5f39"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "gbif:canonicalname": "decodon verticillatus",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "decodon",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3188728",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "YU.056580",
+            "dwc:taxonid": "5420916",
+            "dwc:taxonrank": "species",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:decimalLongitude": "-72.6788",
+            "dwc:scientificName": "Decodon verticillatus",
+            "dwc:month": "0",
+            "flag_dwc_class_replaced": true,
+            "flag_dwc_continent_added": true,
+            "dwc:originalnameusageid": "3989492",
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dcterms:modified": "2011-07-28 00:00:00",
+            "dwc:coordinateUncertaintyInMeters": "8341",
+            "gbif:reference": [
+              {
+                "coreid": "5420916",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "ell.: in: sketch, 1: 543"
+              }
+            ],
+            "dwc:year": "0"
+          },
+          "coordinateuncertainty": 8341,
+          "data": {
+            "dwc:specificEpithet": "verticillatus",
+            "dwc:county": "Hartford County",
+            "dwc:recordedBy": "Alexander William Evans",
+            "dwc:order": "Myrtales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=225110",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:occurrenceID": "urn:uuid:75ec3fe3-d886-4f2e-bceb-390b436d3072",
+            "dwc:scientificNameAuthorship": "(L.) Elliot",
+            "id": "225110",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:collectionID": "urn:lsid:biocol.org:col:14791",
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "dwc:country": "USA",
+            "idigbio:recordId": "urn:uuid:3cb1e17a-6c0c-41bf-b3ef-f5f451ceaa33",
+            "dwc:collectionCode": "YU",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "41.9945",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Decodon",
+            "dwc:family": "Lythraceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:municipality": "Suffield",
+            "dwc:phylum": "Charophyta",
+            "dwc:geodeticDatum": "WGS84",
+            "dwc:class": "Equisetopsida",
+            "dwc:catalogNumber": "YU.056580",
+            "dwc:month": "0",
+            "dwc:decimalLongitude": "-72.6788",
+            "dwc:coordinateUncertaintyInMeters": "8341",
+            "dcterms:modified": "2011-07-28 00:00:00",
+            "dwc:scientificName": "Decodon verticillatus",
+            "dwc:year": "0"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:75ec3fe3-d886-4f2e-bceb-390b436d3072",
+          "country": "united states",
+          "geopoint": {
+            "lat": 41.9945,
+            "lon": -72.6788
+          },
+          "collectioncode": "yu",
+          "canonicalname": "decodon verticillatus",
+          "flags": [
+            "dwc_taxonrank_added",
+            "gbif_reference_added",
+            "gbif_canonicalname_added",
+            "dwc_country_replaced",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_originalnameusageid_added",
+            "dwc_scientificnameauthorship_replaced",
+            "dwc_parentnameusageid_added",
+            "dwc_phylum_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_class_replaced",
+            "dwc_continent_added"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "urn:uuid:3cb1e17a-6c0c-41bf-b3ef-f5f451ceaa33",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\urn:uuid:75ec3fe3-d886-4f2e-bceb-390b436d3072",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\225110"
+          ],
+          "genus": "decodon",
+          "order": "myrtales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "top_genus": {
+      "doc_count_error_upper_bound": 1929,
+      "sum_other_doc_count": 918024,
+      "buckets": [
+        {
+          "key": "miconia",
+          "doc_count": 150096
+        },
+        {
+          "key": "epilobium",
+          "doc_count": 139673
+        },
+        {
+          "key": "oenothera",
+          "doc_count": 115160
+        },
+        {
+          "key": "eugenia",
+          "doc_count": 99006
+        },
+        {
+          "key": "ludwigia",
+          "doc_count": 88998
+        },
+        {
+          "key": "myrcia",
+          "doc_count": 69141
+        },
+        {
+          "key": "cuphea",
+          "doc_count": 63548
+        },
+        {
+          "key": "tibouchina",
+          "doc_count": 51404
+        },
+        {
+          "key": "eucalyptus",
+          "doc_count": 50611
+        },
+        {
+          "key": "clidemia",
+          "doc_count": 40477
+        }
+      ]
+    }
+  }
+}

--- a/__tests__/mock/search-91560b12812090cdb7d15205814b7471.json
+++ b/__tests__/mock/search-91560b12812090cdb7d15205814b7471.json
@@ -1,0 +1,1197 @@
+{
+  "timed_out": false,
+  "_shards": {
+    "total": 48,
+    "successful": 48,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1955,
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "84006c59-fead-4b84-b3b5-cedf28f67ea9",
+        "_score": 1,
+        "_source": {
+          "publisher": "089a51fa-5f81-48e7-a1b7-9bc539555f29",
+          "uuid": "84006c59-fead-4b84-b3b5-cedf28f67ea9",
+          "dqs": -1,
+          "archivelink": "http://xbiod.osu.edu/ipt/archive.do?r=ucfc",
+          "rights": "no license, assume public domain",
+          "contacts": [
+            {
+              "first_name": "Hojun",
+              "last_name": "Song",
+              "role": "Curator, Asst. Professor",
+              "email": "song@ucf.edu"
+            },
+            {
+              "first_name": "Norman",
+              "last_name": "Johnson",
+              "role": "Director, Professor",
+              "email": "johnson.2@osu.edu"
+            },
+            {
+              "first_name": "Sandor",
+              "last_name": "Kelly",
+              "role": "Collection Manager",
+              "email": "sandor.kelly@ucf.edu"
+            },
+            {
+              "first_name": "Hojun",
+              "last_name": "Song",
+              "role": "Curator, Asst. Professor",
+              "email": "song@ucf.edu"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "089a51fa-5f81-48e7-a1b7-9bc539555f29",
+            "eml_link": "http://xbiod.osu.edu/ipt/eml.do?r=ucfc",
+            "contacts": [
+              {
+                "first_name": "Hojun",
+                "last_name": "Song",
+                "role": "Curator, Asst. Professor",
+                "email": "song@ucf.edu"
+              },
+              {
+                "first_name": "Norman",
+                "last_name": "Johnson",
+                "role": "Director, Professor",
+                "email": "johnson.2@osu.edu"
+              },
+              {
+                "first_name": "Sandor",
+                "last_name": "Kelly",
+                "role": "Collection Manager",
+                "email": "sandor.kelly@ucf.edu"
+              },
+              {
+                "first_name": "Hojun",
+                "last_name": "Song",
+                "role": "Curator, Asst. Professor",
+                "email": "song@ucf.edu"
+              }
+            ],
+            "collection_name": "Stuart M. Fullerton Collection of Arthropods (UCFC), University of Central Florida",
+            "idigbio:uuid": "84006c59-fead-4b84-b3b5-cedf28f67ea9",
+            "idigbio:etag": "41e6af7fc888b9ef73a8e01384ad73abed6f84a8",
+            "update": "2018-08-29T08:25:24",
+            "ingest": true,
+            "institution_web_address": "http://bugcloset.cos.ucf.edu",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "262f8270-f9c2-4bc6-a562-8ed71c0790e6"
+            ],
+            "link": "http://xbiod.osu.edu/ipt/archive.do?r=ucfc",
+            "idigbio:dateModified": "2018-08-29T09:25:42.776340",
+            "collection_description": "Vouchered occurrence records for arthropods, primarily insects, from the Stuart M. Fullerton Collection of Arthropods at the University of Central Florida.",
+            "id": "262f8270-f9c2-4bc6-a562-8ed71c0790e6",
+            "other_guids": [],
+            "data_rights": "No license, assume Public Domain"
+          },
+          "etag": "41e6af7fc888b9ef73a8e01384ad73abed6f84a8",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "http://xbiod.osu.edu/ipt/eml.do?r=ucfc",
+          "recordids": [
+            "262f8270-f9c2-4bc6-a562-8ed71c0790e6"
+          ],
+          "data": {
+            "eml_link": "http://xbiod.osu.edu/ipt/eml.do?r=ucfc",
+            "contacts": [
+              {
+                "first_name": "Hojun",
+                "last_name": "Song",
+                "role": "Curator, Asst. Professor",
+                "email": "song@ucf.edu"
+              },
+              {
+                "first_name": "Norman",
+                "last_name": "Johnson",
+                "role": "Director, Professor",
+                "email": "johnson.2@osu.edu"
+              },
+              {
+                "first_name": "Sandor",
+                "last_name": "Kelly",
+                "role": "Collection Manager",
+                "email": "sandor.kelly@ucf.edu"
+              },
+              {
+                "first_name": "Hojun",
+                "last_name": "Song",
+                "role": "Curator, Asst. Professor",
+                "email": "song@ucf.edu"
+              }
+            ],
+            "collection_name": "Stuart M. Fullerton Collection of Arthropods (UCFC), University of Central Florida",
+            "update": "2018-08-29T08:25:24",
+            "ingest": true,
+            "data_rights": "No license, assume Public Domain",
+            "link": "http://xbiod.osu.edu/ipt/archive.do?r=ucfc",
+            "collection_description": "Vouchered occurrence records for arthropods, primarily insects, from the Stuart M. Fullerton Collection of Arthropods at the University of Central Florida.",
+            "other_guids": [],
+            "institution_web_address": "http://bugcloset.cos.ucf.edu",
+            "id": "262f8270-f9c2-4bc6-a562-8ed71c0790e6"
+          },
+          "datemodified": "2018-08-29T09:25:42.776340+00:00",
+          "name": "stuart m. fullerton collection of arthropods (ucfc), university of central florida"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "9475a9e1-cd56-4f5c-8d21-4206b088231b",
+        "_score": 1,
+        "_source": {
+          "publisher": "26281097-694b-483d-ae22-676a2a448bf1",
+          "uuid": "9475a9e1-cd56-4f5c-8d21-4206b088231b",
+          "dqs": -1,
+          "archivelink": "http://danbif.au.dk/ipt/archive.do?r=macroarthropods_nuupkangerlua2013_greenland",
+          "rights": "cc4 by",
+          "contacts": [
+            {
+              "first_name": "Toke Thomas",
+              "last_name": "Høye",
+              "role": "Senior scientist",
+              "email": "tth@bios.au.dk"
+            },
+            {
+              "first_name": "Toke Thomas",
+              "last_name": "Høye",
+              "role": "Senior scientist",
+              "email": "tth@bios.au.dk"
+            },
+            {
+              "first_name": "Isabel",
+              "last_name": "Calabuig",
+              "role": "Node manager, Data curator",
+              "email": "icalabuig@snm.ku.dk"
+            },
+            {
+              "first_name": "Toke Thomas",
+              "last_name": "Høye",
+              "role": "Senior scientist",
+              "email": "tth@bios.au.dk"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "26281097-694b-483d-ae22-676a2a448bf1",
+            "eml_link": "http://danbif.au.dk/ipt/eml.do?r=macroarthropods_nuupkangerlua2013_greenland",
+            "contacts": [
+              {
+                "first_name": "Toke Thomas",
+                "last_name": "Høye",
+                "role": "Senior scientist",
+                "email": "tth@bios.au.dk"
+              },
+              {
+                "first_name": "Toke Thomas",
+                "last_name": "Høye",
+                "role": "Senior scientist",
+                "email": "tth@bios.au.dk"
+              },
+              {
+                "first_name": "Isabel",
+                "last_name": "Calabuig",
+                "role": "Node manager, Data curator",
+                "email": "icalabuig@snm.ku.dk"
+              },
+              {
+                "first_name": "Toke Thomas",
+                "last_name": "Høye",
+                "role": "Senior scientist",
+                "email": "tth@bios.au.dk"
+              }
+            ],
+            "collection_name": "Macroarthropods, Godthåbsfjorden (Nuup Kangerlua) 2013, Greenland",
+            "idigbio:uuid": "9475a9e1-cd56-4f5c-8d21-4206b088231b",
+            "idigbio:etag": "2b558403c4bcd68517331e6d2d19d73d0ad465b4",
+            "update": "2017-08-09T08:49:56",
+            "ingest": true,
+            "institution_web_address": "",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "59d25ddf-355d-47d7-b8a1-c1e2819014c7"
+            ],
+            "link": "http://danbif.au.dk/ipt/archive.do?r=macroarthropods_nuupkangerlua2013_greenland",
+            "idigbio:dateModified": "2017-08-09T09:05:46.761969",
+            "collection_description": "Pitfall trap data set collected by Toke Thomas Høye, Rikke Reisner Hansen, and Oskar Liset Pryds Hansen",
+            "id": "59d25ddf-355d-47d7-b8a1-c1e2819014c7",
+            "other_guids": [],
+            "data_rights": "CC4 BY"
+          },
+          "etag": "2b558403c4bcd68517331e6d2d19d73d0ad465b4",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "http://danbif.au.dk/ipt/eml.do?r=macroarthropods_nuupkangerlua2013_greenland",
+          "recordids": [
+            "59d25ddf-355d-47d7-b8a1-c1e2819014c7"
+          ],
+          "data": {
+            "eml_link": "http://danbif.au.dk/ipt/eml.do?r=macroarthropods_nuupkangerlua2013_greenland",
+            "contacts": [
+              {
+                "first_name": "Toke Thomas",
+                "last_name": "Høye",
+                "role": "Senior scientist",
+                "email": "tth@bios.au.dk"
+              },
+              {
+                "first_name": "Toke Thomas",
+                "last_name": "Høye",
+                "role": "Senior scientist",
+                "email": "tth@bios.au.dk"
+              },
+              {
+                "first_name": "Isabel",
+                "last_name": "Calabuig",
+                "role": "Node manager, Data curator",
+                "email": "icalabuig@snm.ku.dk"
+              },
+              {
+                "first_name": "Toke Thomas",
+                "last_name": "Høye",
+                "role": "Senior scientist",
+                "email": "tth@bios.au.dk"
+              }
+            ],
+            "collection_name": "Macroarthropods, Godthåbsfjorden (Nuup Kangerlua) 2013, Greenland",
+            "update": "2017-08-09T08:49:56",
+            "ingest": true,
+            "data_rights": "CC4 BY",
+            "link": "http://danbif.au.dk/ipt/archive.do?r=macroarthropods_nuupkangerlua2013_greenland",
+            "collection_description": "Pitfall trap data set collected by Toke Thomas Høye, Rikke Reisner Hansen, and Oskar Liset Pryds Hansen",
+            "other_guids": [],
+            "institution_web_address": "",
+            "id": "59d25ddf-355d-47d7-b8a1-c1e2819014c7"
+          },
+          "datemodified": "2017-08-09T09:05:46.761969+00:00",
+          "name": "macroarthropods, godthåbsfjorden (nuup kangerlua) 2013, greenland"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "d2e46893-099f-45eb-9a76-d2a66f43bec8",
+        "_score": 1,
+        "_source": {
+          "publisher": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+          "uuid": "d2e46893-099f-45eb-9a76-d2a66f43bec8",
+          "dqs": -1,
+          "archivelink": "https://www.snib.mx/iptconabio/archive.do?r=snib-hc022",
+          "rights": "cc4 by",
+          "contacts": [
+            {
+              "first_name": "Francisco Xavier",
+              "last_name": "González Cózatl",
+              "role": "Responsable"
+            },
+            {
+              "first_name": "CONABIO",
+              "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            },
+            {
+              "first_name": "Patricia",
+              "last_name": "Ramos Rivera",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-HC022",
+            "contacts": [
+              {
+                "first_name": "Francisco Xavier",
+                "last_name": "González Cózatl",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Computarización de la colección de mamíferos del Centro de Educación Ambiental e Investigación Sierra de Huautla (CEAMISH) de la Universidad Autónoma del Estado de Morelos (UAEM)",
+            "idigbio:uuid": "d2e46893-099f-45eb-9a76-d2a66f43bec8",
+            "idigbio:etag": "587c955722ea3dcfe8475f08f1e1519c07c8bb1b",
+            "update": "2021-07-16T23:04:11",
+            "ingest": true,
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=HC&Numero=22",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "f0d7eb48-a312-4643-a1bb-1ba9370497ec"
+            ],
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-HC022",
+            "idigbio:dateModified": "2021-07-27T02:26:40.506165",
+            "collection_description": "La Colección de Mamíferos del CEAMISH (CMC) se inició en el año 2000 con la incorporación de ejemplares colectados en proyectos financiados por el CONACYT, la Universidad Autónoma del Estado de Morelos y tres instituciones extranjeras.  La CMC fue formalmente registrada ante la SEMARNAT en el año del 2005.  Cuenta con 2,424 ejemplares pertenecientes a 7 ordenes, 17 familias, 48 géneros y 81 especies, principalmente del orden Rodentia.  La mayoría de los ejemplares provienen de localidades de bosque mesófilo y selva baja caducifolia de México.  Actualmente, 1,166 ejemplares están catalogados formalmente con identificaciones hasta el nivel de especie,  353 ejemplares están en proceso de identificación y 35 más acaban de ingresar y están en el proceso de catalogación.  Afortunadamente, cerca del 95% de los ejemplares están referenciados con coordenadas geográficas.  Para más del 75% de estos ejemplares se preserva muestras de tejido congelado o en alcohol para estudios moleculares.  Además, se cuenta con muestras de sangre de 45% de los ejemplares para determinar la presencia de virus tales como el arenavirus y el hantavirus.  Sin embargo, debido a que la CMC ha tenido limitaciones de financiamiento, infraestructura, y ha carecido de personal de apoyo de tiempo competo asociado a la misma, aún falta computarizar mucha de la información asociada a los ejemplares.  Además, es necesario completar el proceso de curación de más del 50% de los ejemplares que integran la CMC.  En este sentido, la presente propuesta tiene como objetivo solicitar recursos para computarizar la información asociada a los ejemplares de la CMC, y  completar el proceso de curación del material biológico depositado en la CMC, procurando que éste quede resguardado en gabinetes adecuados para su protección. Reino: 1\nFilo: 1\nClase: 1\nOrden: 7\nFamilia: 17\nGénero: 49\nEspecie: 99",
+            "id": "f0d7eb48-a312-4643-a1bb-1ba9370497ec",
+            "other_guids": [],
+            "data_rights": "CC4 BY"
+          },
+          "etag": "587c955722ea3dcfe8475f08f1e1519c07c8bb1b",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "https://www.snib.mx/iptconabio/eml.do?r=snib-hc022",
+          "recordids": [
+            "f0d7eb48-a312-4643-a1bb-1ba9370497ec"
+          ],
+          "data": {
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-HC022",
+            "contacts": [
+              {
+                "first_name": "Francisco Xavier",
+                "last_name": "González Cózatl",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Computarización de la colección de mamíferos del Centro de Educación Ambiental e Investigación Sierra de Huautla (CEAMISH) de la Universidad Autónoma del Estado de Morelos (UAEM)",
+            "update": "2021-07-16T23:04:11",
+            "ingest": true,
+            "data_rights": "CC4 BY",
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-HC022",
+            "collection_description": "La Colección de Mamíferos del CEAMISH (CMC) se inició en el año 2000 con la incorporación de ejemplares colectados en proyectos financiados por el CONACYT, la Universidad Autónoma del Estado de Morelos y tres instituciones extranjeras.  La CMC fue formalmente registrada ante la SEMARNAT en el año del 2005.  Cuenta con 2,424 ejemplares pertenecientes a 7 ordenes, 17 familias, 48 géneros y 81 especies, principalmente del orden Rodentia.  La mayoría de los ejemplares provienen de localidades de bosque mesófilo y selva baja caducifolia de México.  Actualmente, 1,166 ejemplares están catalogados formalmente con identificaciones hasta el nivel de especie,  353 ejemplares están en proceso de identificación y 35 más acaban de ingresar y están en el proceso de catalogación.  Afortunadamente, cerca del 95% de los ejemplares están referenciados con coordenadas geográficas.  Para más del 75% de estos ejemplares se preserva muestras de tejido congelado o en alcohol para estudios moleculares.  Además, se cuenta con muestras de sangre de 45% de los ejemplares para determinar la presencia de virus tales como el arenavirus y el hantavirus.  Sin embargo, debido a que la CMC ha tenido limitaciones de financiamiento, infraestructura, y ha carecido de personal de apoyo de tiempo competo asociado a la misma, aún falta computarizar mucha de la información asociada a los ejemplares.  Además, es necesario completar el proceso de curación de más del 50% de los ejemplares que integran la CMC.  En este sentido, la presente propuesta tiene como objetivo solicitar recursos para computarizar la información asociada a los ejemplares de la CMC, y  completar el proceso de curación del material biológico depositado en la CMC, procurando que éste quede resguardado en gabinetes adecuados para su protección. Reino: 1\nFilo: 1\nClase: 1\nOrden: 7\nFamilia: 17\nGénero: 49\nEspecie: 99",
+            "other_guids": [],
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=HC&Numero=22",
+            "id": "f0d7eb48-a312-4643-a1bb-1ba9370497ec"
+          },
+          "datemodified": "2021-07-27T02:26:40.506165+00:00",
+          "name": "computarización de la colección de mamíferos del centro de educación ambiental e investigación sierra de huautla (ceamish) de la universidad autónoma del estado de morelos (uaem)"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "9a0d6dc0-689f-4327-8cf3-1c530443f49a",
+        "_score": 1,
+        "_source": {
+          "publisher": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+          "uuid": "9a0d6dc0-689f-4327-8cf3-1c530443f49a",
+          "dqs": -1,
+          "archivelink": "https://www.snib.mx/iptconabio/archive.do?r=snib-l070",
+          "rights": "cc4 by",
+          "contacts": [
+            {
+              "first_name": "José Alberto",
+              "last_name": "Ocaña Luna",
+              "role": "Responsable"
+            },
+            {
+              "first_name": "CONABIO",
+              "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            },
+            {
+              "first_name": "Patricia",
+              "last_name": "Ramos Rivera",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-L070",
+            "contacts": [
+              {
+                "first_name": "José Alberto",
+                "last_name": "Ocaña Luna",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Diversidad del ictioplancton en las lagunas Madre y Almagre, Tamaulipas, y laguna de Tampamachoco, Veracruz",
+            "idigbio:uuid": "9a0d6dc0-689f-4327-8cf3-1c530443f49a",
+            "idigbio:etag": "7ba2765075772838bb6b8a206377dc7c88b59a74",
+            "update": "2021-07-16T23:12:16",
+            "ingest": true,
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=L&Numero=70",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "d22863c3-aff9-4f91-b727-dc3ece083694"
+            ],
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-L070",
+            "idigbio:dateModified": "2021-07-27T02:27:01.694180",
+            "collection_description": "Este proyecto tiene como objetivo principal conocer la diversidad y variación espacio-temporal del ictioplancton en tres sistemas lagunares: Laguna Madre y Laguna Almagre, Tamaulipas (lagunas adyacentes a la región prioritaria para la conservación No. 67) y Laguna de Tampamachoco, Veracruz (región prioritaria para la conservación No. 106). Actualmente se tiene cubierta la parte central de la Laguna Madre y la Laguna de Tampamachoco costituyendo alrededor del 75% del total de regiones comprometidas a la CONABIO en el presente proyecto, provenientes de 74 muestras de las cuales se extrajeron un total de 7,721 organismos que corresponde a 434 registros. En el sur de la Laguna Madre y la Laguna Almagre  se planea realizar cuatro colectas (agosto y noviembre,1997; febrero y mayo 1998) en 17 estaciones, con lo cual se espera obtener durante esta fase de proyecto alrededor de 126 registros y 2,500-3,000 ejemplares. Este proyecto se desarrollará en el Laboratorio de Ecología  de la Escuela Nacional de Ciencias Biológicas del IPN, bajo la  responsabilidad de un profesor-investigador de esta escuela, con la participación de un investigador del Instituto de Geografía y con estudiantes de posgrado de la Facultad de Ciencias de la UNAM. Reino: 1\nFilo: 1\nClase: 1\nOrden: 17\nFamilia: 22\nGénero: 41\nEspecie: 49",
+            "id": "d22863c3-aff9-4f91-b727-dc3ece083694",
+            "other_guids": [],
+            "data_rights": "CC4 BY"
+          },
+          "etag": "7ba2765075772838bb6b8a206377dc7c88b59a74",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "https://www.snib.mx/iptconabio/eml.do?r=snib-l070",
+          "recordids": [
+            "d22863c3-aff9-4f91-b727-dc3ece083694"
+          ],
+          "data": {
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-L070",
+            "contacts": [
+              {
+                "first_name": "José Alberto",
+                "last_name": "Ocaña Luna",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Diversidad del ictioplancton en las lagunas Madre y Almagre, Tamaulipas, y laguna de Tampamachoco, Veracruz",
+            "update": "2021-07-16T23:12:16",
+            "ingest": true,
+            "data_rights": "CC4 BY",
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-L070",
+            "collection_description": "Este proyecto tiene como objetivo principal conocer la diversidad y variación espacio-temporal del ictioplancton en tres sistemas lagunares: Laguna Madre y Laguna Almagre, Tamaulipas (lagunas adyacentes a la región prioritaria para la conservación No. 67) y Laguna de Tampamachoco, Veracruz (región prioritaria para la conservación No. 106). Actualmente se tiene cubierta la parte central de la Laguna Madre y la Laguna de Tampamachoco costituyendo alrededor del 75% del total de regiones comprometidas a la CONABIO en el presente proyecto, provenientes de 74 muestras de las cuales se extrajeron un total de 7,721 organismos que corresponde a 434 registros. En el sur de la Laguna Madre y la Laguna Almagre  se planea realizar cuatro colectas (agosto y noviembre,1997; febrero y mayo 1998) en 17 estaciones, con lo cual se espera obtener durante esta fase de proyecto alrededor de 126 registros y 2,500-3,000 ejemplares. Este proyecto se desarrollará en el Laboratorio de Ecología  de la Escuela Nacional de Ciencias Biológicas del IPN, bajo la  responsabilidad de un profesor-investigador de esta escuela, con la participación de un investigador del Instituto de Geografía y con estudiantes de posgrado de la Facultad de Ciencias de la UNAM. Reino: 1\nFilo: 1\nClase: 1\nOrden: 17\nFamilia: 22\nGénero: 41\nEspecie: 49",
+            "other_guids": [],
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=L&Numero=70",
+            "id": "d22863c3-aff9-4f91-b727-dc3ece083694"
+          },
+          "datemodified": "2021-07-27T02:27:01.694180+00:00",
+          "name": "diversidad del ictioplancton en las lagunas madre y almagre, tamaulipas, y laguna de tampamachoco, veracruz"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "03e291b1-e74e-489a-8ec9-d23ff481c13c",
+        "_score": 1,
+        "_source": {
+          "publisher": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+          "uuid": "03e291b1-e74e-489a-8ec9-d23ff481c13c",
+          "dqs": -1,
+          "archivelink": "https://www.snib.mx/iptconabio/archive.do?r=snib-l074",
+          "rights": "cc4 by",
+          "contacts": [
+            {
+              "first_name": "Teresa",
+              "last_name": "Terrazas Salgado",
+              "role": "Responsable"
+            },
+            {
+              "first_name": "CONABIO",
+              "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            },
+            {
+              "first_name": "Patricia",
+              "last_name": "Ramos Rivera",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-L074",
+            "contacts": [
+              {
+                "first_name": "Teresa",
+                "last_name": "Terrazas Salgado",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Filogenia de las cactáceas columnares (Pachycereeae) con base en caracteres anatómico-morfológicos",
+            "idigbio:uuid": "03e291b1-e74e-489a-8ec9-d23ff481c13c",
+            "idigbio:etag": "f5fb6529a68f8a63d0403822cf3ea65e0d915ef7",
+            "update": "2021-07-16T23:12:15",
+            "ingest": true,
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=L&Numero=74",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "80863c34-f762-11e1-a439-00145eb45e9a"
+            ],
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-L074",
+            "idigbio:dateModified": "2021-07-27T02:26:52.812930",
+            "collection_description": "La tribu Pachycereeae sensu Barthlott y Hunt contiene 10 géneros y 60 especies. El mayor número de especies de esta tribu son endémicas a México, además de ser elementos dominantes de algunas comunidades vegetales del país. La tribu fue dividida por Gibson y Horak en dos subtribus con base en caracteres anatómicos, morfológicos y fitioquímicos, no obstante la monofilia de algunos géneros se ha cuestionado en trabajos más recientes. Por otra parte un análisis riguroso (cladistico) con base en caracteres anatómicos y morfológicos no se ha realizado y la información existente a la fecha es parcial y difícil de re-analizarse, en especial para los caracteres anatómicos. Con base en lo anterior se plantea analizar la información anatómica-morfológica  de los miembros de este tribu a través del método de cladismo. Este proyecto pretende con base en colectas de campo: 1) generar información anivel anatómico para las especies de Pachycereeae y 2) generar/sintetizar información ya disponible de los caracteres morfológicos para las especies de dicha tribu y con ambos conjuntos de postular hipótesis de relaciones filogenéticas. Reino: 1\nFilo: 1\nClase: 1\nOrden: 1\nFamilia: 1\nGénero: 10\nEspecie: 48",
+            "id": "80863c34-f762-11e1-a439-00145eb45e9a",
+            "other_guids": [],
+            "data_rights": "CC4 BY"
+          },
+          "etag": "f5fb6529a68f8a63d0403822cf3ea65e0d915ef7",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "https://www.snib.mx/iptconabio/eml.do?r=snib-l074",
+          "recordids": [
+            "80863c34-f762-11e1-a439-00145eb45e9a"
+          ],
+          "data": {
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-L074",
+            "contacts": [
+              {
+                "first_name": "Teresa",
+                "last_name": "Terrazas Salgado",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Filogenia de las cactáceas columnares (Pachycereeae) con base en caracteres anatómico-morfológicos",
+            "update": "2021-07-16T23:12:15",
+            "ingest": true,
+            "data_rights": "CC4 BY",
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-L074",
+            "collection_description": "La tribu Pachycereeae sensu Barthlott y Hunt contiene 10 géneros y 60 especies. El mayor número de especies de esta tribu son endémicas a México, además de ser elementos dominantes de algunas comunidades vegetales del país. La tribu fue dividida por Gibson y Horak en dos subtribus con base en caracteres anatómicos, morfológicos y fitioquímicos, no obstante la monofilia de algunos géneros se ha cuestionado en trabajos más recientes. Por otra parte un análisis riguroso (cladistico) con base en caracteres anatómicos y morfológicos no se ha realizado y la información existente a la fecha es parcial y difícil de re-analizarse, en especial para los caracteres anatómicos. Con base en lo anterior se plantea analizar la información anatómica-morfológica  de los miembros de este tribu a través del método de cladismo. Este proyecto pretende con base en colectas de campo: 1) generar información anivel anatómico para las especies de Pachycereeae y 2) generar/sintetizar información ya disponible de los caracteres morfológicos para las especies de dicha tribu y con ambos conjuntos de postular hipótesis de relaciones filogenéticas. Reino: 1\nFilo: 1\nClase: 1\nOrden: 1\nFamilia: 1\nGénero: 10\nEspecie: 48",
+            "other_guids": [],
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=L&Numero=74",
+            "id": "80863c34-f762-11e1-a439-00145eb45e9a"
+          },
+          "datemodified": "2021-07-27T02:26:52.812930+00:00",
+          "name": "filogenia de las cactáceas columnares (pachycereeae) con base en caracteres anatómico-morfológicos"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "080f57e4-505c-4e56-bfad-d1861609f146",
+        "_score": 1,
+        "_source": {
+          "publisher": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+          "uuid": "080f57e4-505c-4e56-bfad-d1861609f146",
+          "dqs": -1,
+          "archivelink": "https://www.snib.mx/iptconabio/archive.do?r=snib-h285",
+          "rights": "cc4 by",
+          "contacts": [
+            {
+              "first_name": "Clementina de los Angeles",
+              "last_name": "Equihua Zamora",
+              "role": "Responsable"
+            },
+            {
+              "first_name": "CONABIO",
+              "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            },
+            {
+              "first_name": "Patricia",
+              "last_name": "Ramos Rivera",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-H285",
+            "contacts": [
+              {
+                "first_name": "Clementina de los Angeles",
+                "last_name": "Equihua Zamora",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Brioflora de la Reserva de Montes Azules, Chis.: Diversidad, Biogeografía y Depauperación por Actividad Humana",
+            "idigbio:uuid": "080f57e4-505c-4e56-bfad-d1861609f146",
+            "idigbio:etag": "c0a9d8febe4be588695f74fa11939781e40d309b",
+            "update": "2021-07-16T23:08:28",
+            "ingest": true,
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=H&Numero=285",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "80bfa122-f762-11e1-a439-00145eb45e9a"
+            ],
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-H285",
+            "idigbio:dateModified": "2021-07-27T02:27:14.791596",
+            "collection_description": "Los musgos y hepáticas (en conjunto denominados briofitas) constituyen el segundo grupo en diversidad del reino vegetal (Mishler, 1988 y Buck y Thiers, 1989).  Al igual que las angiospermas, es de esperar mayor diversidad en las briofloras tropicales que las de regiones templadas, y aún así, Delgadillo y Equihua (1990) solamente citan dos trabajos que dedican su investigación al estado de Chiapas. Ambos estudios están enfocados a la parte central y los altos de Chiapas. Chiapas es uno de los estados más diversos de nuestro país (Breedlove, 1973 y Flores-Villela y Gerez, 1988) y donde se ubica uno de los límites septentrionales de bosque húmedo tropical (Medellín, et al., 1992).  La zona Lacandona, específicamente la Reserva de Montes Azules, ha sido muy poco estudiada (Delgadillo, 1993).  Este es el primer trabajo formal sobre briofitas en la zona y abarcará tanto la adquisición de información elemental sobre la brioflora de la zona, como análisis básicos sobre su ecología y distribución geográfica. Se han realizado cuatro visitas a la Reserva de Montes Azules y a zonas aledañas incluidas en la selva Lacandona: la región de Ixcán, alrededores de la estación Chajul, zona del río Tzendales, alrededores de los poblados de Nahá, Lacanhá y Nuevo Chapultepec.  Durante estas visitas se han colectado un total de 994 ejemplares y se están procesando 623 previamente colectados.  Hasta el momento se han determinado 60% de los ejemplares distribuidos en 170 especies.  Dentro de estas especies se han encontrado 14 nuevos registros para el país: nueve de hepáticas epífilas (Pócs y Equihua en prep.) y 5 de musgos (Equihua y García-Ávila, en prep).  Al finalizar este proyecto, se depositarán los ejemplares en el herbario nacional (MEXU). También se han realizado colectas en cuadrantes en los diferentes tipos de perturbación más frecuentes en la zona: acahuales y cacaotales, para comparar la diversidad con sitios sin perturbar (Equihua y Gradstein, en prep.). Al finalizar este estudió se publicará un listado florístico, un estudio biogeográfico y un estudio comparativo del efecto de la perturbación humana sobre las comunidades de briofitas. Reino: 1\nFilo: 3\nClase: 4\nOrden: 17\nFamilia: 48\nGénero: 134\nEspecie: 227\nEpitetoinfraespecifico: 7",
+            "id": "80bfa122-f762-11e1-a439-00145eb45e9a",
+            "other_guids": [],
+            "data_rights": "CC4 BY"
+          },
+          "etag": "c0a9d8febe4be588695f74fa11939781e40d309b",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "https://www.snib.mx/iptconabio/eml.do?r=snib-h285",
+          "recordids": [
+            "80bfa122-f762-11e1-a439-00145eb45e9a"
+          ],
+          "data": {
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-H285",
+            "contacts": [
+              {
+                "first_name": "Clementina de los Angeles",
+                "last_name": "Equihua Zamora",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Brioflora de la Reserva de Montes Azules, Chis.: Diversidad, Biogeografía y Depauperación por Actividad Humana",
+            "update": "2021-07-16T23:08:28",
+            "ingest": true,
+            "data_rights": "CC4 BY",
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-H285",
+            "collection_description": "Los musgos y hepáticas (en conjunto denominados briofitas) constituyen el segundo grupo en diversidad del reino vegetal (Mishler, 1988 y Buck y Thiers, 1989).  Al igual que las angiospermas, es de esperar mayor diversidad en las briofloras tropicales que las de regiones templadas, y aún así, Delgadillo y Equihua (1990) solamente citan dos trabajos que dedican su investigación al estado de Chiapas. Ambos estudios están enfocados a la parte central y los altos de Chiapas. Chiapas es uno de los estados más diversos de nuestro país (Breedlove, 1973 y Flores-Villela y Gerez, 1988) y donde se ubica uno de los límites septentrionales de bosque húmedo tropical (Medellín, et al., 1992).  La zona Lacandona, específicamente la Reserva de Montes Azules, ha sido muy poco estudiada (Delgadillo, 1993).  Este es el primer trabajo formal sobre briofitas en la zona y abarcará tanto la adquisición de información elemental sobre la brioflora de la zona, como análisis básicos sobre su ecología y distribución geográfica. Se han realizado cuatro visitas a la Reserva de Montes Azules y a zonas aledañas incluidas en la selva Lacandona: la región de Ixcán, alrededores de la estación Chajul, zona del río Tzendales, alrededores de los poblados de Nahá, Lacanhá y Nuevo Chapultepec.  Durante estas visitas se han colectado un total de 994 ejemplares y se están procesando 623 previamente colectados.  Hasta el momento se han determinado 60% de los ejemplares distribuidos en 170 especies.  Dentro de estas especies se han encontrado 14 nuevos registros para el país: nueve de hepáticas epífilas (Pócs y Equihua en prep.) y 5 de musgos (Equihua y García-Ávila, en prep).  Al finalizar este proyecto, se depositarán los ejemplares en el herbario nacional (MEXU). También se han realizado colectas en cuadrantes en los diferentes tipos de perturbación más frecuentes en la zona: acahuales y cacaotales, para comparar la diversidad con sitios sin perturbar (Equihua y Gradstein, en prep.). Al finalizar este estudió se publicará un listado florístico, un estudio biogeográfico y un estudio comparativo del efecto de la perturbación humana sobre las comunidades de briofitas. Reino: 1\nFilo: 3\nClase: 4\nOrden: 17\nFamilia: 48\nGénero: 134\nEspecie: 227\nEpitetoinfraespecifico: 7",
+            "other_guids": [],
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=H&Numero=285",
+            "id": "80bfa122-f762-11e1-a439-00145eb45e9a"
+          },
+          "datemodified": "2021-07-27T02:27:14.791596+00:00",
+          "name": "brioflora de la reserva de montes azules, chis.: diversidad, biogeografía y depauperación por actividad humana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "a9223e1d-7a81-4311-800e-211c5a1b8205",
+        "_score": 1,
+        "_source": {
+          "publisher": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+          "uuid": "a9223e1d-7a81-4311-800e-211c5a1b8205",
+          "dqs": -1,
+          "archivelink": "https://www.snib.mx/iptconabio/archive.do?r=snib-j063",
+          "rights": "cc4 by",
+          "contacts": [
+            {
+              "first_name": "Diego David",
+              "last_name": "Reygadas Prado",
+              "role": "Responsable"
+            },
+            {
+              "first_name": "CONABIO",
+              "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            },
+            {
+              "first_name": "Patricia",
+              "last_name": "Ramos Rivera",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-J063",
+            "contacts": [
+              {
+                "first_name": "Diego David",
+                "last_name": "Reygadas Prado",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Sistema de apoyo a la toma de decisiones para la reforestación rural en México",
+            "idigbio:uuid": "a9223e1d-7a81-4311-800e-211c5a1b8205",
+            "idigbio:etag": "34be2144b0279bd5c958018446e78f94dfb96f94",
+            "update": "2021-07-16T23:06:42",
+            "ingest": true,
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=J&Numero=63",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "80a89392-f762-11e1-a439-00145eb45e9a"
+            ],
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-J063",
+            "idigbio:dateModified": "2021-07-27T02:27:29.693139",
+            "collection_description": "La reforestación es la acción más directa e inmediata que apoya la recuperación de las áreas degradadas en México y a la conservación de aquellas susceptibles de afectación y pérdida de la cobertura vegetal y biodiversidad asociada. Se ha dado un impulso importante a los programas de reforestación a nivel nacional en los últimos años, de hecho se tiene programada una meta de 1,700 millones de plantas para el presente sexenio, aunque el enfoque que se ha dado a las plantaciones no se puede decir que refleja esta directriz de manera adecuada ya que la reforestación se ha dirigido en un alto porcentaje hacia las áreas urbanas y con especies exóticas. Es importante que el enfoque que se de a los trabajos futuros de reforestación se dirijan a especies nativas y en las áreas rurales de nuestro país dentro de las cuales los problemas ecológicos, económicos y sociales en conjunto requieren de una solución a corto plazo. En este contexto, este proyecto considera el empleo de herramientas como las bases de datos relacionales y los sistemas de información geográfica para conjuntar y analizar la información ecológica,, social y económica relacionada con la reforestación rural en México, a fin de proporcionar elementos de apoyo a la toma de decisiones que conlleven al desarrollo sustentable de las comunidades que habitan las áreas rurales de nuestro país. Reino: 1\nFilo: 1\nClase: 2\nOrden: 38\nFamilia: 85\nGénero: 262\nSubgénero: 7\nEspecie: 435\nEpitetoinfraespecifico: 5",
+            "id": "80a89392-f762-11e1-a439-00145eb45e9a",
+            "other_guids": [],
+            "data_rights": "CC4 BY"
+          },
+          "etag": "34be2144b0279bd5c958018446e78f94dfb96f94",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "https://www.snib.mx/iptconabio/eml.do?r=snib-j063",
+          "recordids": [
+            "80a89392-f762-11e1-a439-00145eb45e9a"
+          ],
+          "data": {
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-J063",
+            "contacts": [
+              {
+                "first_name": "Diego David",
+                "last_name": "Reygadas Prado",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Sistema de apoyo a la toma de decisiones para la reforestación rural en México",
+            "update": "2021-07-16T23:06:42",
+            "ingest": true,
+            "data_rights": "CC4 BY",
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-J063",
+            "collection_description": "La reforestación es la acción más directa e inmediata que apoya la recuperación de las áreas degradadas en México y a la conservación de aquellas susceptibles de afectación y pérdida de la cobertura vegetal y biodiversidad asociada. Se ha dado un impulso importante a los programas de reforestación a nivel nacional en los últimos años, de hecho se tiene programada una meta de 1,700 millones de plantas para el presente sexenio, aunque el enfoque que se ha dado a las plantaciones no se puede decir que refleja esta directriz de manera adecuada ya que la reforestación se ha dirigido en un alto porcentaje hacia las áreas urbanas y con especies exóticas. Es importante que el enfoque que se de a los trabajos futuros de reforestación se dirijan a especies nativas y en las áreas rurales de nuestro país dentro de las cuales los problemas ecológicos, económicos y sociales en conjunto requieren de una solución a corto plazo. En este contexto, este proyecto considera el empleo de herramientas como las bases de datos relacionales y los sistemas de información geográfica para conjuntar y analizar la información ecológica,, social y económica relacionada con la reforestación rural en México, a fin de proporcionar elementos de apoyo a la toma de decisiones que conlleven al desarrollo sustentable de las comunidades que habitan las áreas rurales de nuestro país. Reino: 1\nFilo: 1\nClase: 2\nOrden: 38\nFamilia: 85\nGénero: 262\nSubgénero: 7\nEspecie: 435\nEpitetoinfraespecifico: 5",
+            "other_guids": [],
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=J&Numero=63",
+            "id": "80a89392-f762-11e1-a439-00145eb45e9a"
+          },
+          "datemodified": "2021-07-27T02:27:29.693139+00:00",
+          "name": "sistema de apoyo a la toma de decisiones para la reforestación rural en méxico"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "ea3c3b03-0ed5-42fc-b192-7328459ea04a",
+        "_score": 1,
+        "_source": {
+          "publisher": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+          "uuid": "ea3c3b03-0ed5-42fc-b192-7328459ea04a",
+          "dqs": -1,
+          "archivelink": "https://www.snib.mx/iptconabio/archive.do?r=snib-u048",
+          "rights": "cc4 by",
+          "contacts": [
+            {
+              "first_name": "Enrique",
+              "last_name": "Guízar Nolazco",
+              "role": "Responsable"
+            },
+            {
+              "first_name": "CONABIO",
+              "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            },
+            {
+              "first_name": "Patricia",
+              "last_name": "Ramos Rivera",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-U048",
+            "contacts": [
+              {
+                "first_name": "Enrique",
+                "last_name": "Guízar Nolazco",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Banco de datos florísticos del Herbario CHAP",
+            "idigbio:uuid": "ea3c3b03-0ed5-42fc-b192-7328459ea04a",
+            "idigbio:etag": "ba0e2b66042b2ad2cad1d209ba0196a424b8288c",
+            "update": "2021-07-16T23:06:13",
+            "ingest": true,
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=U&Numero=48",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "9d300300-333d-4ac3-abcb-04d4b369e556"
+            ],
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-U048",
+            "idigbio:dateModified": "2021-07-27T02:26:58.291460",
+            "collection_description": "La colección científica del Herbario CHAP es la más antigua, cuantiosa e importante de la Universidad Autónoma Chapingo, esta constituida por aproximadamente 50,800 ejemplares debidamente registrados, pertenecientes a las diferentes formas biológicas de las plantas fanerógamas, así como de los diferentes tipos de vegetación existentes en México. Reviste importancia porque posee una de las colecciones más completas del grupo de las gimnospermas mexicanas y en general de la flora dendrológica. Contiene colecciones importantes entre las que destacan las de Pennington y Sarukhán del trópico cálido-húmedo, las colectas de Zsolt Debreczy e Iztvan Rácz correspondientes a las coníferas colectadas en México como parte del proyecto internacional Atlas Dendrológico, además de estar representadas las siguientes regiones: Sierra Nevada del Eje Neovolcánico, Noroeste de Chihuahua y Durango, cuenca alta del Balsas y las Mixtecas Poblana-Oaxaqueña. Reino: 1\nFilo: 1\nClase: 3\nOrden: 68\nFamilia: 267\nGénero: 1975\nSubgénero: 23\nEspecie: 8814\nEpitetoinfraespecifico: 465",
+            "id": "9d300300-333d-4ac3-abcb-04d4b369e556",
+            "other_guids": [],
+            "data_rights": "CC4 BY"
+          },
+          "etag": "ba0e2b66042b2ad2cad1d209ba0196a424b8288c",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "https://www.snib.mx/iptconabio/eml.do?r=snib-u048",
+          "recordids": [
+            "9d300300-333d-4ac3-abcb-04d4b369e556"
+          ],
+          "data": {
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-U048",
+            "contacts": [
+              {
+                "first_name": "Enrique",
+                "last_name": "Guízar Nolazco",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Banco de datos florísticos del Herbario CHAP",
+            "update": "2021-07-16T23:06:13",
+            "ingest": true,
+            "data_rights": "CC4 BY",
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-U048",
+            "collection_description": "La colección científica del Herbario CHAP es la más antigua, cuantiosa e importante de la Universidad Autónoma Chapingo, esta constituida por aproximadamente 50,800 ejemplares debidamente registrados, pertenecientes a las diferentes formas biológicas de las plantas fanerógamas, así como de los diferentes tipos de vegetación existentes en México. Reviste importancia porque posee una de las colecciones más completas del grupo de las gimnospermas mexicanas y en general de la flora dendrológica. Contiene colecciones importantes entre las que destacan las de Pennington y Sarukhán del trópico cálido-húmedo, las colectas de Zsolt Debreczy e Iztvan Rácz correspondientes a las coníferas colectadas en México como parte del proyecto internacional Atlas Dendrológico, además de estar representadas las siguientes regiones: Sierra Nevada del Eje Neovolcánico, Noroeste de Chihuahua y Durango, cuenca alta del Balsas y las Mixtecas Poblana-Oaxaqueña. Reino: 1\nFilo: 1\nClase: 3\nOrden: 68\nFamilia: 267\nGénero: 1975\nSubgénero: 23\nEspecie: 8814\nEpitetoinfraespecifico: 465",
+            "other_guids": [],
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=U&Numero=48",
+            "id": "9d300300-333d-4ac3-abcb-04d4b369e556"
+          },
+          "datemodified": "2021-07-27T02:26:58.291460+00:00",
+          "name": "banco de datos florísticos del herbario chap"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "8cae9490-b1c1-4199-a44e-3a1396666072",
+        "_score": 1,
+        "_source": {
+          "publisher": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+          "uuid": "8cae9490-b1c1-4199-a44e-3a1396666072",
+          "dqs": -1,
+          "archivelink": "https://www.snib.mx/iptconabio/archive.do?r=snib-ej008-ej0080809f-crustaceos",
+          "rights": "cc4 by",
+          "contacts": [
+            {
+              "first_name": "Ma del Carmen",
+              "last_name": "Franco Gordo",
+              "role": "Responsable"
+            },
+            {
+              "first_name": "CONABIO",
+              "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            },
+            {
+              "first_name": "Patricia",
+              "last_name": "Ramos Rivera",
+              "role": "Dirección General de Sistemas",
+              "email": "patricia.ramos@conabio.gob.mx"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-EJ008-EJ0080809F-crustaceos",
+            "contacts": [
+              {
+                "first_name": "Ma del Carmen",
+                "last_name": "Franco Gordo",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Base de datos y colección de distintos grupos del zooplancton de regiones marinas prioritarias de Jalisco y Colima en el Pacífico mexicano (Crustáceos)",
+            "idigbio:uuid": "8cae9490-b1c1-4199-a44e-3a1396666072",
+            "idigbio:etag": "590a9a50a0f250f3fefb8ce3af574564c2f6931d",
+            "update": "2021-07-16T23:12:33",
+            "ingest": true,
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=EJ&Numero=8",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "17f76205-c629-41d8-afc6-8959f90c8ab3"
+            ],
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-EJ008-EJ0080809F-crustaceos",
+            "idigbio:dateModified": "2021-07-27T02:27:10.942999",
+            "collection_description": "Nuestro conocimiento de la fauna zooplanctónica, en toda la costa mexicana, es aún escaso, y los pocos estudios que existen son aislados y no secuenciales. Es por eso que en este proyecto se pretende estudiar y difundir los datos de varios grupos del zooplancton   que fueron recolectados desde el año 1988 (medusas),  1990 (copépodos,  eufáusidos)  y otros colectados de manera sistemática durante 1995-1998  (larvas de peces y quetognatos), conforman cerca de 70 sitios georeferenciados, ubicadas en tres Áreas Marinas Prioritarias del Jalisco y Colima.   Se creará una base de datos en versión BIOTICA con la información de los organismos encontrados y los datos de los sitios de recolección.   Se creará una colección de referencia con por lo menos un ejemplar de cada una de las distintas especies identificadas. Se calcula obtener un mínimo de 100 especies de larvas de peces, 20 especies de medusas, 40 especies de  copépodos,  5 especies de eufaúsidos y 11 especies de quetognatos, más de 10, 000 registros curatoriales y 6100  ejemplares a partir de 50 localidades georreferenciadas y más de 300  muestras analizadas.\nPalabras clave: colección, larvas de peces, copépodos, medusas, quetognatos, eufáusidos Reino: 1\nFilo: 1\nClase: 2\nOrden: 4\nFamilia: 18\nGénero: 25\nEspecie: 48",
+            "id": "17f76205-c629-41d8-afc6-8959f90c8ab3",
+            "other_guids": [],
+            "data_rights": "CC4 BY"
+          },
+          "etag": "590a9a50a0f250f3fefb8ce3af574564c2f6931d",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "https://www.snib.mx/iptconabio/eml.do?r=snib-ej008-ej0080809f-crustaceos",
+          "recordids": [
+            "17f76205-c629-41d8-afc6-8959f90c8ab3"
+          ],
+          "data": {
+            "eml_link": "https://www.snib.mx/iptconabio/eml.do?r=SNIB-EJ008-EJ0080809F-crustaceos",
+            "contacts": [
+              {
+                "first_name": "Ma del Carmen",
+                "last_name": "Franco Gordo",
+                "role": "Responsable"
+              },
+              {
+                "first_name": "CONABIO",
+                "last_name": "Comisión nacional para el conocimiento y uso de la biodiversidad",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              },
+              {
+                "first_name": "Patricia",
+                "last_name": "Ramos Rivera",
+                "role": "Dirección General de Sistemas",
+                "email": "patricia.ramos@conabio.gob.mx"
+              }
+            ],
+            "collection_name": "Base de datos y colección de distintos grupos del zooplancton de regiones marinas prioritarias de Jalisco y Colima en el Pacífico mexicano (Crustáceos)",
+            "update": "2021-07-16T23:12:33",
+            "ingest": true,
+            "data_rights": "CC4 BY",
+            "link": "https://www.snib.mx/iptconabio/archive.do?r=SNIB-EJ008-EJ0080809F-crustaceos",
+            "collection_description": "Nuestro conocimiento de la fauna zooplanctónica, en toda la costa mexicana, es aún escaso, y los pocos estudios que existen son aislados y no secuenciales. Es por eso que en este proyecto se pretende estudiar y difundir los datos de varios grupos del zooplancton   que fueron recolectados desde el año 1988 (medusas),  1990 (copépodos,  eufáusidos)  y otros colectados de manera sistemática durante 1995-1998  (larvas de peces y quetognatos), conforman cerca de 70 sitios georeferenciados, ubicadas en tres Áreas Marinas Prioritarias del Jalisco y Colima.   Se creará una base de datos en versión BIOTICA con la información de los organismos encontrados y los datos de los sitios de recolección.   Se creará una colección de referencia con por lo menos un ejemplar de cada una de las distintas especies identificadas. Se calcula obtener un mínimo de 100 especies de larvas de peces, 20 especies de medusas, 40 especies de  copépodos,  5 especies de eufaúsidos y 11 especies de quetognatos, más de 10, 000 registros curatoriales y 6100  ejemplares a partir de 50 localidades georreferenciadas y más de 300  muestras analizadas.\nPalabras clave: colección, larvas de peces, copépodos, medusas, quetognatos, eufáusidos Reino: 1\nFilo: 1\nClase: 2\nOrden: 4\nFamilia: 18\nGénero: 25\nEspecie: 48",
+            "other_guids": [],
+            "institution_web_address": "http://www.snib.mx/proyectos/cgi-bin/datos2.cgi?Letras=EJ&Numero=8",
+            "id": "17f76205-c629-41d8-afc6-8959f90c8ab3"
+          },
+          "datemodified": "2021-07-27T02:27:10.942999+00:00",
+          "name": "base de datos y colección de distintos grupos del zooplancton de regiones marinas prioritarias de jalisco y colima en el pacífico mexicano (crustáceos)"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "recordsets",
+        "_id": "8dc14464-57b3-423e-8cb0-950ab8f36b6f",
+        "_score": 1,
+        "_source": {
+          "publisher": "4e1beef9-d7c0-4ac0-87df-065bc5a55361",
+          "uuid": "8dc14464-57b3-423e-8cb0-950ab8f36b6f",
+          "dqs": -1,
+          "archivelink": "http://bryophyteportal.org/portal/collections/datasets/dwc/cas_dwc-a.zip",
+          "rights": "cc3 by-nc",
+          "contacts": [
+            {
+              "email": "egbot@asu.edu"
+            },
+            {
+              "first_name": "Debra Trock, Collections Manager, Herbarium",
+              "email": "dtrock@calacademy.org"
+            }
+          ],
+          "indexData": {
+            "idigbio:parent": "4e1beef9-d7c0-4ac0-87df-065bc5a55361",
+            "eml_link": "http://bryophyteportal.org/portal/collections/datasets/dwc/CAS_DwC-A.eml",
+            "contacts": [
+              {
+                "email": "egbot@asu.edu"
+              },
+              {
+                "first_name": "Debra Trock, Collections Manager, Herbarium",
+                "email": "dtrock@calacademy.org"
+              }
+            ],
+            "collection_name": "California Academy of Sciences",
+            "idigbio:uuid": "8dc14464-57b3-423e-8cb0-950ab8f36b6f",
+            "idigbio:etag": "4e9fb98c216afc7ffc4647b7af09be98f397a627",
+            "update": "2015-09-28T21:12:12",
+            "ingest": true,
+            "institution_web_address": "http://research.calacademy.org/botany/collections",
+            "idigbio:siblings": {},
+            "idigbio:recordIds": [
+              "http://bryophyteportal.org/portal/webservices/dwc/d56640e5-4356-4610-8d1e-d5567c193937"
+            ],
+            "link": "http://bryophyteportal.org/portal/collections/datasets/dwc/CAS_DwC-A.zip",
+            "idigbio:dateModified": "2015-09-29T00:21:36.226368",
+            "collection_description": "The herbarium of the California Academy of Sciences (CAS) is the largest collection of vascular plants in the western U.S. It is the sixth largest collection in the United States. Together with the Herbarium of the University of California at Berkeley (UC) the San Francisco Bay area is regarded as a National Resource Center for systematic botany. These two major collections have an informal agreement to avoid duplication, thus providing botanists with a rich and varied resource for research.",
+            "id": "http://bryophyteportal.org/portal/webservices/dwc/d56640e5-4356-4610-8d1e-d5567c193937",
+            "other_guids": [],
+            "logo_url": "http://bryophyteportal.org/portal/images/collicons/CAS.jpg",
+            "data_rights": "CC3 BY-NC"
+          },
+          "etag": "4e9fb98c216afc7ffc4647b7af09be98f397a627",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "emllink": "http://bryophyteportal.org/portal/collections/datasets/dwc/cas_dwc-a.eml",
+          "logourl": "http://bryophyteportal.org/portal/images/collicons/cas.jpg",
+          "recordids": [
+            "http://bryophyteportal.org/portal/webservices/dwc/d56640e5-4356-4610-8d1e-d5567c193937"
+          ],
+          "data": {
+            "eml_link": "http://bryophyteportal.org/portal/collections/datasets/dwc/CAS_DwC-A.eml",
+            "contacts": [
+              {
+                "email": "egbot@asu.edu"
+              },
+              {
+                "first_name": "Debra Trock, Collections Manager, Herbarium",
+                "email": "dtrock@calacademy.org"
+              }
+            ],
+            "collection_name": "California Academy of Sciences",
+            "update": "2015-09-28T21:12:12",
+            "ingest": true,
+            "data_rights": "CC3 BY-NC",
+            "link": "http://bryophyteportal.org/portal/collections/datasets/dwc/CAS_DwC-A.zip",
+            "collection_description": "The herbarium of the California Academy of Sciences (CAS) is the largest collection of vascular plants in the western U.S. It is the sixth largest collection in the United States. Together with the Herbarium of the University of California at Berkeley (UC) the San Francisco Bay area is regarded as a National Resource Center for systematic botany. These two major collections have an informal agreement to avoid duplication, thus providing botanists with a rich and varied resource for research.",
+            "institution_web_address": "http://research.calacademy.org/botany/collections",
+            "other_guids": [],
+            "logo_url": "http://bryophyteportal.org/portal/images/collicons/CAS.jpg",
+            "id": "http://bryophyteportal.org/portal/webservices/dwc/d56640e5-4356-4610-8d1e-d5567c193937"
+          },
+          "datemodified": "2015-09-29T00:21:36.226368+00:00",
+          "name": "california academy of sciences"
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "top_publisher": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 639,
+      "buckets": [
+        {
+          "key": "3b5899c7-f3af-45b7-b992-af5e98b39ecb",
+          "doc_count": 415
+        },
+        {
+          "key": "842a2bb5-d705-4d6c-8401-abf3ca28c05d",
+          "doc_count": 241
+        },
+        {
+          "key": "520dcbb3-f35a-424c-8778-6df11afc9f95",
+          "doc_count": 203
+        },
+        {
+          "key": "96fbcd9e-3c30-41be-865e-7c92fce1bb55",
+          "doc_count": 119
+        },
+        {
+          "key": "efd00b2c-5ade-4a90-a95a-3f9188fcfa71",
+          "doc_count": 69
+        },
+        {
+          "key": "42f2a0a4-5981-4874-88d5-9efb1e8d52c9",
+          "doc_count": 68
+        },
+        {
+          "key": "4e1beef9-d7c0-4ac0-87df-065bc5a55361",
+          "doc_count": 62
+        },
+        {
+          "key": "076c0ff6-65e9-48a5-8e4b-2447936f9a1c",
+          "doc_count": 56
+        },
+        {
+          "key": "e9c875f0-d9c9-426b-bdc8-0999eb1b6deb",
+          "doc_count": 44
+        },
+        {
+          "key": "e3767b6a-ac91-49b9-9e69-bd2fa10caf42",
+          "doc_count": 39
+        }
+      ]
+    }
+  }
+}

--- a/__tests__/mock/search-937ebe7279933ef25dab25be0ac2ec8a.json
+++ b/__tests__/mock/search-937ebe7279933ef25dab25be0ac2ec8a.json
@@ -1,0 +1,4429 @@
+{
+  "timed_out": false,
+  "_shards": {
+    "total": 48,
+    "successful": 48,
+    "failed": 0
+  },
+  "hits": {
+    "total": 337,
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ed59f55e-b53f-4b6a-a38d-451866350792",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.0870167,
+            "lat": 30.7653
+          },
+          "scientificname": "carex gigantea"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c8cf6a5b-695a-4ebb-a95a-111735ad1d18",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.2825,
+            "lat": 29.2522222
+          },
+          "scientificname": "carex fissa var. aristata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4ad7986a-8c1a-4ebd-aeb4-e8c088f89b63",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.9582667,
+            "lat": 30.04235
+          },
+          "scientificname": "carex verrucosa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "599ea6b3-0bb3-41c6-bf88-1d9547beec09",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.0350333,
+            "lat": 29.2097833
+          },
+          "scientificname": "carex comosa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5d8268be-f246-4371-9f3b-3310cbb3ac89",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.27977,
+            "lat": 29.8809
+          },
+          "scientificname": "carex longii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "565ec73f-234a-4431-b528-5e2fce4a16e4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -87.42991,
+            "lat": 32.95601
+          },
+          "scientificname": "carex intumescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "22430ddf-3fd7-4c9a-a78a-114376160235",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.349237,
+            "lat": 29.645619
+          },
+          "scientificname": "carex digitalis var. floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3624f67e-3209-49b6-9b7d-6199444f8cbc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -74.014712,
+            "lat": 18.354311
+          },
+          "scientificname": "carex hamata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cc53f1a7-ccae-4e35-88db-69759607f2d5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.8286111,
+            "lat": 26.4069444
+          },
+          "scientificname": "carex verrucosa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cfc9c527-414c-424a-a2e5-e1058e4b809c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3442,
+            "lat": 29.6451
+          },
+          "scientificname": "carex dasycarpa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a55a3971-beac-49ef-8cd7-3c31ba8e7a98",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.1283889,
+            "lat": 29.3988611
+          },
+          "scientificname": "carex comosa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fb39b82b-7f73-44a2-9959-5fe7db5f63b6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -86.9430556,
+            "lat": 30.8388889
+          },
+          "scientificname": "carex turgescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e0110454-b362-4638-adc7-479f31186b85",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3072222,
+            "lat": 29.4511111
+          },
+          "scientificname": "carex cherokeensis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "864e82ba-fc4d-41da-82d2-febd3d3eea76",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.6990556,
+            "lat": 29.4506944
+          },
+          "scientificname": "carex fissa var. aristata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "88490ce0-5955-4de1-acd5-0735f05538f5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.5833,
+            "lat": 36.6461
+          },
+          "scientificname": "carex appalachica"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b7862b2b-3b60-4a00-b823-1517cdcd6ae6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.986236,
+            "lat": 30.46553
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "22fc05ba-686f-44e0-8838-87dde8244002",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -74.5886111,
+            "lat": 39.9205833
+          },
+          "scientificname": "carex collinsii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f0847781-94b5-4ba9-ac6d-1704fadabcd7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.84016,
+            "lat": 29.28753
+          },
+          "scientificname": "carex gholsonii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cc375381-30d3-4d3c-8b0f-fb09b6f3d6a9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.46186,
+            "lat": 44.00481
+          },
+          "scientificname": "carex pellita"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "15b4cbbe-a383-4ac2-b313-81864c174baf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -88.920943,
+            "lat": 32.326565
+          },
+          "scientificname": "carex socialis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1361356e-abf9-449a-8912-3b2b49510609",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.36551,
+            "lat": 28.54471
+          },
+          "scientificname": "carex godfreyi"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f5f94e60-5082-43d4-aaa6-b3e26836b7c5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.15663,
+            "lat": 32.3997
+          },
+          "scientificname": "carex amphibola"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f09d4036-91ac-4f2b-82e4-589e370b03d5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.97937,
+            "lat": 32.3152
+          },
+          "scientificname": "carex alata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4d66ea24-c633-486e-854b-fab030274f0b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.1059722,
+            "lat": 29.3380833
+          },
+          "scientificname": "carex bromoides"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4f2e05d8-dabe-4742-8ff0-4797040fda8d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.6352778,
+            "lat": 29.2758333
+          },
+          "scientificname": "carex vexans"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0f47091a-cfe9-4792-b443-ef10b15f7351",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.0855278,
+            "lat": 29.3109167
+          },
+          "scientificname": "carex fissa var. aristata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "99ed8490-7f62-44b7-8b6e-8df9b8dede17",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.04486,
+            "lat": 32.42076
+          },
+          "scientificname": "carex kraliana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "34df7753-939f-42e0-8c40-271992b5c106",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.383275,
+            "lat": 40.811747
+          },
+          "scientificname": "carex jamesii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f71a728d-511b-4022-ab44-5032e49dfc23",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3306667,
+            "lat": 29.689
+          },
+          "scientificname": "carex fissa var. aristata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c270467a-364a-415c-83fb-061438d6aa5d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -85.1463889,
+            "lat": 30.4638889
+          },
+          "scientificname": "carex floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "47c054fc-db3e-4937-89fb-062a23000642",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.7683333,
+            "lat": 29.1083333
+          },
+          "scientificname": "carex lupuliformis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1932fbfb-7384-4a8a-8073-e1dae8f35470",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -83.995246,
+            "lat": 38.430697
+          },
+          "scientificname": "carex oligocarpa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c209a5e6-c5c4-4b9e-8fcd-95d14e44c015",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -72.18945,
+            "lat": 42.53241
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c80cef58-1ca5-4edd-891f-76392d8b4960",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.168344,
+            "lat": 32.411758
+          },
+          "scientificname": "carex basiantha"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7fce0c29-176a-49df-a6fc-e8d022ce529e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.349237,
+            "lat": 29.645619
+          },
+          "scientificname": "carex basiantha"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1467231b-30c5-41b6-b8b8-443cbde41265",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.1181667,
+            "lat": 30.8051
+          },
+          "scientificname": "carex tenax"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "62a3a891-46cd-43f1-a650-cdb9919559da",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.44691,
+            "lat": 27.81373
+          },
+          "scientificname": "carex comosa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "83170a54-64b9-454c-99f2-4104e3c5a05d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.04486,
+            "lat": 32.42076
+          },
+          "scientificname": "carex abscondita"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "235c57b4-f0d7-4ad5-a4cd-14bc32171dbb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.9447222,
+            "lat": 29.5458333
+          },
+          "scientificname": "carex digitalis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aaa39ffe-e59e-4061-9d77-c7dfe8376cd8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.97951,
+            "lat": 29.69598
+          },
+          "scientificname": "carex longii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bff9468a-255f-477c-99e2-73593e458194",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.7333333,
+            "lat": 29.3568333
+          },
+          "scientificname": "carex godfreyi"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a41665a4-8945-4d2f-bbc1-89940343fdb9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.6916667,
+            "lat": 29.2736111
+          },
+          "scientificname": "carex bromoides"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a54886cd-ca50-4cae-beb7-8da69d188e74",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -85.11135,
+            "lat": 45.36665
+          },
+          "scientificname": "carex eburnea"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a78c86ba-daf9-4e05-8fca-5eb9df07713a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -74.8122222,
+            "lat": 39.3068333
+          },
+          "scientificname": "carex muehlenbergii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "47263d1f-abce-4397-a885-0c113671255b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.9202778,
+            "lat": 30.6041667
+          },
+          "scientificname": "carex gracilescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6072eb14-8203-4812-8886-4a755da672b5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -85.9275056,
+            "lat": 30.2944222
+          },
+          "scientificname": "carex glaucescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c35ed147-f3b1-41b7-86d3-f586dd975ca4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.9572222,
+            "lat": 29.5466667
+          },
+          "scientificname": "carex stipata var. maxima"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e3071110-8e5c-4589-9dd0-06103f856fa0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.7508333,
+            "lat": 29.5491667
+          },
+          "scientificname": "carex lupuliformis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6de8bafc-4ad5-4a9a-9e9c-08a830a4e922",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.293276,
+            "lat": 29.615246
+          },
+          "scientificname": "carex dasycarpa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "741ec842-d24b-4068-943f-d05040e9f8e3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.58037,
+            "lat": 27.66119
+          },
+          "scientificname": "carex longii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7f01a6fc-673b-4004-a2ae-26c398897d63",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -86.09539,
+            "lat": 42.93547
+          },
+          "scientificname": "carex deflexa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "323f9d29-0165-4dc0-9274-f6306b6a4738",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.97047,
+            "lat": 29.71572
+          },
+          "scientificname": "carex dasycarpa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "03f6da0d-6f40-4e7c-8512-b4a36967d548",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -87.42991,
+            "lat": 32.95601
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "eca812f2-d1ed-48e6-b354-ef1e3bb004cd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.281854,
+            "lat": 32.404194
+          },
+          "scientificname": "carex intumescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "391c3aaf-b5c6-446a-8b51-54517ae6b34a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.59755,
+            "lat": 28.2403667
+          },
+          "scientificname": "carex verrucosa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a799f8a-1d51-4c52-ad39-4983ae74bbf9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.1182333,
+            "lat": 30.8066833
+          },
+          "scientificname": "carex glaucescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8e7d3a8d-addc-4b13-aa05-7adbbe2a989c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -86.7797667,
+            "lat": 30.4513833
+          },
+          "scientificname": "carex glaucescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "db937510-2317-4b95-a161-ee75d03f9f1b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.9175,
+            "lat": 30.6058333
+          },
+          "scientificname": "carex floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e7d4ca44-a7f9-4457-80e4-5a502fb5c174",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.9986111,
+            "lat": 28.5713889
+          },
+          "scientificname": "carex bromoides"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bd278747-c82c-4cee-bb5e-29c00ae657dd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.36807,
+            "lat": 29.63337
+          },
+          "scientificname": "carex striatula"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "57309c9c-375c-4d91-b8f4-f3c5f455d4de",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.0326,
+            "lat": 29.67305
+          },
+          "scientificname": "carex fissa var. aristata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f615c08f-21f4-4e98-932f-f4cb8ea1d7ec",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.6836111,
+            "lat": 29.8333333
+          },
+          "scientificname": "carex gholsonii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "15188f24-05cc-44ed-9c86-bd00d7c66109",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.168344,
+            "lat": 32.411758
+          },
+          "scientificname": "carex pigra"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8d3357b1-a415-4e8d-9e91-48e6196a1b27",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.18005,
+            "lat": 30.17226
+          },
+          "scientificname": "carex verrucosa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4b009d3e-7e69-45c2-955a-d0c7f65158aa",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.97937,
+            "lat": 32.3152
+          },
+          "scientificname": "carex lonchocarpa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "600bf2f0-a912-4b0e-a998-8fe4de22ed2d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.04486,
+            "lat": 32.42076
+          },
+          "scientificname": "carex oxylepis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "05d6f848-e1df-4257-ba14-3da6017498eb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.9572222,
+            "lat": 29.5466667
+          },
+          "scientificname": "carex longii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bbef0e08-ef0a-45ca-a526-a2c88cac39af",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.9677778,
+            "lat": 29.9166667
+          },
+          "scientificname": "carex turgescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "21e3fb71-914c-449a-be8d-9e41bc61a8ef",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.349237,
+            "lat": 29.645619
+          },
+          "scientificname": "carex paeninsulae"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4bd687a5-36cc-41f3-bc53-fd12401937d0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.35935,
+            "lat": 29.6465
+          },
+          "scientificname": "carex digitalis var. floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e857e7e9-ac45-43f3-a876-d038f80eeee6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -83.3233333,
+            "lat": 29.775
+          },
+          "scientificname": "carex gigantea"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c8d890e7-4a20-4579-b3dc-296b487e264a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3587,
+            "lat": 29.6446
+          },
+          "scientificname": "carex oxylepis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c98fae6d-6dbd-4f02-90c2-0576381dde40",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -90.9092639,
+            "lat": 33.4094667
+          },
+          "scientificname": "carex retroflexa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "19fc7957-eda2-4334-b71f-6b17cd3f8943",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -70.65,
+            "lat": 18.8
+          },
+          "scientificname": "carex polysticha"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1dc5eb91-a8d9-4e62-b710-d593395292ab",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.5247222,
+            "lat": 30.3358333
+          },
+          "scientificname": "carex lonchocarpa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d80bfeeb-accd-49d6-9d19-63410f364a36",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.1066667,
+            "lat": 29.3400556
+          },
+          "scientificname": "carex gholsonii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6d8d7172-939e-4163-9a26-8341e3ef1203",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -85.2236111,
+            "lat": 31.0177778
+          },
+          "scientificname": "carex joorii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ade2d8d0-753e-4c3e-848c-06b54f4eb951",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.9213889,
+            "lat": 30.8147222
+          },
+          "scientificname": "carex albicans var. australis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c34b37dc-f368-49fe-b380-0761f5f94038",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.0072,
+            "lat": 29.70116
+          },
+          "scientificname": "carex longii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1ffd6031-18cf-428f-ab0e-a7d86af5fd86",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.35935,
+            "lat": 29.6465
+          },
+          "scientificname": "carex intumescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9e2b8322-a9ef-468a-9ae0-4466d4f1b9f0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3578,
+            "lat": 29.64451
+          },
+          "scientificname": "carex paeninsulae"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "35abc489-6f74-44c4-b305-13e2615c4324",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -85.9297222,
+            "lat": 30.5813889
+          },
+          "scientificname": "carex floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c6711164-d484-4cdc-90be-dc6f651dfeb6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.0326,
+            "lat": 29.67305
+          },
+          "scientificname": "carex longii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d9058344-1f5f-4c49-827b-0144573e07da",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.97738,
+            "lat": 29.69456
+          },
+          "scientificname": "carex longii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b430265e-bf61-4233-90ac-bbbec121cca6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.5041667,
+            "lat": 29.8708333
+          },
+          "scientificname": "carex dasycarpa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "71cb7fcc-32fc-433b-82c8-266a77869832",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.40835,
+            "lat": 29.61374
+          },
+          "scientificname": "carex stipata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "91001e44-484e-4432-bd3e-134043f7304f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.8883333,
+            "lat": 29.1866667
+          },
+          "scientificname": "carex gholsonii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "82a44bab-f3d3-47df-b3ab-cb2414555f75",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.35333,
+            "lat": 28.54616
+          },
+          "scientificname": "carex godfreyi"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d1eea170-49e4-418d-877c-374ee8e5a1a0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -87.41528,
+            "lat": 32.92463
+          },
+          "scientificname": "carex blanda"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "29626304-d789-44ea-af5b-f6a78bf443bf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.168344,
+            "lat": 32.411758
+          },
+          "scientificname": "carex kraliana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a240584-44ff-4333-8567-1ea6f7cffc10",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.15663,
+            "lat": 32.3997
+          },
+          "scientificname": "carex retroflexa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6fef7e4f-6315-4361-b58f-90cc2ec1eb83",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.9986111,
+            "lat": 28.5719444
+          },
+          "scientificname": "carex floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6b3e45dd-d72d-4485-9cbf-17d13f9490a4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.6990556,
+            "lat": 29.4506944
+          },
+          "scientificname": "carex longii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0d94017e-bc50-47be-8486-1b7fd3074d5c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.9647222,
+            "lat": 30.7897222
+          },
+          "scientificname": "carex lonchocarpa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1fe1cac3-a918-4165-81e6-468aa87da86a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.5475,
+            "lat": 29.8705556
+          },
+          "scientificname": "carex alata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f506c370-e31e-4b34-8682-95bc64aec120",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.6738889,
+            "lat": 29.8277778
+          },
+          "scientificname": "carex floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4627a76a-152f-4fb9-969e-56b086d8a029",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.6916667,
+            "lat": 29.2736111
+          },
+          "scientificname": "carex godfreyi"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b3f32aa0-754f-44cd-8c90-ac8c4ba6c093",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -77.4446,
+            "lat": 38.6372833
+          },
+          "scientificname": "carex albolutescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ac2b61bb-26f0-430b-bc26-4a1a8ae1a5fb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.7398333,
+            "lat": 30.749
+          },
+          "scientificname": "carex stipata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ec8dfe26-2fed-403a-b41a-bdfb995af9b1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.04486,
+            "lat": 32.42076
+          },
+          "scientificname": "carex digitalis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f742e6ab-32f0-4325-a4a1-28b095dc72cd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3587,
+            "lat": 29.6446
+          },
+          "scientificname": "carex chapmannii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a238d505-ebf0-44c9-b05e-5e712dde7525",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.9311111,
+            "lat": 30.1722222
+          },
+          "scientificname": "carex verrucosa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3b20f77d-1df4-42a8-b99e-165f282f89c1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.04486,
+            "lat": 32.42076
+          },
+          "scientificname": "carex crinita var. brevicrinis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "327cab5f-1ff2-4977-9440-f42ce2f5c104",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -87.42698,
+            "lat": 32.95601
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "98728ac8-435f-44f5-a5a0-dfcf4167b968",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.87491,
+            "lat": 29.26775
+          },
+          "scientificname": "carex chapmannii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c003b708-86c8-4b33-8a11-ce6a496e1e82",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.35935,
+            "lat": 29.6465
+          },
+          "scientificname": "carex striatula"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "49db6450-861e-432a-bf3c-f0349a401373",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -83.4316,
+            "lat": 35.06092
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4286a498-2a3a-47ed-85ea-a71f9788923a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3587,
+            "lat": 29.6446
+          },
+          "scientificname": "carex striatula"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "be152ba7-c7ef-46b8-aad2-5f5e99acd79a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -74.8122222,
+            "lat": 39.3068333
+          },
+          "scientificname": "carex intumescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "780a2245-01b9-4d7b-856f-6ee4434b7287",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -90.0834167,
+            "lat": 31.55005
+          },
+          "scientificname": "carex flaccosperma"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7ac9f6e5-3972-43df-ac07-6cc3a1a0608d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.9986111,
+            "lat": 28.5713889
+          },
+          "scientificname": "carex fissa var. aristata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f88ba9ce-c87a-4558-90e8-0474c4116dc2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.04486,
+            "lat": 32.42076
+          },
+          "scientificname": "carex retroflexa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d7d8aa26-03e6-41b2-a0b4-c1a43b15b178",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.04486,
+            "lat": 32.42076
+          },
+          "scientificname": "carex retroflexa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6a0d3e37-c8da-4e88-a277-e007fec818ab",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -85.9297222,
+            "lat": 30.5813889
+          },
+          "scientificname": "carex rosea"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4a2b14fb-1e4d-4296-85b7-a8a65296bb62",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3717,
+            "lat": 29.6436
+          },
+          "scientificname": "carex paeninsulae"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "98b10948-7d19-4405-9cb1-e63f4936e16c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.6822778,
+            "lat": 29.8296167
+          },
+          "scientificname": "carex dasycarpa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dfdafe80-1d3f-4aee-bacb-115a86667a64",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.04486,
+            "lat": 32.42076
+          },
+          "scientificname": "carex basiantha"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bc6d8d60-e3af-41c6-88ed-f7afe87466ea",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.7683333,
+            "lat": 29.1166667
+          },
+          "scientificname": "carex paeninsulae"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "761900cb-1051-4d0b-bb30-1dd90a8d9bf2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -83.0666667,
+            "lat": 29.9166667
+          },
+          "scientificname": "carex decomposita"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "569131c6-747c-4db0-a8d8-47f2bb6126b9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.5138889,
+            "lat": 29.5283333
+          },
+          "scientificname": "carex vexans"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2be9e64c-70cd-4d5f-8355-cc75d20a672a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -86.09539,
+            "lat": 42.93547
+          },
+          "scientificname": "carex laxiflora"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "098aee42-dd54-4873-b116-7bcd7545dfbe",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -78.31135,
+            "lat": 39.00782
+          },
+          "scientificname": "carex oligocarpa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "499aa9be-899b-404c-aec0-1571886a72a5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -72.294033,
+            "lat": 18.443286
+          },
+          "scientificname": "carex ekmanii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7815ca17-6b20-44f2-acd5-3d7743ec198e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.9175,
+            "lat": 30.6058333
+          },
+          "scientificname": "carex albicans"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f7dce2c2-181b-49ec-b448-ca6a8df2b525",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.87491,
+            "lat": 29.26775
+          },
+          "scientificname": "carex godfreyi"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e2f5da75-58cc-4ab4-855c-808e8ae838a2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.369024,
+            "lat": 29.631307
+          },
+          "scientificname": "carex floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6330a4e6-e3fd-4a72-97d1-b9e9757045fb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.35935,
+            "lat": 29.6465
+          },
+          "scientificname": "carex basiantha"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dce9233a-7ebc-48ee-a113-6e3b239a87ec",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.9655556,
+            "lat": 30.0438889
+          },
+          "scientificname": "carex verrucosa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cec8cb0b-4869-4d36-89b0-450a0fa9fbe3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.4544444,
+            "lat": 29.7094444
+          },
+          "scientificname": "carex retroflexa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "623974b8-5a11-4b32-ac86-6dc2b6117918",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.9252778,
+            "lat": 30.1813889
+          },
+          "scientificname": "carex elliottii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4d38b57d-0831-4c40-bb04-196fffd919b3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.7,
+            "lat": 29.2265833
+          },
+          "scientificname": "carex lupuliformis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "17f556da-2e75-41fd-950e-8aa7e21f8447",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.1283889,
+            "lat": 29.3988611
+          },
+          "scientificname": "carex comosa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "242381a9-2aba-475b-a19d-ecd0b9b34589",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.4544444,
+            "lat": 29.7094444
+          },
+          "scientificname": "carex basiantha"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2aa25b00-b22c-4047-96fa-c47bacd30e02",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.1120833,
+            "lat": 29.3472778
+          },
+          "scientificname": "carex leptalea"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "049dc504-217a-4eaa-bdc0-bcecf989b383",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.033127,
+            "lat": 29.682572
+          },
+          "scientificname": "carex elliottii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f21eebf7-80e7-4b32-b066-82f56ea1be64",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.51021,
+            "lat": 37.42057
+          },
+          "scientificname": "carex platyphylla"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "04b5f7d9-b720-40c5-ac39-04615861ac2f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -71.27781,
+            "lat": 44.00242
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2f7da5c7-ddc6-4646-ba83-f6923bccb6b7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.35935,
+            "lat": 29.6465
+          },
+          "scientificname": "carex retroflexa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ef443854-0e3c-4481-8cc4-b325f9df7ef9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.986236,
+            "lat": 30.46553
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f72de9f2-5389-46ea-9b00-003933036e5c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.0833333,
+            "lat": 29.0333333
+          },
+          "scientificname": "carex paeninsulae"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cecbdce6-c462-4e12-b426-4c3e4553e84a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -87.2094444,
+            "lat": 30.9619444
+          },
+          "scientificname": "carex floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d06a2e92-167e-454a-8fa9-f35642abc627",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.0397,
+            "lat": 29.2182
+          },
+          "scientificname": "carex debilis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e230cc97-2413-4eea-aeb5-e93ee07808da",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.9833333,
+            "lat": 28.5666667
+          },
+          "scientificname": "carex paeninsulae"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4301ce68-6f53-4e55-bdb4-f1831043181e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.953583,
+            "lat": 29.959467
+          },
+          "scientificname": "carex joorii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9693a4b3-a2da-4bd3-a2ed-dfc54e4202b3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.358,
+            "lat": 29.646
+          },
+          "scientificname": "carex striatula"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0e1a4da9-0b42-4ff3-a4da-89691d4ddabb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.6916667,
+            "lat": 29.2736111
+          },
+          "scientificname": "carex gigantea"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ff45303b-56d7-4cd1-8898-5715808ac4d8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -72.21025,
+            "lat": 42.51142
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a93027b1-2d6c-48e2-9912-2b7fbc8868ef",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3717,
+            "lat": 29.6436
+          },
+          "scientificname": "carex basiantha"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e94cf4a2-13b1-4ec6-af4e-eea254ca97ee",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -85.5477778,
+            "lat": 30.4319444
+          },
+          "scientificname": "carex godfreyi"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bdf47517-1add-4656-b1cb-e27144ede102",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -74.5886111,
+            "lat": 39.9205833
+          },
+          "scientificname": "carex collinsii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b0ff3ce4-19b1-449d-99bd-ccbd2d35b6f0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.0214167,
+            "lat": 29.1962667
+          },
+          "scientificname": "carex vexans"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5b74f298-4eb6-4ef0-ba40-92ab1a5b0c5b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -77.684,
+            "lat": 42.961
+          },
+          "scientificname": "carex pensylvanica"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5c3ba5a1-a0d0-4e92-babf-c9fb2236f543",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.9944444,
+            "lat": 30.0338889
+          },
+          "scientificname": "carex glaucescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0c5249cc-88d9-4dc4-b7e4-5e9e21b6b9ed",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -87.2829722,
+            "lat": 30.5844444
+          },
+          "scientificname": "carex lurida"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "074dd293-24a9-473a-b7fa-9491d5b5bc12",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.0196333,
+            "lat": 29.1937333
+          },
+          "scientificname": "carex striatula"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ab68ff28-d99d-4538-81d6-98491d16668c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.52242,
+            "lat": 37.37482
+          },
+          "scientificname": "carex gynandra"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5b2fec78-99ec-4096-8b48-d445a97846e3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -71.3228,
+            "lat": 44.02657
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ae7d0d9b-4ace-4a91-bd8e-de25ff3b85ff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.6805167,
+            "lat": 29.8295117
+          },
+          "scientificname": "carex godfreyi"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0aa51fc5-d323-4169-b069-aeb7cb3ffe09",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.36807,
+            "lat": 29.63337
+          },
+          "scientificname": "carex dasycarpa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "16fe3c48-f499-4419-ad76-553ed230fb3a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.5614444,
+            "lat": 27.8523611
+          },
+          "scientificname": "carex lupuliformis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "179431bc-c116-4e84-8113-f6965d21219e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.6916667,
+            "lat": 29.2736111
+          },
+          "scientificname": "carex digitalis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b8ed2ec8-6e51-4dbb-9552-f322eade541b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3587,
+            "lat": 29.6446
+          },
+          "scientificname": "carex oxylepis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "50f3631f-9fc3-4a89-be1f-bdd4ab1a37db",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3041,
+            "lat": 29.61061
+          },
+          "scientificname": "carex retroflexa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "34f51a82-8c87-418e-877d-91e1aa1a49a8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -83.3586111,
+            "lat": 29.8266667
+          },
+          "scientificname": "carex verrucosa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2c6b9c08-45c0-4063-991f-98f34fea2dc3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -87.40751,
+            "lat": 32.96651
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "927fb50a-5bab-44a8-8bbc-2b5e644eaf00",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.35935,
+            "lat": 29.6465
+          },
+          "scientificname": "carex paeninsulae"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7d08ebd7-c54b-4805-b2e4-9574b57b8859",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.1387222,
+            "lat": 29.4345278
+          },
+          "scientificname": "carex dasycarpa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ecfb86a6-2917-4c94-99b8-bfdcb590fb93",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.358,
+            "lat": 29.646
+          },
+          "scientificname": "carex digitalis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "213d787c-4495-4db5-9ac4-f7926cee550a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.7183333,
+            "lat": 29.2597222
+          },
+          "scientificname": "carex fissa var. aristata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2d2565ee-55fd-4651-b2f0-a02bafe3800c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -77.684,
+            "lat": 42.961
+          },
+          "scientificname": "carex pedunculata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9592e758-5e52-427f-b2ba-926c052165d2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -71.27781,
+            "lat": 44.00242
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d607f0f0-7605-406e-9401-9060c5cc7b96",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.281854,
+            "lat": 32.404194
+          },
+          "scientificname": "carex tribuloides"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8dbadbf4-bf79-4797-b6c0-b21f3749bfe6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.84016,
+            "lat": 29.28753
+          },
+          "scientificname": "carex godfreyi"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ecf94ff2-ba2f-46d3-bbfa-0d7b1a8437a1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.2897222,
+            "lat": 29.4569444
+          },
+          "scientificname": "carex atlantica ssp. capillacea"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "febe33b4-aeff-44f1-ad68-8d464d9a6ec1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -83.3236111,
+            "lat": 29.7763889
+          },
+          "scientificname": "carex godfreyi"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c8a1182a-508b-4292-8776-adb5ac8ff816",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.3022222,
+            "lat": 28.7222222
+          },
+          "scientificname": "carex floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ce73df39-d5cf-45cf-abc5-dda5e5d309e5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.04486,
+            "lat": 32.42076
+          },
+          "scientificname": "carex striatula"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b5657a33-70d0-4b5a-942d-b8bec3f90261",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.84016,
+            "lat": 29.28753
+          },
+          "scientificname": "carex alata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "05751809-35f4-429f-b7cc-e6f8a8b5dbae",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.35899,
+            "lat": 28.54224
+          },
+          "scientificname": "carex gholsonii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d284b82b-97e9-44ac-a669-7bd0514670ff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.53736,
+            "lat": 37.35024
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "240064ab-4859-4dc0-ab6a-d69ced8a1053",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3587,
+            "lat": 29.6446
+          },
+          "scientificname": "carex chapmannii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e91a1d24-6857-4173-90ab-f1bedf08432c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.649568,
+            "lat": 40.575387
+          },
+          "scientificname": "carex aurea"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fbe2e906-0538-43de-85f3-127638bcd5b7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.369024,
+            "lat": 29.631307
+          },
+          "scientificname": "carex intumescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e66ff5f3-ab79-4dfd-957b-42cc93351191",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3225,
+            "lat": 29.2613889
+          },
+          "scientificname": "carex floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9429e0e2-4926-47a4-8a9d-5a17dae935c3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.0149,
+            "lat": 29.2144667
+          },
+          "scientificname": "carex glaucescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "588063b5-4b75-4c83-bf19-a450ddff988c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -83.44288,
+            "lat": 35.02879
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ff1f8ed3-fc08-42b5-a4d7-9c253ff2a49e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.8349,
+            "lat": 34.0135
+          },
+          "scientificname": "carex seorsa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0713b183-837e-4147-8d9f-9f070e140037",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.08751,
+            "lat": 32.42811
+          },
+          "scientificname": "carex aureolensis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bc1b1522-56cc-4eec-bf9a-d467b67e0e7a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.5758333,
+            "lat": 29.9811111
+          },
+          "scientificname": "carex styloflexa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ed8d8a3d-b8f1-4dcb-8b0c-ee7d4a083713",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -83.1938333,
+            "lat": 30.3461667
+          },
+          "scientificname": "carex digitalis var. floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "adef9d5d-07a1-4c8c-9625-91e27b840293",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.15663,
+            "lat": 32.3997
+          },
+          "scientificname": "carex retroflexa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0c277d55-8058-4f7b-8d0e-ac611dc64fe9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.6355556,
+            "lat": 29.2761111
+          },
+          "scientificname": "carex lupuliformis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1b9af712-c6c9-4c59-ad81-2278781a9c75",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.9436111,
+            "lat": 30.1758333
+          },
+          "scientificname": "carex lonchocarpa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "32ca2292-ee92-4f36-b988-e7cadbae92ea",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.9422222,
+            "lat": 29.5094444
+          },
+          "scientificname": "carex lupuliformis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6cc824cd-0b63-4ec0-9252-d4a04f9df4be",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.0835556,
+            "lat": 29.3034167
+          },
+          "scientificname": "carex gholsonii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e8f5fcdf-b1f2-4508-b8c8-b70861da83fc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.5938611,
+            "lat": 28.9595833
+          },
+          "scientificname": "carex fissa var. aristata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b322abb1-663f-4411-87af-39f7c6588f20",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.5475,
+            "lat": 29.8705556
+          },
+          "scientificname": "carex lupuliformis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d88184b7-cfbc-4cf9-8589-84a508ad81fd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.9175,
+            "lat": 30.6058333
+          },
+          "scientificname": "carex crebriflora"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fe6cc147-9450-4118-b00b-753b01dcf48f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -72.21199,
+            "lat": 42.51229
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cbb5737a-b76e-4b5f-87df-ebda90c88685",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.35935,
+            "lat": 29.6465
+          },
+          "scientificname": "carex oxylepis var. oxylepis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e2b720ec-dd90-405f-a6ff-5bda4680fa89",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3760556,
+            "lat": 29.6001389
+          },
+          "scientificname": "carex fissa var. aristata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "727cf308-746b-4872-8688-8f919fc0186b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3072222,
+            "lat": 29.4511111
+          },
+          "scientificname": "carex basiantha"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5dc5f1d4-bc89-4fbe-8ec7-240e27832f13",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.40865,
+            "lat": 29.61223
+          },
+          "scientificname": "carex longii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4d5eb87d-1000-49d6-875c-169d961a43df",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -83.9486111,
+            "lat": 30.4791667
+          },
+          "scientificname": "carex albicans"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "076975a5-d6a1-4ef9-bab1-cd97ec2cbc5d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.0870167,
+            "lat": 30.7653
+          },
+          "scientificname": "carex glaucescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "be1a36cc-2355-4f74-bdf1-6d910a088f9b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.84016,
+            "lat": 29.28753
+          },
+          "scientificname": "carex cherokeensis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8eac7e65-967e-41e4-a848-313c18c6aca2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.04486,
+            "lat": 32.42076
+          },
+          "scientificname": "carex crebriflora"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "396110fa-722a-4ff9-b83c-4dff343f6d46",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.6958166,
+            "lat": 29.439133
+          },
+          "scientificname": "carex lupuliformis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f064feba-b1c2-435a-b4c3-aaeb300e5d9d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.293276,
+            "lat": 29.615246
+          },
+          "scientificname": "carex dasycarpa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "31402256-c36a-4743-b6af-0edcb3400dd0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.0294167,
+            "lat": 29.1997167
+          },
+          "scientificname": "carex floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a7268352-3d98-4b05-9a9f-ab8321a7e5a7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -88.8774,
+            "lat": 32.26815
+          },
+          "scientificname": "carex floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "46f305e0-8fe2-4ab8-8f20-828d8da848f2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.7395,
+            "lat": 30.7495
+          },
+          "scientificname": "carex lupuliformis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1ad32df6-867a-4c83-83ec-e668b92f1caf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -76.5335278,
+            "lat": 39.1089444
+          },
+          "scientificname": "carex mitchelliana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b7fd6717-7019-4c32-8c93-992c5a25695a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.0312833,
+            "lat": 29.2007167
+          },
+          "scientificname": "carex longii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "90e91662-cef8-4380-a9f6-3e11e3cd8117",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -83.9683333,
+            "lat": 30.1471667
+          },
+          "scientificname": "carex stipata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9e3d2678-4aa8-4c40-a492-648f9896f739",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.26027,
+            "lat": 33.41522
+          },
+          "scientificname": "carex digitalis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1ce134cf-913d-4617-9428-5fed6faf0f03",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -86.5071,
+            "lat": 30.72747
+          },
+          "scientificname": "carex tenax"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "18e3302a-2a6c-40f9-aab4-3a06d0b2eec0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.36551,
+            "lat": 28.54471
+          },
+          "scientificname": "carex dasycarpa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aeabb1b0-7b74-4b82-8989-0c86862af21d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -83.9683333,
+            "lat": 30.1471667
+          },
+          "scientificname": "carex cherokeensis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "74fa2377-6d0f-42cd-8969-ffad2f59dfe1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.375,
+            "lat": 33.41831
+          },
+          "scientificname": "carex planispicata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6b8ced54-ffc5-4f06-bbd2-ece29e54215e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -86.7866667,
+            "lat": 30.9972222
+          },
+          "scientificname": "carex atlantica ssp. atlantica"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "91ce7354-a53c-44de-a72f-b86106415da3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3578,
+            "lat": 29.6445
+          },
+          "scientificname": "carex stipata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "91ccaf11-7634-42fa-a4a2-233098d525a7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.6352778,
+            "lat": 29.2758333
+          },
+          "scientificname": "carex striata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c4665694-4e9f-4951-bc0d-142015bdc14a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -79.6172,
+            "lat": 33.2237
+          },
+          "scientificname": "carex glaucescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "90f1038a-4ec3-456e-8bb5-75384ee017c5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.36551,
+            "lat": 28.54471
+          },
+          "scientificname": "carex floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7aa9252f-11b1-44a6-92c9-0b664df734e2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3587,
+            "lat": 29.6446
+          },
+          "scientificname": "carex bromoides"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a5d4da7e-5cd5-499c-bdeb-798fa2b03cf5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.41002,
+            "lat": 29.61307
+          },
+          "scientificname": "carex retroflexa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e3a66df1-dd2f-4ca0-85c3-8321fb9ed67a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3072222,
+            "lat": 29.4511111
+          },
+          "scientificname": "carex longii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0d61670b-6619-449a-a623-689badf50481",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.7508333,
+            "lat": 29.5491667
+          },
+          "scientificname": "carex verrucosa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4a4a4d8d-180f-4db3-bf05-c3dc884b80aa",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.168344,
+            "lat": 32.411758
+          },
+          "scientificname": "carex blanda"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6ec8972f-c175-451a-bc51-bb0609af653d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.168344,
+            "lat": 32.411758
+          },
+          "scientificname": "carex rosea"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "befd30c0-f055-4331-8705-030f1d95c548",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.1268333,
+            "lat": 29.3716944
+          },
+          "scientificname": "carex longii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a6a52873-8234-4e18-a987-05a4b47dac60",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.46186,
+            "lat": 44.00481
+          },
+          "scientificname": "carex duriuscula"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "711246f6-f1bc-444b-b578-8df5a9ef2983",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.7596667,
+            "lat": 30.7461667
+          },
+          "scientificname": "carex glaucescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5d36861e-f5d6-4c9f-9818-c54683e854b3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.1147222,
+            "lat": 29.4263889
+          },
+          "scientificname": "carex longii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6ffe9ad4-c130-42e8-86ad-29680891f712",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.168344,
+            "lat": 32.411758
+          },
+          "scientificname": "carex planispicata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5f275f70-d0c8-4264-b0dd-31a7ef823380",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3578,
+            "lat": 29.6445
+          },
+          "scientificname": "carex blanda"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "de5ee7df-c3d4-4afa-b886-caf25ece5d65",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -86.28012,
+            "lat": 43.3865
+          },
+          "scientificname": "carex inops"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "94c74404-94b1-4c3b-b58b-e2ec64f204d7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3586,
+            "lat": 29.6451
+          },
+          "scientificname": "carex digitalis var. floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7843fddc-9580-42ce-b8a1-3027d799b6a1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.5041667,
+            "lat": 29.8708333
+          },
+          "scientificname": "carex chapmannii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5ae7f383-773e-4213-8ab0-47cf843d21f1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3587,
+            "lat": 29.6446
+          },
+          "scientificname": "carex oxylepis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "623b4aab-5630-42a0-89e2-65b0fbe949dc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3587,
+            "lat": 29.6446
+          },
+          "scientificname": "carex retroflexa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3d486120-3ad4-452e-a75e-fa72675536c1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.7183333,
+            "lat": 29.2597222
+          },
+          "scientificname": "carex basiantha"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7cf17847-483c-45d5-b58a-34f046ec29db",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.0196333,
+            "lat": 29.1937333
+          },
+          "scientificname": "carex alata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a94c0c63-f71f-46c8-8c51-15b8d05cf5a3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -87.42991,
+            "lat": 32.95601
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bbc9045e-aa42-47a4-bfea-0f6e826dc081",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -83.46432,
+            "lat": 35.06633
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0cb1709d-317f-4bb3-8e1b-2b0deba8c24e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -72.21223,
+            "lat": 42.46628
+          },
+          "scientificname": "carex platyphylla"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "acc2a1c5-6af2-498b-9968-d7371659c9e4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.281854,
+            "lat": 32.404194
+          },
+          "scientificname": "carex aureolensis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b1a9fd5d-3914-47c4-ba69-f83b2aee7b4a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.40811,
+            "lat": 29.61377
+          },
+          "scientificname": "carex comosa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "01c35fa0-ef21-4147-9ba4-937658aa9a6d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -87.2902778,
+            "lat": 30.6805556
+          },
+          "scientificname": "carex nigromarginata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "64ce3ca1-5552-496a-b6f4-3a15280c15d8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -86.025,
+            "lat": 30.7211111
+          },
+          "scientificname": "carex glaucescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bf7ca783-8818-4d1c-95d6-f08428450fa1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.0326,
+            "lat": 29.67305
+          },
+          "scientificname": "carex longii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8625fbb6-8b2d-4b89-b9bd-bd82b562691c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.27362,
+            "lat": 29.52846
+          },
+          "scientificname": "carex gholsonii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6fad734f-826a-4d1c-a751-db5c5e36e40b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.369024,
+            "lat": 29.631307
+          },
+          "scientificname": "carex basiantha"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0ece6407-be88-432c-b5ea-45df4ec88644",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.03246,
+            "lat": 29.6732
+          },
+          "scientificname": "carex fissa var. aristata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d962bc95-feab-469b-8bd4-7a83e9776ab0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.168344,
+            "lat": 32.411758
+          },
+          "scientificname": "carex styloflexa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "440c0e01-0614-45f8-aabe-dfb5b8ad3979",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3578,
+            "lat": 29.64451
+          },
+          "scientificname": "carex bromoides"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f64f919c-2457-44f5-99dc-d1206ad3defa",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.0312833,
+            "lat": 29.2007167
+          },
+          "scientificname": "carex stipata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "abb45fe5-154a-49c8-af7c-a4a7a274c45b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.9625,
+            "lat": 30.5483333
+          },
+          "scientificname": "carex mitchelliana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ac72387f-8b59-4987-a7e3-332a37f1cea8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.3144167,
+            "lat": 29.3121111
+          },
+          "scientificname": "carex lupuliformis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bf53deb5-e0d3-4b9f-a4d3-96ccd25eb520",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.53374,
+            "lat": 37.37009
+          },
+          "scientificname": "carex digitalis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2c4bb247-f39d-499e-b37a-7cf20b83e421",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -86.7238889,
+            "lat": 30.9138889
+          },
+          "scientificname": "carex lonchocarpa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "190edb62-e88e-43c4-bf35-100a36da44c0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.358,
+            "lat": 29.646
+          },
+          "scientificname": "carex digitalis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "afd52eb1-96cf-4ad1-9d1f-49a79fd3591f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.27977,
+            "lat": 29.8809
+          },
+          "scientificname": "carex albolutescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b0c69ed5-dbfb-4983-a3fb-b43ba4aef8d1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -87.2094444,
+            "lat": 30.9619444
+          },
+          "scientificname": "carex atlantica ssp. atlantica"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a40dcb59-705d-4526-961c-e5ef545e0638",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3586,
+            "lat": 29.6451
+          },
+          "scientificname": "carex basiantha"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "05007afe-e8ae-481b-ba04-672f487439b4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.5987167,
+            "lat": 28.9005
+          },
+          "scientificname": "carex godfreyi"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "383b99b6-0ae3-43b6-aa8b-d2f5e7b740ad",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.9202778,
+            "lat": 30.6041667
+          },
+          "scientificname": "carex albicans"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "57cda694-e41a-4940-8170-22a6996d1ce4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82,
+            "lat": 29.2122167
+          },
+          "scientificname": "carex blanda"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "63e006cc-2e69-4696-8e43-7429b350fb74",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.26027,
+            "lat": 33.41522
+          },
+          "scientificname": "carex striatula"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "32915a74-23ed-4058-ad16-a62e186d3ef4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -86.09539,
+            "lat": 42.93547
+          },
+          "scientificname": "carex pensylvanica"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "95b1efdd-5507-4335-858b-76b45d25e0f2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.7115,
+            "lat": 30.5446111
+          },
+          "scientificname": "carex glaucescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9800367e-21e2-44e6-8e07-5cd5c4b9d70a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.40685,
+            "lat": 29.61218
+          },
+          "scientificname": "carex retroflexa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ae8a7443-8ecd-41b5-8e3c-c336c6c355e6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -87.40751,
+            "lat": 32.96651
+          },
+          "scientificname": "carex intumescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "33431464-e961-4085-a8e9-eaca9df93f08",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.383275,
+            "lat": 40.811747
+          },
+          "scientificname": "carex oligosperma"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "77bd1db5-b93b-493f-ba0e-93314c9dcdb2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.5619167,
+            "lat": 30.3786833
+          },
+          "scientificname": "carex glaucescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "40383bdc-e918-4906-92fa-82122b560a5e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.6916667,
+            "lat": 29.2736111
+          },
+          "scientificname": "carex dasycarpa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0f5cd263-7772-4bf8-a9b8-ec9ae1e6c694",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.9183333,
+            "lat": 28.7597222
+          },
+          "scientificname": "carex stipata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e6e3ed8d-368b-4b6b-ba03-c576f05a4bb8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.5758333,
+            "lat": 29.9811111
+          },
+          "scientificname": "carex corrugata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "35fd15f4-5628-4309-b7fe-d40bacdc48bc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.15663,
+            "lat": 32.3997
+          },
+          "scientificname": "carex cherokeensis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b89d0700-1a78-4696-85b6-7e00f30517fd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -88.98965,
+            "lat": 32.46024
+          },
+          "scientificname": "carex reniformis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e1b03bcc-719b-468e-89ce-167fa8963918",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.4777778,
+            "lat": 30.3575
+          },
+          "scientificname": "carex chapmannii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "198d8e56-0592-4576-ae5d-1af424fdf211",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.29105,
+            "lat": 29.51456
+          },
+          "scientificname": "carex aureolensis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1ba06c68-db66-4dc6-8d45-e11017b43d1f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -77.684,
+            "lat": 42.961
+          },
+          "scientificname": "carex woodii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "234cb0ca-e8cb-4501-a6a2-fab0c345fd07",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -74.8122222,
+            "lat": 39.3068333
+          },
+          "scientificname": "carex intumescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aff520aa-f319-49ee-b815-55dabd806c59",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.9647222,
+            "lat": 30.7897222
+          },
+          "scientificname": "carex elliottii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4bf63c7a-980d-4d9e-8aea-75ba560da485",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -86.09539,
+            "lat": 42.93547
+          },
+          "scientificname": "carex tonsa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8420d6c1-bc9c-4508-a819-6a46e93ceef3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -86.28012,
+            "lat": 43.3865
+          },
+          "scientificname": "carex muehlenbergii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "349ebcea-c728-4b44-8bc1-72e6409039ff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.168344,
+            "lat": 32.411758
+          },
+          "scientificname": "carex floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cbf2bd0b-d4df-4495-a701-bee19119027c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.7183333,
+            "lat": 29.2597222
+          },
+          "scientificname": "carex lupuliformis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d779f66c-921a-4daf-80b5-01d0f6459e1e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.8883333,
+            "lat": 29.1866667
+          },
+          "scientificname": "carex gholsonii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "44afc41f-7965-47aa-95d3-e6e5924f7e9d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3041,
+            "lat": 29.61061
+          },
+          "scientificname": "carex blanda"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dc677c34-80c8-42a0-9bc0-6b6e3a0dfaa9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -87.44094,
+            "lat": 32.89671
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a50489cf-bbaa-4a72-83b7-d5292d3135b2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3586,
+            "lat": 29.6451
+          },
+          "scientificname": "carex floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a2084c47-c09d-43bc-9f49-faae654cf4a8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.96965,
+            "lat": 29.71967
+          },
+          "scientificname": "carex floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fcb5f9c0-6121-475b-941e-76ba1b59d8b2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3717,
+            "lat": 29.6436
+          },
+          "scientificname": "carex dasycarpa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e9f99185-8510-4779-ba63-04b005b7e053",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3399167,
+            "lat": 29.5955556
+          },
+          "scientificname": "carex retroflexa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fd2cc4da-00fb-4ec7-993c-c203e86206b4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.5608333,
+            "lat": 30.1886111
+          },
+          "scientificname": "carex chapmannii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6f863cf5-2435-4df7-9417-3bfb6c6c89de",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.45324,
+            "lat": 27.82018
+          },
+          "scientificname": "carex vexans"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6585191d-ebe5-4c6a-bc35-82eb7da5ea6e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.9988889,
+            "lat": 30.0063889
+          },
+          "scientificname": "carex joorii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "395e7f2a-4015-42dd-a0a6-f2e2786faec0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3850333,
+            "lat": 30.0411667
+          },
+          "scientificname": "carex verrucosa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c86ec4cf-fa8f-4b09-902f-55d7a072599b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -71.3735,
+            "lat": 42.4294722
+          },
+          "scientificname": "carex vulpinoidea"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "78a3e137-5b08-4038-b0ad-1292c5813bea",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -71.45205,
+            "lat": 44.01744
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "734236f2-47cf-421f-a9d5-ceb648c5f133",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.04486,
+            "lat": 32.42076
+          },
+          "scientificname": "carex joorii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "696e794e-0fd6-4011-a52d-51e840fe259b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -72.17526,
+            "lat": 42.54023
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a570cce4-dd32-4da9-830b-92f77716608e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.87491,
+            "lat": 29.26775
+          },
+          "scientificname": "carex gholsonii"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3d774295-b806-442d-9ba5-9acb28c3fc72",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.359,
+            "lat": 29.644
+          },
+          "scientificname": "carex digitalis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7e44d153-02c5-48cf-a93c-974d55aaa1eb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -94.474164,
+            "lat": 42.00842
+          },
+          "scientificname": "carex blanda"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fa105b36-28ec-4f2e-9fb4-53ac5c61b329",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -88.71904,
+            "lat": 32.34856
+          },
+          "scientificname": "carex breviculmis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "19a15a8b-8399-4b26-84c4-995d494de519",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.4544444,
+            "lat": 29.7094444
+          },
+          "scientificname": "carex bromoides"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3793f910-074f-4e4a-ac12-a4d165bd4092",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.8425,
+            "lat": 29.285
+          },
+          "scientificname": "carex basiantha"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b2457a3a-82f6-4d9a-94d7-3042af6d8126",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -83.4316,
+            "lat": 35.06092
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "48d839db-f699-4fdd-8969-91c33b27321e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.35899,
+            "lat": 28.54224
+          },
+          "scientificname": "carex leptalea"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c4db8e6a-76e7-46f9-b82a-9aae76c43f6e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.0072,
+            "lat": 29.70116
+          },
+          "scientificname": "carex atlantica ssp. capillacea"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ce0b95e4-ac24-481f-b3c8-1af1cfd47d77",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.0297,
+            "lat": 29.67501
+          },
+          "scientificname": "carex atlantica ssp. capillacea"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d4d7bcfc-73e4-4e7d-b2d3-049b983be7a7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3587,
+            "lat": 29.6446
+          },
+          "scientificname": "carex intumescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0425adcf-58a9-4e3e-9e56-f497494290ba",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -83.9965667,
+            "lat": 30.4294667
+          },
+          "scientificname": "carex glaucescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6c7b21e9-d02c-42d7-aed2-75c04899a4d3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.5475,
+            "lat": 29.8705556
+          },
+          "scientificname": "carex alata"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5465e874-5ac4-4ec5-bc45-f9bf9b53c87d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3586944,
+            "lat": 29.6439722
+          },
+          "scientificname": "carex debilis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1c0bdb5e-d40f-4189-86e2-9f98e6072de7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.40614,
+            "lat": 29.61168
+          },
+          "scientificname": "carex basiantha"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d5a4f9a9-1131-4ea5-bdb9-d4e6cb83165d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.281854,
+            "lat": 32.404194
+          },
+          "scientificname": "carex bromoides"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e7b59caa-eb97-4d3e-807c-72746b9758ca",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.7508333,
+            "lat": 29.5491667
+          },
+          "scientificname": "carex granularis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "57f5dc6b-2a0c-4d0e-b54a-20d2bcbda9f5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.5987167,
+            "lat": 28.9005
+          },
+          "scientificname": "carex godfreyi"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "13fc2f7e-7b1e-4e41-b815-32892180a932",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.3587,
+            "lat": 29.6446
+          },
+          "scientificname": "carex intumescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "160843c9-9278-4acf-9dcb-de2df20ab87d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.03745,
+            "lat": 29.2166333
+          },
+          "scientificname": "carex dasycarpa"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "087c5de9-5c2f-41cf-a014-cdf08b1e4a9b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.4882222,
+            "lat": 28.8770278
+          },
+          "scientificname": "carex lupuliformis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fb48c612-44eb-4220-905c-77b0cfb284e5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.40811,
+            "lat": 29.61377
+          },
+          "scientificname": "carex lupuliformis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "445585c5-c2e7-4842-92fd-cafec98f332d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -83.9708333,
+            "lat": 30.11
+          },
+          "scientificname": "carex hyalinolepis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "77af82fa-a6d0-4faa-814c-6cfdba4b972c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.41002,
+            "lat": 29.61307
+          },
+          "scientificname": "carex godfreyi"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8fd10245-b020-4c49-bfde-70fb9ae71eb1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.98682,
+            "lat": 29.69876
+          },
+          "scientificname": "carex floridana"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "92b96393-2172-4d56-b299-ea63146d4dd5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -85.4191667,
+            "lat": 35.5833333
+          },
+          "scientificname": "carex glaucescens"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "973ac99f-358b-4fd5-b611-d4852df2aaf7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -85.0178333,
+            "lat": 30.4427222
+          },
+          "scientificname": "carex cherokeensis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "88e32309-af22-4e07-907c-1201534ff438",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -77.684,
+            "lat": 42.961
+          },
+          "scientificname": "carex communis"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d0359fe7-b805-4ca6-9d00-287e435e9799",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.019065,
+            "lat": 29.176772
+          },
+          "scientificname": "carex godfreyi"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5eb4a44c-edbd-4722-8a38-d580492beb20",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -89.04486,
+            "lat": 32.42076
+          },
+          "scientificname": "carex amphibola"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6e5251c6-4f48-4f64-93a0-e8d60c562f19",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -87.44094,
+            "lat": 32.89671
+          },
+          "scientificname": "carex"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "95aaca44-07f1-4033-bcc8-e13563a44efa",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -88.904238,
+            "lat": 32.334263
+          },
+          "scientificname": "carex dasycarpa"
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "gstyle": {
+      "doc_count": 137283704,
+      "f": {
+        "doc_count": 341,
+        "style": {
+          "doc_count_error_upper_bound": 0,
+          "sum_other_doc_count": 263,
+          "buckets": [
+            {
+              "key": "carex",
+              "doc_count": 22
+            },
+            {
+              "key": "carex floridana",
+              "doc_count": 16
+            },
+            {
+              "key": "carex longii",
+              "doc_count": 14
+            },
+            {
+              "key": "carex dasycarpa",
+              "doc_count": 13
+            },
+            {
+              "key": "carex glaucescens",
+              "doc_count": 13
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/__tests__/mock/search-94ca9a8ee61213aed6e58c60383129fa.json
+++ b/__tests__/mock/search-94ca9a8ee61213aed6e58c60383129fa.json
@@ -1,0 +1,2358 @@
+{
+  "timed_out": false,
+  "_shards": {
+    "total": 48,
+    "successful": 48,
+    "failed": 0
+  },
+  "hits": {
+    "total": 5433124,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cc7d3d7f-1691-424b-931d-1c4556041890",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          "aaronsohnia"
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4d6552a4-2d7a-4d2d-8218-49be12048b4c",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          "aaronsohnia"
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8b5cb0f1-3558-415d-aba2-1dcecf038b3c",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          "aaronsohnia"
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7de2461d-ad3f-44d4-8d9e-5ec608842463",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          "aaronsohnia"
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3bc61a88-f365-4e81-812f-098c4a608f76",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          "aaronsohnia"
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a7d23de7-bf17-4bca-a304-e9212c876289",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          "aaronsohnia"
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e375d7a3-3c64-4569-8451-22c588140bbc",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          "aaronsohnia"
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "90e585a9-2f99-40b9-a246-1dc0fbf60983",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          "aaronsohnia"
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "54300624-0e32-4a14-b8b2-8aee92d45e30",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          "aaronsohnia"
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "73f9412f-d306-4496-a555-f08d4ce87b1b",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          "aaronsohnia"
+        ]
+      }
+    ]
+  },
+  "aggregations": {
+    "rs": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+          "doc_count": 516260
+        },
+        {
+          "key": "fc014977-92f7-47fd-92d7-b609c39d8212",
+          "doc_count": 388020
+        },
+        {
+          "key": "a6eee223-cf3b-4079-8bb2-b77dad8cae9d",
+          "doc_count": 356755
+        },
+        {
+          "key": "36d35b23-113e-4633-90ec-19d265a3b5f6",
+          "doc_count": 275137
+        },
+        {
+          "key": "5386d272-06c6-4027-b5d5-d588c2afe5e5",
+          "doc_count": 246119
+        },
+        {
+          "key": "fabcdc12-9d29-4bd2-912b-176e71818144",
+          "doc_count": 242650
+        },
+        {
+          "key": "765aa536-b79e-4794-a0d2-40a160233922",
+          "doc_count": 135352
+        },
+        {
+          "key": "f778ecc0-8371-49d5-9ab1-9d75f0b76fad",
+          "doc_count": 122370
+        },
+        {
+          "key": "7450a9e3-ef95-4f9e-8260-09b498d2c5e6",
+          "doc_count": 100046
+        },
+        {
+          "key": "a4e6033a-d1eb-46d3-869d-7c0328f09aa7",
+          "doc_count": 96050
+        },
+        {
+          "key": "70abba3e-5f2a-4276-87f3-261706e24453",
+          "doc_count": 95094
+        },
+        {
+          "key": "26f7cbde-fbcb-4500-80a9-a99daa0ead9d",
+          "doc_count": 91665
+        },
+        {
+          "key": "2d7910d9-7f63-4bde-918a-9e0265f1c245",
+          "doc_count": 85334
+        },
+        {
+          "key": "e6ccc2bd-9451-4802-8a51-8640d9f09793",
+          "doc_count": 76002
+        },
+        {
+          "key": "c55ac6d0-180d-41be-829a-e82898c5ca54",
+          "doc_count": 64928
+        },
+        {
+          "key": "65536dcd-7bb2-44e5-af3f-4a13f08e53d0",
+          "doc_count": 57422
+        },
+        {
+          "key": "db6c3db9-1e6d-4def-af29-33aa0339bfa9",
+          "doc_count": 56748
+        },
+        {
+          "key": "d7b285d4-2643-45ee-9302-b0c3d51dda5c",
+          "doc_count": 56042
+        },
+        {
+          "key": "4e3043a6-d48a-4a35-b5fb-f67d50cbc158",
+          "doc_count": 54246
+        },
+        {
+          "key": "953b0329-c3e4-4816-a038-7afbd2bb2547",
+          "doc_count": 49710
+        },
+        {
+          "key": "4523e216-ee13-4b15-a3f7-a6fd56431604",
+          "doc_count": 44997
+        },
+        {
+          "key": "3c9420c9-c4a8-47dc-88b7-b5638ca5e716",
+          "doc_count": 43660
+        },
+        {
+          "key": "ba042ffa-8175-4a47-8eb1-08b4d6319ccf",
+          "doc_count": 42353
+        },
+        {
+          "key": "a2b36fdf-50bc-44ef-a6a4-ca6dc1dc148a",
+          "doc_count": 41695
+        },
+        {
+          "key": "d82fa49b-915e-4aa8-acc6-51df3d431884",
+          "doc_count": 41348
+        },
+        {
+          "key": "f0174bc9-0cca-450e-a941-655d80040139",
+          "doc_count": 40218
+        },
+        {
+          "key": "72d4c3c7-3413-4588-a803-e1a63e0d7c6c",
+          "doc_count": 38678
+        },
+        {
+          "key": "beab5209-9628-4d4d-851e-2bc9bb1a0105",
+          "doc_count": 38447
+        },
+        {
+          "key": "9e5aede6-bee5-4a3d-a255-513771b20035",
+          "doc_count": 36728
+        },
+        {
+          "key": "40250f4d-7aa6-4fcc-ac38-2868fa4846bd",
+          "doc_count": 33842
+        },
+        {
+          "key": "bf1fee2d-f760-4068-b8e6-d1db63ce434c",
+          "doc_count": 33365
+        },
+        {
+          "key": "205fa34c-2fcb-4492-b992-972b18560f6f",
+          "doc_count": 31488
+        },
+        {
+          "key": "e2def7e2-1455-4856-9823-6d3738417d24",
+          "doc_count": 31078
+        },
+        {
+          "key": "d53132e6-7997-4850-8607-4fec5a3f9c3f",
+          "doc_count": 30487
+        },
+        {
+          "key": "3027c437-cdb3-4072-9410-5a46ec3b1fd5",
+          "doc_count": 28797
+        },
+        {
+          "key": "e60301d9-9b40-483f-92de-065769b9d3dd",
+          "doc_count": 27843
+        },
+        {
+          "key": "8b0c1f4b-9de7-4521-98c2-983e0bfd33c7",
+          "doc_count": 27754
+        },
+        {
+          "key": "7c1a1d78-aeaa-4501-87e1-83eceb8ca8ea",
+          "doc_count": 27253
+        },
+        {
+          "key": "6cc31636-c3e5-4887-bbee-2e56621771c4",
+          "doc_count": 25372
+        },
+        {
+          "key": "0dab1fc7-ca99-456b-9985-76edbac003e0",
+          "doc_count": 25129
+        },
+        {
+          "key": "e5cb850f-de98-45ce-9872-95262732809f",
+          "doc_count": 24733
+        },
+        {
+          "key": "0fd6e726-6828-4f62-ba8d-6ec316fe0b52",
+          "doc_count": 24533
+        },
+        {
+          "key": "275a8cea-1c34-4580-a030-4f58e680605c",
+          "doc_count": 23487
+        },
+        {
+          "key": "781fd581-7b93-471e-a025-413e4bcd8491",
+          "doc_count": 23297
+        },
+        {
+          "key": "96662fa9-ff60-495b-912a-284f3b98ed72",
+          "doc_count": 23092
+        },
+        {
+          "key": "d7540872-1c53-48ac-a617-2d0739eadcbd",
+          "doc_count": 22720
+        },
+        {
+          "key": "215eeaf0-0a88-409e-a75d-aec98b7c41eb",
+          "doc_count": 22469
+        },
+        {
+          "key": "0583609b-202f-40d0-8021-4c019635d4c9",
+          "doc_count": 21297
+        },
+        {
+          "key": "d06a16c6-f540-40a8-9e92-876ad1955d03",
+          "doc_count": 21105
+        },
+        {
+          "key": "f1cf8457-237e-487a-9d13-5de7d81b9de4",
+          "doc_count": 20960
+        },
+        {
+          "key": "9151bc4c-8505-4b22-a16b-9dbf337535fa",
+          "doc_count": 20439
+        },
+        {
+          "key": "e4ff51ba-5007-4c40-9a86-e8c6f4db77b7",
+          "doc_count": 18984
+        },
+        {
+          "key": "b531ea59-025d-4c29-9d23-99ae75bcd55f",
+          "doc_count": 18742
+        },
+        {
+          "key": "b667cef4-96fe-42e8-a9fa-6298aa80bb14",
+          "doc_count": 18652
+        },
+        {
+          "key": "f8866892-56a0-4f46-9583-6719d42d81de",
+          "doc_count": 18520
+        },
+        {
+          "key": "0ed8a17e-149b-4cbe-8383-7676da92ea1c",
+          "doc_count": 18281
+        },
+        {
+          "key": "b6ec6203-09db-4d6e-8cba-ee4bebd2934c",
+          "doc_count": 18186
+        },
+        {
+          "key": "a7228b3f-982a-4518-a761-b19b00e14844",
+          "doc_count": 17854
+        },
+        {
+          "key": "2c00c297-9ebd-498a-b701-d3ebde4b49f3",
+          "doc_count": 17590
+        },
+        {
+          "key": "a6e02b78-6fc6-4cb6-bb87-8d5a443f2c2a",
+          "doc_count": 17095
+        },
+        {
+          "key": "e7301984-8b46-4932-b670-21c231ae4c01",
+          "doc_count": 16972
+        },
+        {
+          "key": "62a36329-6b82-48bc-94d8-1cb9adb91ab5",
+          "doc_count": 16809
+        },
+        {
+          "key": "59efaf7d-60b5-4295-abb3-27ba42eb5231",
+          "doc_count": 16560
+        },
+        {
+          "key": "6258d160-a7aa-4937-bce3-3538eebd374f",
+          "doc_count": 16329
+        },
+        {
+          "key": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "doc_count": 16206
+        },
+        {
+          "key": "8057906f-17c9-4e25-b173-4e7fb938078b",
+          "doc_count": 15580
+        },
+        {
+          "key": "710a8a54-783c-41aa-ad9a-05544cdb4c55",
+          "doc_count": 15577
+        },
+        {
+          "key": "b9ab58cf-785e-44a7-a873-1966e14a6715",
+          "doc_count": 15491
+        },
+        {
+          "key": "253f90be-3b94-469c-820c-cb727b85bdd4",
+          "doc_count": 15483
+        },
+        {
+          "key": "5e29dbcc-ce45-4f05-9bb0-212baffa8932",
+          "doc_count": 15033
+        },
+        {
+          "key": "c2767dde-1315-4d78-abf9-8e098dd588ab",
+          "doc_count": 15022
+        },
+        {
+          "key": "83ad8494-136b-485a-87d4-8ce01dd6a8de",
+          "doc_count": 14920
+        },
+        {
+          "key": "c569e530-7322-40b8-9b66-1e0ed96fefcb",
+          "doc_count": 14024
+        },
+        {
+          "key": "aca26f37-3ec8-4e9e-b927-50b4944a0096",
+          "doc_count": 13734
+        },
+        {
+          "key": "8ec76c75-a673-4682-bfde-00a18bc12794",
+          "doc_count": 13342
+        },
+        {
+          "key": "0bc60df1-a162-4173-9a73-c51e09031843",
+          "doc_count": 13257
+        },
+        {
+          "key": "71bf994a-3af5-484d-983b-b146aa1512d1",
+          "doc_count": 12913
+        },
+        {
+          "key": "b2b294ed-1742-4479-b0c8-a8891fccd7eb",
+          "doc_count": 12649
+        },
+        {
+          "key": "4ac45d7e-c6e5-45ea-a0e0-aea6ebe2afcf",
+          "doc_count": 12581
+        },
+        {
+          "key": "f3ee2661-268a-48dc-b931-b9429d5674f4",
+          "doc_count": 12106
+        },
+        {
+          "key": "844875a9-9927-48a5-90b4-76c5f227f145",
+          "doc_count": 11977
+        },
+        {
+          "key": "5835f642-2560-4e3e-9c25-741a12cc3fe8",
+          "doc_count": 11871
+        },
+        {
+          "key": "b88033dd-5dbb-4377-b374-2210f32ece16",
+          "doc_count": 11838
+        },
+        {
+          "key": "dd232f5c-7f53-48ec-9bb7-7205702c3dc8",
+          "doc_count": 11818
+        },
+        {
+          "key": "e36691ec-c4f8-4bec-b331-b48ffa82ff49",
+          "doc_count": 11776
+        },
+        {
+          "key": "ddef79ec-043c-4027-9876-c4a298feff6d",
+          "doc_count": 11688
+        },
+        {
+          "key": "237d30ca-7675-4840-b4fd-96771fabf518",
+          "doc_count": 11666
+        },
+        {
+          "key": "e185415c-15c4-4612-89f3-27cfebbca0d9",
+          "doc_count": 11472
+        },
+        {
+          "key": "ff89320d-e232-4edd-9cdd-4b6acc672ad3",
+          "doc_count": 11140
+        },
+        {
+          "key": "d78d13a7-3852-4244-ba34-86ef5765fa99",
+          "doc_count": 10816
+        },
+        {
+          "key": "341da8fa-d049-46ee-9be8-463043f26fa7",
+          "doc_count": 10470
+        },
+        {
+          "key": "f84d528a-7d08-467e-b532-ace707316f1d",
+          "doc_count": 10208
+        },
+        {
+          "key": "3e5a9f79-297b-497d-84eb-97e0d1e5c2bf",
+          "doc_count": 9981
+        },
+        {
+          "key": "20360fae-574a-4d63-b9f6-47b1cc07fd22",
+          "doc_count": 9785
+        },
+        {
+          "key": "3998ec8d-4aae-46db-9370-179c19b69356",
+          "doc_count": 9418
+        },
+        {
+          "key": "264c48ec-8636-451f-a7e0-74131bc6f84c",
+          "doc_count": 9297
+        },
+        {
+          "key": "b5b79eb9-c270-4427-9cd6-43bd6c4b73ab",
+          "doc_count": 9263
+        },
+        {
+          "key": "ec4acc26-ff1b-4131-a1df-a950fe31bb0e",
+          "doc_count": 9171
+        },
+        {
+          "key": "948a3370-bdb4-46cb-a047-c777a76ae420",
+          "doc_count": 9164
+        },
+        {
+          "key": "9b725e43-93c9-423b-adf8-a11d08a83d13",
+          "doc_count": 9149
+        },
+        {
+          "key": "207b6c64-7b58-4d6a-816d-bc759c27eafc",
+          "doc_count": 8950
+        },
+        {
+          "key": "05c029de-734c-450a-a41a-56061b7ebb18",
+          "doc_count": 8897
+        },
+        {
+          "key": "d8862887-ff5c-4caa-9d61-f1958887ebc1",
+          "doc_count": 8837
+        },
+        {
+          "key": "d2217bca-3a93-4407-bb56-087afa000cbc",
+          "doc_count": 8638
+        },
+        {
+          "key": "c5b7dae8-b483-4742-9954-d7f9226daa34",
+          "doc_count": 8347
+        },
+        {
+          "key": "471835cc-feb6-4d05-a8d1-62ce71399326",
+          "doc_count": 8342
+        },
+        {
+          "key": "364a24d9-d4a8-4e0b-8e50-07b90f844548",
+          "doc_count": 7935
+        },
+        {
+          "key": "46c11153-2154-495d-89d2-7cdef6425cdb",
+          "doc_count": 7741
+        },
+        {
+          "key": "7cb4bbe6-d9b7-4cdb-b3bf-97a971487f75",
+          "doc_count": 7718
+        },
+        {
+          "key": "ba54ba45-caac-4708-a389-ac94642976f8",
+          "doc_count": 7515
+        },
+        {
+          "key": "76fd34da-4892-4821-858d-98fe9e28ba8b",
+          "doc_count": 7344
+        },
+        {
+          "key": "e5f57bb0-07ec-4405-90b6-dc89647a1cb5",
+          "doc_count": 7323
+        },
+        {
+          "key": "1527b668-b797-42be-94d3-0058e1393e94",
+          "doc_count": 7280
+        },
+        {
+          "key": "244ee82a-438c-4e77-a2ce-4e2af9ddbe4d",
+          "doc_count": 7140
+        },
+        {
+          "key": "de5203b1-5a44-4010-948c-b7d33f46397a",
+          "doc_count": 6992
+        },
+        {
+          "key": "f31a5f98-efd3-476a-9627-de3add582acd",
+          "doc_count": 6736
+        },
+        {
+          "key": "ca8f64d0-40d2-452a-b1b8-713a3861fe69",
+          "doc_count": 6731
+        },
+        {
+          "key": "7644703a-ce24-4f7b-b800-66ddf8812f86",
+          "doc_count": 6644
+        },
+        {
+          "key": "14f8f83f-7a0c-458c-b6d5-6da7dc8eaa0a",
+          "doc_count": 6561
+        },
+        {
+          "key": "82672123-feef-4b1c-9ee3-9a681204ae76",
+          "doc_count": 6517
+        },
+        {
+          "key": "664bd710-8791-4dba-a3b6-000a1b140951",
+          "doc_count": 6515
+        },
+        {
+          "key": "703b5bdc-4581-47e3-b4b6-e6f32d0eec54",
+          "doc_count": 6479
+        },
+        {
+          "key": "be31dfd1-c721-4697-8ee0-f7043c070810",
+          "doc_count": 6350
+        },
+        {
+          "key": "5baa1d0c-cfc0-4c89-8e3e-7a49359b0caa",
+          "doc_count": 6285
+        },
+        {
+          "key": "09a3fcf2-55a1-488f-aa42-f103bdce0536",
+          "doc_count": 6111
+        },
+        {
+          "key": "910eadc8-8131-428c-b28a-91d0e2890f1d",
+          "doc_count": 5923
+        },
+        {
+          "key": "0c94911f-6f18-40a2-a0c3-95c845bc41d7",
+          "doc_count": 5877
+        },
+        {
+          "key": "005ac06a-3d9a-46ad-ac3c-062aaa5b7059",
+          "doc_count": 5784
+        },
+        {
+          "key": "120d557c-c5be-474d-98f0-1ba00ae16b40",
+          "doc_count": 5773
+        },
+        {
+          "key": "e794b292-4a94-471e-ab84-6aaef1fea1b3",
+          "doc_count": 5620
+        },
+        {
+          "key": "a16dc8d8-ff4a-4d62-a684-2937fb292b8d",
+          "doc_count": 5580
+        },
+        {
+          "key": "1e798b2d-7f97-49b0-a864-79c968af91d3",
+          "doc_count": 5508
+        },
+        {
+          "key": "17ff84d1-e3e9-43d1-a746-745ef8d339d0",
+          "doc_count": 5424
+        },
+        {
+          "key": "38db50bb-72f3-4416-aeb9-61457e655a6d",
+          "doc_count": 5364
+        },
+        {
+          "key": "5ee6f92f-c65c-4888-98e3-f152b3ceb184",
+          "doc_count": 5309
+        },
+        {
+          "key": "43aa1339-67e4-4298-b7c5-3d0f201266ef",
+          "doc_count": 5248
+        },
+        {
+          "key": "67b5d248-4a1e-4861-bc2a-3ac7f379acde",
+          "doc_count": 5219
+        },
+        {
+          "key": "35830c1e-429e-4006-a153-78984a3e0ee2",
+          "doc_count": 5085
+        },
+        {
+          "key": "4db72a36-c08b-4a6b-8c68-ab45ebb0efce",
+          "doc_count": 5034
+        },
+        {
+          "key": "d478c23a-1993-443d-85ea-308870606626",
+          "doc_count": 4968
+        },
+        {
+          "key": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "doc_count": 4937
+        },
+        {
+          "key": "21b563bc-70c2-46d5-bce8-2489db2db3d8",
+          "doc_count": 4907
+        },
+        {
+          "key": "1549b662-ec36-436a-8593-76f7642ec9e4",
+          "doc_count": 4609
+        },
+        {
+          "key": "e6eba8cd-fa2c-4ba2-bec0-6841e7633695",
+          "doc_count": 4561
+        },
+        {
+          "key": "ef77ec72-6537-41ab-a418-17f9a58e6e73",
+          "doc_count": 4532
+        },
+        {
+          "key": "17fc477d-727e-4dde-99d6-ac440e937d14",
+          "doc_count": 4513
+        },
+        {
+          "key": "7311c4ac-7cf6-4160-a55c-4a4c7cd0cf89",
+          "doc_count": 4453
+        },
+        {
+          "key": "cd7b335e-6f5c-4259-ba45-5e334a719464",
+          "doc_count": 4293
+        },
+        {
+          "key": "98ece30d-bf85-4122-b872-7786031b457f",
+          "doc_count": 4149
+        },
+        {
+          "key": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "doc_count": 4058
+        },
+        {
+          "key": "8f689b8b-5b65-4638-9555-f2a5d237a624",
+          "doc_count": 4038
+        },
+        {
+          "key": "ea3c3b03-0ed5-42fc-b192-7328459ea04a",
+          "doc_count": 4034
+        },
+        {
+          "key": "0f19f6d6-79a4-434e-ba0b-a4f49f334078",
+          "doc_count": 4008
+        },
+        {
+          "key": "9e89b6af-4bb5-45af-93d8-0112bd20a60d",
+          "doc_count": 3958
+        },
+        {
+          "key": "678dc436-3370-4992-a361-761dab8c3fda",
+          "doc_count": 3912
+        },
+        {
+          "key": "5f513dff-ccd8-4578-ad0b-5e6cf035e4d1",
+          "doc_count": 3898
+        },
+        {
+          "key": "ceba331e-9da3-44ee-8970-f1eb8d1a68d6",
+          "doc_count": 3777
+        },
+        {
+          "key": "48f5d475-7381-4d06-88eb-119796b9d189",
+          "doc_count": 3752
+        },
+        {
+          "key": "3420d3d5-f142-4db6-951c-5d37cb72ce53",
+          "doc_count": 3687
+        },
+        {
+          "key": "c57817e7-034c-4796-ac47-2bc2191713b3",
+          "doc_count": 3643
+        },
+        {
+          "key": "e647814d-6975-4b34-b8c4-e79b7ca83085",
+          "doc_count": 3601
+        },
+        {
+          "key": "9ea3f46b-f7b9-4b2e-8d4e-a052fbe69de9",
+          "doc_count": 3490
+        },
+        {
+          "key": "33b5b5e7-f4e6-435c-9e0f-bb264d58581b",
+          "doc_count": 3442
+        },
+        {
+          "key": "91f4f1c9-37e3-430b-8020-f8d65af8e422",
+          "doc_count": 3430
+        },
+        {
+          "key": "97e4947d-fce9-4019-9f86-c0d94c820269",
+          "doc_count": 3401
+        },
+        {
+          "key": "30733214-8eb0-4894-b19d-775fe8a617cf",
+          "doc_count": 3360
+        },
+        {
+          "key": "22436fe4-5049-4266-9849-335dd3f161aa",
+          "doc_count": 3244
+        },
+        {
+          "key": "37213da3-a1c7-4644-917e-8f8440e1c4d4",
+          "doc_count": 3214
+        },
+        {
+          "key": "1f5a1b81-e361-4d65-ab1c-6fb7e30c9910",
+          "doc_count": 3182
+        },
+        {
+          "key": "2e4ccf50-bb7d-43a6-9640-088b248c2c5a",
+          "doc_count": 3164
+        },
+        {
+          "key": "0e5201c0-bad2-4e28-9322-5c5dca8862c8",
+          "doc_count": 3154
+        },
+        {
+          "key": "23a47a5f-2ac1-4f81-acd3-21d5b82ed22a",
+          "doc_count": 3135
+        },
+        {
+          "key": "ef59f7cc-ed42-45fc-9abc-5edfb2c8caec",
+          "doc_count": 3089
+        },
+        {
+          "key": "570dcca6-a84f-43aa-8053-1a2ac60d9ead",
+          "doc_count": 3059
+        },
+        {
+          "key": "fd66cee6-5310-4201-9949-0ea04a05b72b",
+          "doc_count": 2995
+        },
+        {
+          "key": "3056112e-97c6-4d0d-b6c2-3c0a9adaca24",
+          "doc_count": 2953
+        },
+        {
+          "key": "1c729855-f3dd-439d-b326-54d62f57b0fd",
+          "doc_count": 2940
+        },
+        {
+          "key": "b4cce5b5-6450-443c-8988-a279b9cefaab",
+          "doc_count": 2937
+        },
+        {
+          "key": "687efa84-c549-4743-a193-72d198d8e19c",
+          "doc_count": 2929
+        },
+        {
+          "key": "5277e72c-9e53-4c98-85f1-ee413bc473cd",
+          "doc_count": 2865
+        },
+        {
+          "key": "57a6bf5f-cda1-41fd-8c12-804c95f74841",
+          "doc_count": 2723
+        },
+        {
+          "key": "e7016bd5-cb10-45b9-8959-0f5750f7a5db",
+          "doc_count": 2704
+        },
+        {
+          "key": "05498053-5a06-45d5-bf6c-dbea1c42cb2b",
+          "doc_count": 2662
+        },
+        {
+          "key": "cb33cf97-2a7b-4b45-9b73-5aca568332a6",
+          "doc_count": 2628
+        },
+        {
+          "key": "04fe30b4-c1e5-4482-addb-67a4c2cd39ef",
+          "doc_count": 2622
+        },
+        {
+          "key": "c1e2b821-96a2-422f-a1fe-7a53aaa2e9bf",
+          "doc_count": 2576
+        },
+        {
+          "key": "1e054b9b-0193-4ff3-b623-9264cf982d4d",
+          "doc_count": 2539
+        },
+        {
+          "key": "8400a716-0aef-4131-9e79-c8ad81d244ad",
+          "doc_count": 2482
+        },
+        {
+          "key": "fd09683f-efe8-446c-9e43-7d11f62e597c",
+          "doc_count": 2480
+        },
+        {
+          "key": "b58043bc-9e47-4a8f-9e4b-5d4c510ea0e1",
+          "doc_count": 2427
+        },
+        {
+          "key": "8295ea14-c4fd-499b-bc68-2907ed36badc",
+          "doc_count": 2414
+        },
+        {
+          "key": "50b0bbe4-f075-4427-8dfc-fcc469dd3e78",
+          "doc_count": 2342
+        },
+        {
+          "key": "361efdf7-9845-411c-90bd-e51ec7991e87",
+          "doc_count": 2322
+        },
+        {
+          "key": "7e4aacd3-0a24-49ab-b019-518b7069b682",
+          "doc_count": 2304
+        },
+        {
+          "key": "d5a1b706-c624-43df-afcf-9cea7094e75b",
+          "doc_count": 2298
+        },
+        {
+          "key": "b590be71-5a03-4f29-bcd4-e91c1b876137",
+          "doc_count": 2225
+        },
+        {
+          "key": "364b1f8d-5975-48d9-bba1-c97ab172986c",
+          "doc_count": 2223
+        },
+        {
+          "key": "ca4e7ee9-06f5-4f93-830c-507a6598ec25",
+          "doc_count": 2221
+        },
+        {
+          "key": "1d17fdad-d338-4ae0-9232-dbf18eaf9f66",
+          "doc_count": 2204
+        },
+        {
+          "key": "042dbdba-a449-4291-8777-577a5a4045de",
+          "doc_count": 2197
+        },
+        {
+          "key": "3c6f1ea5-f2e7-4203-9cfe-74ec2fb1b035",
+          "doc_count": 2189
+        },
+        {
+          "key": "9e1958fb-1dc4-4375-ae35-67ba7f9c7afe",
+          "doc_count": 2140
+        },
+        {
+          "key": "4fed055b-3c46-4ec4-b76d-84d43df9258b",
+          "doc_count": 2138
+        },
+        {
+          "key": "2df867b1-89de-4539-8414-67c47a88f0c8",
+          "doc_count": 2130
+        },
+        {
+          "key": "18cc4ad5-9449-470e-9195-5858b12d822c",
+          "doc_count": 2118
+        },
+        {
+          "key": "92e4e092-6dcb-46bc-85a0-dea8310aba45",
+          "doc_count": 2074
+        },
+        {
+          "key": "12018be6-3795-43a3-a073-a2b9d60c0af3",
+          "doc_count": 2058
+        },
+        {
+          "key": "bf9066a2-2c5f-4cf2-821a-1a68b4df5b1b",
+          "doc_count": 2037
+        },
+        {
+          "key": "0582c7d8-f9f8-4f1b-acab-9bb5598c10c4",
+          "doc_count": 1999
+        },
+        {
+          "key": "b1549ab7-5fc7-4966-a210-0846484fb171",
+          "doc_count": 1959
+        },
+        {
+          "key": "b30a7dd2-d974-4073-bdd0-cb4ea5402bae",
+          "doc_count": 1957
+        },
+        {
+          "key": "341611f4-8b65-4655-b244-9be91a1109cd",
+          "doc_count": 1953
+        },
+        {
+          "key": "0ed6268e-7449-414c-a93c-57ea68f8ab3e",
+          "doc_count": 1941
+        },
+        {
+          "key": "5e2f4c81-8c8a-45f3-a220-851f85f86b40",
+          "doc_count": 1906
+        },
+        {
+          "key": "c7821624-d246-43b8-9dfd-de470f9dc294",
+          "doc_count": 1901
+        },
+        {
+          "key": "50ee2f53-7f79-4808-bceb-3e660fd1e666",
+          "doc_count": 1898
+        },
+        {
+          "key": "3ac8f738-bc3e-43e4-8358-00a32594954d",
+          "doc_count": 1870
+        },
+        {
+          "key": "ad4e4ea0-2ac9-4030-b4bd-bf4206e79bcc",
+          "doc_count": 1870
+        },
+        {
+          "key": "4cd8e87c-93b6-41cc-9189-50585cdb0518",
+          "doc_count": 1868
+        },
+        {
+          "key": "0038ce2e-43bb-4f70-8dd6-dca34efd3fca",
+          "doc_count": 1864
+        },
+        {
+          "key": "c5eeb223-0515-423a-a51a-151426c8f60d",
+          "doc_count": 1862
+        },
+        {
+          "key": "aac5fd7f-8043-4aa8-811f-e50de70d96f3",
+          "doc_count": 1857
+        },
+        {
+          "key": "e23109b4-e143-437c-b329-3dff7cb35488",
+          "doc_count": 1808
+        },
+        {
+          "key": "f016064e-c9c6-4baf-925c-e68e1190bb6d",
+          "doc_count": 1781
+        },
+        {
+          "key": "c3134980-bf5c-49b8-a289-790d45f02c86",
+          "doc_count": 1755
+        },
+        {
+          "key": "f0599190-e5b7-42ed-bec8-810905f50c34",
+          "doc_count": 1733
+        },
+        {
+          "key": "41b166d5-ce08-4efe-99fc-6df77d8fe29e",
+          "doc_count": 1711
+        },
+        {
+          "key": "750a80fe-60b9-423b-aca1-dcc7937d2c84",
+          "doc_count": 1708
+        },
+        {
+          "key": "667a12e7-c6d8-4de0-933f-ce2f07cb7a92",
+          "doc_count": 1686
+        },
+        {
+          "key": "d5b9fb39-d233-4cd0-8682-c4deff1e337b",
+          "doc_count": 1665
+        },
+        {
+          "key": "8f3923b5-4802-40ff-bf98-0acba66691ec",
+          "doc_count": 1650
+        },
+        {
+          "key": "3c367a2d-eec0-4ef1-b3bc-4cbebb320c5a",
+          "doc_count": 1621
+        },
+        {
+          "key": "a4378725-7967-47bc-aada-0220e02e1f96",
+          "doc_count": 1614
+        },
+        {
+          "key": "6ae7221e-2085-46cf-9ad0-353269e95bc8",
+          "doc_count": 1608
+        },
+        {
+          "key": "a2105c9c-b869-4637-8850-eb51ea6b1066",
+          "doc_count": 1590
+        },
+        {
+          "key": "c49bc91d-0a50-497b-8b17-d77808745cf9",
+          "doc_count": 1575
+        },
+        {
+          "key": "e7496fd0-725a-42eb-bf35-af72885b6c0d",
+          "doc_count": 1570
+        },
+        {
+          "key": "fe52a17a-a7aa-4f95-a3ea-26fe640170fe",
+          "doc_count": 1555
+        },
+        {
+          "key": "204fbebc-37cc-4331-a2be-11f38949561c",
+          "doc_count": 1553
+        },
+        {
+          "key": "93e97f6c-0ab6-41a7-9b58-7e230a80ec1e",
+          "doc_count": 1511
+        },
+        {
+          "key": "36be338b-cfb2-47e4-a1fc-b3f7a1aaaf22",
+          "doc_count": 1496
+        },
+        {
+          "key": "d1f70494-b5d9-4c84-973d-e34445b7552b",
+          "doc_count": 1489
+        },
+        {
+          "key": "06c35934-1b75-4196-838d-29d509951bf9",
+          "doc_count": 1476
+        },
+        {
+          "key": "88595487-6d33-4980-ba54-bcf427c9466e",
+          "doc_count": 1458
+        },
+        {
+          "key": "fd62a976-d195-492a-b6f0-f57fef8b6acc",
+          "doc_count": 1433
+        },
+        {
+          "key": "826420a8-3d4a-4cee-901c-f0f2ee9e00b4",
+          "doc_count": 1430
+        },
+        {
+          "key": "a89f64ab-8b3b-4267-b18a-3207d25a45ad",
+          "doc_count": 1430
+        },
+        {
+          "key": "a83151ae-e1db-4166-9dde-438f6544dca9",
+          "doc_count": 1399
+        },
+        {
+          "key": "28a8561d-4699-4c90-823b-686d6207d675",
+          "doc_count": 1398
+        },
+        {
+          "key": "c8eeddef-b903-4aa3-a0fb-44344b8bf301",
+          "doc_count": 1398
+        },
+        {
+          "key": "8096525f-6f67-4bd2-a160-48ed4bea8aa7",
+          "doc_count": 1388
+        },
+        {
+          "key": "f89ada44-88df-46f0-bc61-cc46d9c84673",
+          "doc_count": 1371
+        },
+        {
+          "key": "e34cf41b-196c-4199-85d5-4d2ca5954b09",
+          "doc_count": 1343
+        },
+        {
+          "key": "d38fd1e8-bc15-46b2-92d5-5f3df98cff53",
+          "doc_count": 1336
+        },
+        {
+          "key": "1bfc0147-2df1-4488-bcf7-d140e24dda51",
+          "doc_count": 1318
+        },
+        {
+          "key": "dbb2acdc-a808-4deb-9dc2-542d70368a3f",
+          "doc_count": 1318
+        },
+        {
+          "key": "7e44229a-e8fa-4570-ada1-0cd7843a66d7",
+          "doc_count": 1315
+        },
+        {
+          "key": "6b2c3ca9-69ad-4316-a2d1-33399e9f547e",
+          "doc_count": 1293
+        },
+        {
+          "key": "b12b08da-3d05-4406-a051-0139a33ecf35",
+          "doc_count": 1289
+        },
+        {
+          "key": "67893f3c-c409-41c6-a8f2-47956739a911",
+          "doc_count": 1231
+        },
+        {
+          "key": "3fe3a250-0f48-4a9b-bb71-36d798694912",
+          "doc_count": 1222
+        },
+        {
+          "key": "6d09cfc1-a17c-4067-b1a0-557b8e5334ea",
+          "doc_count": 1218
+        },
+        {
+          "key": "c7ae0ade-c23e-4fe6-a3d4-79bd973374c2",
+          "doc_count": 1193
+        },
+        {
+          "key": "53aa69a7-bd66-468b-8ffa-ec6cb06d7d8d",
+          "doc_count": 1191
+        },
+        {
+          "key": "589ee0cf-456c-4d9c-8e7e-3adc3cec0e09",
+          "doc_count": 1171
+        },
+        {
+          "key": "bd211251-f857-4110-89df-ae59772e44c9",
+          "doc_count": 1159
+        },
+        {
+          "key": "151075fa-f464-4d76-9064-b24aa945b30f",
+          "doc_count": 1123
+        },
+        {
+          "key": "662b1aa5-9c19-4eb9-9766-1da78a117456",
+          "doc_count": 1109
+        },
+        {
+          "key": "bc93e4c6-fd85-4412-987f-52f6fa3bb67d",
+          "doc_count": 1093
+        },
+        {
+          "key": "d14d21fe-da24-47e5-81fb-4bfe962ce828",
+          "doc_count": 1070
+        },
+        {
+          "key": "5663707e-1f94-40a1-97f3-aaeff1d41d20",
+          "doc_count": 1066
+        },
+        {
+          "key": "0bffd75c-2c42-4119-bae7-1ca6d8eb4d1a",
+          "doc_count": 1049
+        },
+        {
+          "key": "5ffc8bc6-e366-4157-b1ba-00859f1048a4",
+          "doc_count": 1033
+        },
+        {
+          "key": "5f6fcfc2-598c-42e8-abb3-50ca9c2446e2",
+          "doc_count": 1024
+        },
+        {
+          "key": "74ba1d92-d9a5-486e-8e52-bb44d51e1788",
+          "doc_count": 1022
+        },
+        {
+          "key": "86b2bfc9-ca99-4250-b93a-f86f3777236d",
+          "doc_count": 1020
+        },
+        {
+          "key": "2941b767-e90b-41b9-9627-6e589e0c0c85",
+          "doc_count": 1014
+        },
+        {
+          "key": "1fc07b28-43f5-49d1-badf-63005e1c3e9a",
+          "doc_count": 1011
+        },
+        {
+          "key": "3799e4f9-f685-4796-99b5-f78524441b93",
+          "doc_count": 1007
+        },
+        {
+          "key": "de67ccab-7d04-43b9-8083-81e45f628505",
+          "doc_count": 998
+        },
+        {
+          "key": "f39780bd-7108-4685-8e6a-b340ff5a5965",
+          "doc_count": 987
+        },
+        {
+          "key": "2c84db50-bab1-40a6-a9ef-405f3ffcec7e",
+          "doc_count": 976
+        },
+        {
+          "key": "bfa3c276-a3a9-48cd-8d4a-4ac42f4fe10a",
+          "doc_count": 962
+        },
+        {
+          "key": "d5c32031-231f-4213-b0f1-2dc4bbf711a0",
+          "doc_count": 961
+        },
+        {
+          "key": "b133b7cb-c0a1-4cd7-9775-cbc78fea50fc",
+          "doc_count": 957
+        },
+        {
+          "key": "d07e7b8a-2222-477f-a7f3-f098bbfdaf54",
+          "doc_count": 952
+        },
+        {
+          "key": "d1de8464-14d4-43da-8a57-9792fc34d4bf",
+          "doc_count": 948
+        },
+        {
+          "key": "a5b1b714-7470-4635-805d-a0cdcc6a6a4b",
+          "doc_count": 930
+        },
+        {
+          "key": "2532cbd0-2752-4211-b249-4a9811a280f2",
+          "doc_count": 929
+        },
+        {
+          "key": "954ec5e0-4fcd-414d-8ad2-46b4b75cfc74",
+          "doc_count": 928
+        },
+        {
+          "key": "79aa7602-a963-44f3-82dd-e141a387adb8",
+          "doc_count": 909
+        },
+        {
+          "key": "e701ecce-f9ab-445f-afcb-24f279efbc9c",
+          "doc_count": 900
+        },
+        {
+          "key": "bfb53140-79c1-4625-81aa-3f37de7c0c2f",
+          "doc_count": 843
+        },
+        {
+          "key": "8b196eb7-1fbf-4eac-9f58-1fccae076f7f",
+          "doc_count": 831
+        },
+        {
+          "key": "b0e9fd61-1e0f-408f-b035-d7952614d7f3",
+          "doc_count": 823
+        },
+        {
+          "key": "e01f53f2-8e1b-41cb-9e5a-3dfb3ccf44d6",
+          "doc_count": 810
+        },
+        {
+          "key": "414a5bf5-061e-4e47-8410-0f76a04f7d1d",
+          "doc_count": 798
+        },
+        {
+          "key": "dcc8c1ac-38c7-4ada-a389-f4aceeacb531",
+          "doc_count": 798
+        },
+        {
+          "key": "e8c034d5-c2c7-4f23-8dc0-7f94f4116306",
+          "doc_count": 795
+        },
+        {
+          "key": "473400bf-fe83-4bd6-9f69-c4608f4cdf4f",
+          "doc_count": 786
+        },
+        {
+          "key": "5d0a9aa8-91f2-4fa4-b4df-554a4221dfcb",
+          "doc_count": 781
+        },
+        {
+          "key": "1da8098a-1e82-4b8b-bf81-d30e423cdaba",
+          "doc_count": 766
+        },
+        {
+          "key": "5486b66d-2082-433d-9223-bd789ebca29c",
+          "doc_count": 765
+        },
+        {
+          "key": "1720ead7-9d20-4179-8998-2a59b8bfa8d7",
+          "doc_count": 748
+        },
+        {
+          "key": "745caa9d-02be-4a67-a142-103282aa0bda",
+          "doc_count": 737
+        },
+        {
+          "key": "899855ee-4fd9-4e85-9033-880058303b5c",
+          "doc_count": 719
+        },
+        {
+          "key": "6f470382-cb0b-4634-a796-2248bfa97fdc",
+          "doc_count": 707
+        },
+        {
+          "key": "bf5b0620-1ff0-45af-a2eb-96f3c739edf2",
+          "doc_count": 707
+        },
+        {
+          "key": "2f740a87-8049-435d-9d06-1c393c9c11b7",
+          "doc_count": 700
+        },
+        {
+          "key": "9cd34069-24ca-4ae8-9c10-78ccfac6523d",
+          "doc_count": 690
+        },
+        {
+          "key": "5e24c385-dab9-40a3-a2dd-2cf8758821b6",
+          "doc_count": 677
+        },
+        {
+          "key": "f0bb124f-5840-41ea-98ab-b8fd8802ea5f",
+          "doc_count": 669
+        },
+        {
+          "key": "f08c31ea-0e90-4cc1-b471-dfd0584ae7cf",
+          "doc_count": 653
+        },
+        {
+          "key": "fdf98e60-9feb-4b86-a42e-ae6c7152d02c",
+          "doc_count": 648
+        },
+        {
+          "key": "4960f30c-c1c7-490e-966a-61ad02969e38",
+          "doc_count": 642
+        },
+        {
+          "key": "ac8c109d-b69c-4359-87f4-8714f8c8a65d",
+          "doc_count": 638
+        },
+        {
+          "key": "73236de8-c2cc-458c-b0c3-743c7b57db3a",
+          "doc_count": 630
+        },
+        {
+          "key": "902f9e08-9180-4f12-97b6-d8662f2b583f",
+          "doc_count": 623
+        },
+        {
+          "key": "b4154ce7-8145-4fd8-92ed-edd124d53730",
+          "doc_count": 617
+        },
+        {
+          "key": "a73b61c5-812c-453b-b12b-5c65929e947a",
+          "doc_count": 608
+        },
+        {
+          "key": "c892f8d1-108c-44f7-9458-0abb96633976",
+          "doc_count": 590
+        },
+        {
+          "key": "a4babe52-5740-44e4-9ea2-acef4797f127",
+          "doc_count": 576
+        },
+        {
+          "key": "6d99bdeb-a96f-47bf-8e28-ce1093347335",
+          "doc_count": 571
+        },
+        {
+          "key": "b6ebfa9d-fed3-4e0c-8877-47c1190f346c",
+          "doc_count": 568
+        },
+        {
+          "key": "afd773b8-280f-4a0f-98a7-7977b7e1ca24",
+          "doc_count": 562
+        },
+        {
+          "key": "964c24a3-cca4-4028-a0d8-b83513d14b7d",
+          "doc_count": 561
+        },
+        {
+          "key": "724dc40a-421c-44f8-b426-969f99fa8a1c",
+          "doc_count": 552
+        },
+        {
+          "key": "fe04dab1-5a3d-4c28-a450-012658e982d8",
+          "doc_count": 510
+        },
+        {
+          "key": "677f57a9-9a0d-4e69-8622-96aa1e6392c2",
+          "doc_count": 509
+        },
+        {
+          "key": "43c69d2a-0fd2-4d34-a1ef-50d0f9c01353",
+          "doc_count": 506
+        },
+        {
+          "key": "282fe9c2-d6cb-4325-b3b5-b70ab1d22bbb",
+          "doc_count": 504
+        },
+        {
+          "key": "69d150df-eba4-4ab3-9156-71cb0db41830",
+          "doc_count": 504
+        },
+        {
+          "key": "f5d395b8-c3c9-43df-b4ff-63d65c6a971e",
+          "doc_count": 504
+        },
+        {
+          "key": "b26cc2c9-1141-4502-805a-b9dd1d83c321",
+          "doc_count": 503
+        },
+        {
+          "key": "8bcb95b2-ab5c-4368-8ead-14588eeb9c98",
+          "doc_count": 502
+        },
+        {
+          "key": "3a0d8092-c577-4775-a586-1542574edc53",
+          "doc_count": 495
+        },
+        {
+          "key": "8dfc3d88-8f6b-4432-b69c-534717906004",
+          "doc_count": 495
+        },
+        {
+          "key": "33bac15d-b1d0-42a1-8801-86149887eeef",
+          "doc_count": 494
+        },
+        {
+          "key": "90e07356-df5d-4372-a2c4-34927db9a3ec",
+          "doc_count": 488
+        },
+        {
+          "key": "431b56fc-d016-459a-97ab-1e9c8168a7f0",
+          "doc_count": 487
+        },
+        {
+          "key": "a8cafd75-ca3b-42c6-8b8e-52aafa15753b",
+          "doc_count": 487
+        },
+        {
+          "key": "2d4658e3-0d1a-43fc-97ff-b4813dd1f86e",
+          "doc_count": 479
+        },
+        {
+          "key": "6e922c92-b37d-4c46-8982-19d945ff8fd1",
+          "doc_count": 463
+        },
+        {
+          "key": "7886c689-ed46-47e9-8dba-4c0468212c65",
+          "doc_count": 461
+        },
+        {
+          "key": "2d47501f-dbed-43ce-a9c3-9c8542648ce4",
+          "doc_count": 460
+        },
+        {
+          "key": "be72355e-a5d6-4094-8635-0127dfb510aa",
+          "doc_count": 456
+        },
+        {
+          "key": "cb2973af-0d5a-4fbf-80ab-ec96ede33ef0",
+          "doc_count": 454
+        },
+        {
+          "key": "f1960cd5-e27a-40f0-b4bd-3ca7157e4bbb",
+          "doc_count": 448
+        },
+        {
+          "key": "0f65c2e4-fc98-4a2c-bfbe-24de6ab1feb6",
+          "doc_count": 447
+        },
+        {
+          "key": "5db52f01-8d71-43e5-b835-0ff7d33d715b",
+          "doc_count": 439
+        },
+        {
+          "key": "3a5b5c9b-b241-4883-904a-b167a7edb41a",
+          "doc_count": 426
+        },
+        {
+          "key": "046a2685-be26-4d6e-80cc-d95e907922fa",
+          "doc_count": 425
+        },
+        {
+          "key": "b10b9eb2-3786-4483-8b73-3cfdf1a9eb90",
+          "doc_count": 421
+        },
+        {
+          "key": "ea9de87b-7231-4a05-809f-4b658ea4173d",
+          "doc_count": 407
+        },
+        {
+          "key": "aeed0286-ffe4-45b8-a7b9-bcee18361433",
+          "doc_count": 398
+        },
+        {
+          "key": "5af1bae4-35c0-4ab7-9d08-08bbe22ca003",
+          "doc_count": 392
+        },
+        {
+          "key": "5ab348ab-439a-4697-925c-d6abe0c09b92",
+          "doc_count": 390
+        },
+        {
+          "key": "945d6d7d-c768-4189-be9d-f693104d590c",
+          "doc_count": 381
+        },
+        {
+          "key": "d4711660-a622-4c15-adb8-608b7ac6a084",
+          "doc_count": 380
+        },
+        {
+          "key": "0fb6618f-f8d6-4361-8b2d-0923d4aa3c09",
+          "doc_count": 379
+        },
+        {
+          "key": "a50e98bd-13e9-41fe-a5cc-aee4f240628b",
+          "doc_count": 371
+        },
+        {
+          "key": "2b21081c-d5e9-49bd-b29a-0b6e4a551b78",
+          "doc_count": 370
+        },
+        {
+          "key": "7fbf76b1-6bd6-4217-a5bc-1d89e45f6a68",
+          "doc_count": 364
+        },
+        {
+          "key": "d1983d53-434a-436e-a698-3a2745eb61dc",
+          "doc_count": 359
+        },
+        {
+          "key": "fe51bced-93ce-45b2-b0c6-f7256719a07b",
+          "doc_count": 359
+        },
+        {
+          "key": "b7a5dadd-7429-489b-9b3b-72abcd9518a3",
+          "doc_count": 355
+        },
+        {
+          "key": "6226705f-4867-464d-9fab-4e81ecee731f",
+          "doc_count": 354
+        },
+        {
+          "key": "1a44dfa0-6a54-4584-8c57-d98669d7f033",
+          "doc_count": 353
+        },
+        {
+          "key": "535d4a21-8650-41d0-b92f-b6c028db13e2",
+          "doc_count": 352
+        },
+        {
+          "key": "9d35f82b-c19b-4dce-b296-808598d1fb6b",
+          "doc_count": 352
+        },
+        {
+          "key": "350ed733-b782-4195-a5dd-e61e5c82d837",
+          "doc_count": 349
+        },
+        {
+          "key": "c13a5966-99a3-4383-b9ef-259cf46800fe",
+          "doc_count": 348
+        },
+        {
+          "key": "03e04b8e-1dea-49ac-8a46-4276ddcfed21",
+          "doc_count": 345
+        },
+        {
+          "key": "feb74628-8724-466f-8c8c-b3d3b72f2417",
+          "doc_count": 341
+        },
+        {
+          "key": "080aa588-2f4c-4d65-8a55-f0b83e8aa7e6",
+          "doc_count": 330
+        },
+        {
+          "key": "a0ec3ce6-fc8a-48b7-9105-cecf27602e37",
+          "doc_count": 326
+        },
+        {
+          "key": "7915973f-a3b0-4d2c-86e7-02d40647393c",
+          "doc_count": 322
+        },
+        {
+          "key": "7e43ea77-d2e5-4bdc-a4f7-a4792866f53f",
+          "doc_count": 319
+        },
+        {
+          "key": "6f510e69-96b2-4817-bab7-3a36c8250c79",
+          "doc_count": 314
+        },
+        {
+          "key": "212dcc45-bf5b-43d8-a804-3351c04c2f7a",
+          "doc_count": 312
+        },
+        {
+          "key": "7026b70a-7245-42bd-8162-81ae9a6cfbcb",
+          "doc_count": 309
+        },
+        {
+          "key": "8ed556b0-b801-4575-ae53-db7cacbfd0c9",
+          "doc_count": 309
+        },
+        {
+          "key": "6d710d01-54f6-448b-bbf9-adee9e46fc3c",
+          "doc_count": 301
+        },
+        {
+          "key": "a69decc7-76ba-496a-a66e-f91049c02cf0",
+          "doc_count": 301
+        },
+        {
+          "key": "8e2f9392-55ac-49f3-bcc2-131a00122626",
+          "doc_count": 295
+        },
+        {
+          "key": "af4f13cd-f1e8-4e18-ac7a-b0aeee90c749",
+          "doc_count": 294
+        },
+        {
+          "key": "7f497d81-4c7e-4e06-b166-a459968b14e3",
+          "doc_count": 289
+        },
+        {
+          "key": "a0546df1-b727-402f-b9b8-570e65e58026",
+          "doc_count": 289
+        },
+        {
+          "key": "68abd0b8-cff1-4c84-a2d9-bd4ac6df4fa4",
+          "doc_count": 285
+        },
+        {
+          "key": "25972252-d6b1-4b52-b4b8-64d09d7e7da1",
+          "doc_count": 268
+        },
+        {
+          "key": "9f3bbc7b-c682-4f66-88b3-48eef3a38f38",
+          "doc_count": 268
+        },
+        {
+          "key": "40d35f62-cf89-488a-bad3-66e66d38c10c",
+          "doc_count": 260
+        },
+        {
+          "key": "37287863-bf14-438e-a194-cc2ee7ae24be",
+          "doc_count": 256
+        },
+        {
+          "key": "58afd7df-a696-4dd6-a765-540f8b31c07d",
+          "doc_count": 256
+        },
+        {
+          "key": "9d9016ef-a88f-4312-a0bf-638fc4be53ba",
+          "doc_count": 251
+        },
+        {
+          "key": "7b1f4ee4-7f50-4c82-9007-ba76528a84df",
+          "doc_count": 247
+        },
+        {
+          "key": "2cebadf7-6d52-49b2-b3a7-d4969a36aa12",
+          "doc_count": 236
+        },
+        {
+          "key": "90739622-5232-4048-8121-9af9ec69604f",
+          "doc_count": 226
+        },
+        {
+          "key": "ef967959-19e5-4e21-8821-89f822d3303b",
+          "doc_count": 225
+        },
+        {
+          "key": "23b85d9d-4669-40db-901f-aaad686fe0b8",
+          "doc_count": 220
+        },
+        {
+          "key": "f3327705-8d69-4d9c-88b7-584a08c74653",
+          "doc_count": 218
+        },
+        {
+          "key": "64b54f96-91f0-4442-b6de-173aa1a5c31b",
+          "doc_count": 215
+        },
+        {
+          "key": "560b2536-a07e-46c0-b179-6ba1ba6f5b20",
+          "doc_count": 214
+        },
+        {
+          "key": "e2fda823-8a6e-4bd8-8602-924615373938",
+          "doc_count": 213
+        },
+        {
+          "key": "23655eb9-7798-4865-9a92-1dbbc609511d",
+          "doc_count": 212
+        },
+        {
+          "key": "2fe72860-9220-4acd-894b-81b4d98a5e24",
+          "doc_count": 209
+        },
+        {
+          "key": "c22f048c-6f77-4488-a203-865537dddba9",
+          "doc_count": 203
+        },
+        {
+          "key": "f8e830e3-9b0d-4e5d-9f24-9f2ed3b465da",
+          "doc_count": 202
+        },
+        {
+          "key": "781b461a-2788-4fa6-b3df-bbed9447f5a3",
+          "doc_count": 194
+        },
+        {
+          "key": "99e84c7d-dd3c-40d9-9526-54f4342cda95",
+          "doc_count": 193
+        },
+        {
+          "key": "4c9d08ce-71c1-47b8-a572-2d40e5984c49",
+          "doc_count": 192
+        },
+        {
+          "key": "78bb515d-4508-45d6-94e2-e53638ce2fe4",
+          "doc_count": 191
+        },
+        {
+          "key": "55ddd3f9-0e9a-40e8-9e8f-d3a3ab871434",
+          "doc_count": 190
+        },
+        {
+          "key": "9e66257f-21a9-491a-ac23-06b7b62ceeb7",
+          "doc_count": 189
+        },
+        {
+          "key": "997c4dda-0465-40c0-af8d-67f8f90dea3b",
+          "doc_count": 187
+        },
+        {
+          "key": "d08a71aa-fe87-4bf5-ac68-8e7497bf585c",
+          "doc_count": 187
+        },
+        {
+          "key": "b0a3324f-849a-43bf-811a-9dd10f04806b",
+          "doc_count": 184
+        },
+        {
+          "key": "0ed0b942-198e-4500-8fe0-1d1ef0785454",
+          "doc_count": 183
+        },
+        {
+          "key": "a9b8572c-ec86-4e6b-9ed9-03d939b7f363",
+          "doc_count": 183
+        },
+        {
+          "key": "f5c38252-89f1-4753-af3a-da8818fe3a86",
+          "doc_count": 182
+        },
+        {
+          "key": "50ca2a08-0e76-4f56-9976-d344dd201a9b",
+          "doc_count": 178
+        },
+        {
+          "key": "abbf4722-c63b-492f-b183-cb45ad9f5211",
+          "doc_count": 177
+        },
+        {
+          "key": "a72205bf-d800-46a4-83a8-5fae54cdf877",
+          "doc_count": 174
+        },
+        {
+          "key": "b7704325-2dfd-4fcf-8193-01b5bdce825d",
+          "doc_count": 172
+        },
+        {
+          "key": "b1f0612a-bc21-424f-b9c1-3bba69ad4f54",
+          "doc_count": 171
+        },
+        {
+          "key": "92f0b5e8-27b5-48ae-be72-616657821f7b",
+          "doc_count": 169
+        },
+        {
+          "key": "d36887a2-9f9a-44af-887a-5bb95d09a83b",
+          "doc_count": 167
+        },
+        {
+          "key": "394dda75-c336-4ca3-acdd-1c2a317d7361",
+          "doc_count": 164
+        },
+        {
+          "key": "b6d0f953-29b4-41da-a255-2ed07c83edf1",
+          "doc_count": 164
+        },
+        {
+          "key": "0a410c4a-cd4f-4bd8-b6ba-a0c2baa37622",
+          "doc_count": 154
+        },
+        {
+          "key": "a77b7747-8a1e-40ff-8c63-fb9087cc099d",
+          "doc_count": 154
+        },
+        {
+          "key": "5a9ae910-9e4b-488b-af8e-88074fabc3a4",
+          "doc_count": 145
+        },
+        {
+          "key": "921cf6ba-3f58-41ac-90fb-33fa4ec6b282",
+          "doc_count": 144
+        },
+        {
+          "key": "ab3c6b74-477b-4f79-8711-0643851021f0",
+          "doc_count": 144
+        },
+        {
+          "key": "41800344-33b3-4201-b9d2-cabbbf564fbc",
+          "doc_count": 140
+        },
+        {
+          "key": "11f88400-8e44-4592-88e4-9d2ce4f37716",
+          "doc_count": 136
+        },
+        {
+          "key": "3a771a31-8cd0-40ac-befc-69509201b61b",
+          "doc_count": 133
+        },
+        {
+          "key": "2bfc480c-e5b3-4a9b-9587-a92c22830ace",
+          "doc_count": 132
+        },
+        {
+          "key": "9a861ebe-f8d7-4eb1-a2c8-3006f07cfec2",
+          "doc_count": 131
+        },
+        {
+          "key": "1f2933c1-3f7a-4521-9b16-2c34b369ee95",
+          "doc_count": 130
+        },
+        {
+          "key": "3ef3ced6-9fa0-4d30-98b4-2d1337d2477d",
+          "doc_count": 121
+        },
+        {
+          "key": "fb33ec4c-1bab-48f2-9faf-a5205a9a2c37",
+          "doc_count": 117
+        },
+        {
+          "key": "41b119de-f745-482d-be42-a0155bc76e5d",
+          "doc_count": 116
+        },
+        {
+          "key": "879d475f-4b76-4d18-8cf6-a7e5a6d44926",
+          "doc_count": 110
+        },
+        {
+          "key": "886f3b02-e2f2-4c49-9ace-df25bf5d091a",
+          "doc_count": 110
+        },
+        {
+          "key": "688b7731-d818-4063-b29d-666bd0024b8b",
+          "doc_count": 109
+        },
+        {
+          "key": "97c1db9d-b3c1-4c05-9b55-e99c37773a29",
+          "doc_count": 109
+        },
+        {
+          "key": "a6966178-9495-4093-9cb2-dfed4acddde6",
+          "doc_count": 105
+        },
+        {
+          "key": "94b17bab-a41a-4cb2-8ae4-209e31c5144d",
+          "doc_count": 96
+        },
+        {
+          "key": "383d5325-b1ae-4739-b5ff-8afc4e30a0db",
+          "doc_count": 92
+        },
+        {
+          "key": "3eb6d387-985a-4eed-be62-3fcfc26534cd",
+          "doc_count": 88
+        },
+        {
+          "key": "c44e18ab-837b-4a58-b8df-dc521a173029",
+          "doc_count": 88
+        },
+        {
+          "key": "53a8ce69-d9b9-4ae2-848a-dab0d4d810d1",
+          "doc_count": 86
+        },
+        {
+          "key": "67174355-6ee7-4a4c-af45-60e848973853",
+          "doc_count": 82
+        },
+        {
+          "key": "d29aa22a-03d0-4b01-b18b-fec07cea3db8",
+          "doc_count": 82
+        },
+        {
+          "key": "72f0493a-b4a7-4d0c-a3ea-dab177a95a61",
+          "doc_count": 81
+        },
+        {
+          "key": "4efa0623-a625-4949-aea4-7cb60a99b6f8",
+          "doc_count": 77
+        },
+        {
+          "key": "7ae4d15d-62e2-459b-842a-446f921b9d3f",
+          "doc_count": 76
+        },
+        {
+          "key": "b027383d-6705-4d06-8514-db6ef16efdb5",
+          "doc_count": 75
+        },
+        {
+          "key": "f0f0731a-e2c2-415e-a41c-9f514296844c",
+          "doc_count": 75
+        },
+        {
+          "key": "f5118065-6cf3-402d-a35d-8fdd2830f4da",
+          "doc_count": 73
+        },
+        {
+          "key": "6f2cd35e-9ee6-44d5-b182-cdd19d01a4c3",
+          "doc_count": 72
+        },
+        {
+          "key": "6c6f34ed-58a4-4ba2-b9c7-34524f79a349",
+          "doc_count": 71
+        },
+        {
+          "key": "ce98b978-4542-45c6-aecf-79cf3f6979ed",
+          "doc_count": 71
+        },
+        {
+          "key": "751b5d4c-aba7-4c1f-b0a1-dfe2e9346d1b",
+          "doc_count": 68
+        },
+        {
+          "key": "9ef0bd4b-c016-4791-8a3f-a99c218c1d29",
+          "doc_count": 68
+        },
+        {
+          "key": "1bc74afb-698f-43a7-90e6-352dba6c74da",
+          "doc_count": 64
+        },
+        {
+          "key": "c96ca51c-908e-41cc-ae10-ac1fb72ca3d9",
+          "doc_count": 62
+        },
+        {
+          "key": "cc05ec4b-2d82-4d89-a43c-e313c8641cf5",
+          "doc_count": 60
+        },
+        {
+          "key": "65d603ef-19be-4d6f-92dc-76c5e4220175",
+          "doc_count": 59
+        },
+        {
+          "key": "028990be-11ff-4c6b-9684-59cb1e1c3ab6",
+          "doc_count": 58
+        },
+        {
+          "key": "f4573d80-dd92-4337-9005-ba71e8a8563a",
+          "doc_count": 58
+        },
+        {
+          "key": "9c4f4765-2d02-452c-9ae9-cdd1d4846d5d",
+          "doc_count": 57
+        },
+        {
+          "key": "b1db48d5-22e7-4f5e-bce2-d267b447cdaa",
+          "doc_count": 57
+        },
+        {
+          "key": "466ee466-51d5-4bab-99e6-92e534e6877b",
+          "doc_count": 55
+        },
+        {
+          "key": "97b858df-0110-4d27-a891-75e6a0f18938",
+          "doc_count": 53
+        },
+        {
+          "key": "b80d24e8-17ff-4092-88d7-7e5ad11c117a",
+          "doc_count": 53
+        },
+        {
+          "key": "ecd540e2-b2b5-452f-b5e8-d54aac884f49",
+          "doc_count": 53
+        },
+        {
+          "key": "a1b2bdfd-00c7-4c31-8046-2c991ca777d0",
+          "doc_count": 52
+        },
+        {
+          "key": "4ecc6eb6-5f2f-4b00-8d26-a58bfa0e7f02",
+          "doc_count": 46
+        },
+        {
+          "key": "3602074e-1160-46a8-b796-349eb14b598a",
+          "doc_count": 45
+        },
+        {
+          "key": "b101e53b-8934-42ef-92db-904c226f29a8",
+          "doc_count": 45
+        },
+        {
+          "key": "4b05f088-74a4-44a5-a161-8b1484efc240",
+          "doc_count": 39
+        },
+        {
+          "key": "85ae9fb4-de87-41ce-abb3-44fda2fb24a8",
+          "doc_count": 34
+        },
+        {
+          "key": "8e58cd34-3cbb-46f7-9c25-527251881a6f",
+          "doc_count": 33
+        },
+        {
+          "key": "de41423b-7326-413a-880f-58176ef95ec7",
+          "doc_count": 29
+        },
+        {
+          "key": "c1fa848f-ec37-4cdb-930b-c38de2ae63e6",
+          "doc_count": 27
+        },
+        {
+          "key": "908ccd97-c8e1-4c7c-9871-7a80e2940032",
+          "doc_count": 26
+        },
+        {
+          "key": "b9d08bac-6b78-484b-9a96-da61552f53a5",
+          "doc_count": 26
+        },
+        {
+          "key": "384a1909-f66c-4551-9b26-ea985cd9ccd8",
+          "doc_count": 24
+        },
+        {
+          "key": "72161544-62e7-4e30-b399-ac8115c3a250",
+          "doc_count": 22
+        },
+        {
+          "key": "199dc2c5-b3fb-40e4-bbbb-0b5ef2bbf777",
+          "doc_count": 21
+        },
+        {
+          "key": "9357e02f-20fc-4bc5-9bcb-dc8abcbebf16",
+          "doc_count": 19
+        },
+        {
+          "key": "9e8c4024-45b1-4c06-854d-9f6d807dae67",
+          "doc_count": 19
+        },
+        {
+          "key": "e78939ad-42a2-4908-b914-baf5a33fabe0",
+          "doc_count": 19
+        },
+        {
+          "key": "ec6cef7d-d8aa-43b4-b352-908f172a378e",
+          "doc_count": 19
+        },
+        {
+          "key": "7c2c5cdc-80e6-49d5-8e95-08fc7da0a370",
+          "doc_count": 18
+        },
+        {
+          "key": "08fdc20d-be37-4dc4-97ef-abddffdc825a",
+          "doc_count": 17
+        },
+        {
+          "key": "53091d18-f173-4fc0-b9d9-20a1494e2466",
+          "doc_count": 16
+        },
+        {
+          "key": "ba0cbea4-9a25-49de-bfb4-02201b392f5e",
+          "doc_count": 16
+        },
+        {
+          "key": "433d3c37-8dde-42e4-a344-2cb6605c5da2",
+          "doc_count": 15
+        },
+        {
+          "key": "63ce9d6b-ec89-4e17-880d-c0a31acb4a6d",
+          "doc_count": 15
+        },
+        {
+          "key": "8b727955-5ef2-4339-b5af-e17177377470",
+          "doc_count": 15
+        },
+        {
+          "key": "a9223e1d-7a81-4311-800e-211c5a1b8205",
+          "doc_count": 15
+        },
+        {
+          "key": "5076f892-a05d-4018-9c2c-d537a22095af",
+          "doc_count": 14
+        },
+        {
+          "key": "cdb6ec43-935e-4da2-8798-71e40ca6d12a",
+          "doc_count": 14
+        },
+        {
+          "key": "b33e9dc3-8e86-40ab-a0bd-d11d817ea370",
+          "doc_count": 13
+        },
+        {
+          "key": "ecb0a329-c019-4a59-abe3-fa7e72055902",
+          "doc_count": 13
+        },
+        {
+          "key": "4c46db9d-74d7-4e45-9ed2-0da40ec6b44f",
+          "doc_count": 12
+        },
+        {
+          "key": "9835e4d7-a817-430f-9f55-5fc3325e4399",
+          "doc_count": 12
+        },
+        {
+          "key": "bb83e45d-1ed3-41ed-834a-f0f7cff4c464",
+          "doc_count": 11
+        },
+        {
+          "key": "139f2c47-4051-4c44-b95a-45fd20b1a8b9",
+          "doc_count": 9
+        },
+        {
+          "key": "7f7939c8-5276-4fbb-b12c-de89a5a8044f",
+          "doc_count": 9
+        },
+        {
+          "key": "a2bc3d61-3c37-4aca-b47d-c3413f7e3b87",
+          "doc_count": 9
+        },
+        {
+          "key": "3617a6a3-d384-48de-948d-2d1e1c54e090",
+          "doc_count": 8
+        },
+        {
+          "key": "5a660a44-afdd-45ac-8c48-1a6c570ce0b5",
+          "doc_count": 8
+        },
+        {
+          "key": "f2696243-01cd-4b91-9c13-1b30c8a85898",
+          "doc_count": 8
+        },
+        {
+          "key": "9f4ed3ee-33f7-47e9-a4a5-a1224fec2b6e",
+          "doc_count": 7
+        },
+        {
+          "key": "72059315-e131-42ba-b7c6-489415e297b9",
+          "doc_count": 6
+        },
+        {
+          "key": "25e4ea2d-74ef-4251-b461-6ceb3c812bf1",
+          "doc_count": 5
+        },
+        {
+          "key": "0e162e0a-bf3e-4710-9357-44258ca12abb",
+          "doc_count": 4
+        },
+        {
+          "key": "2cf2843f-567c-45c1-a328-cc210af76fc1",
+          "doc_count": 4
+        },
+        {
+          "key": "d4ea4495-c4b2-4d05-b524-163423f17cd7",
+          "doc_count": 4
+        },
+        {
+          "key": "2292f5d5-d39f-4944-be72-fa5dd62f581c",
+          "doc_count": 3
+        },
+        {
+          "key": "2e96b570-4567-4538-add2-bca9552f6d32",
+          "doc_count": 3
+        },
+        {
+          "key": "5626f61a-822e-4692-b432-51f53d053e4d",
+          "doc_count": 3
+        },
+        {
+          "key": "667c2736-bcd3-4a6a-abf4-db5d2dc815c4",
+          "doc_count": 3
+        },
+        {
+          "key": "b5f4526b-f4fb-4d90-8ce0-975e0cda8ff6",
+          "doc_count": 3
+        },
+        {
+          "key": "00049fe7-5ca2-4936-be50-c736221ef186",
+          "doc_count": 2
+        },
+        {
+          "key": "59428ba2-556f-4179-a9e6-3926f09e0bf3",
+          "doc_count": 2
+        },
+        {
+          "key": "5aef068f-efd3-4851-a623-f542e97350cd",
+          "doc_count": 2
+        },
+        {
+          "key": "6aad3ea3-3c10-4eb5-8c42-3e12c3429c67",
+          "doc_count": 2
+        },
+        {
+          "key": "8f886a6c-a477-42b0-8587-db4832177be9",
+          "doc_count": 2
+        },
+        {
+          "key": "a8823dd5-32d7-4465-932b-accdf76ef4ff",
+          "doc_count": 2
+        },
+        {
+          "key": "c9dad611-5e60-4456-934e-75b0e0842ddd",
+          "doc_count": 2
+        },
+        {
+          "key": "dbb14b3f-3a6b-4f3c-872d-9a5a28064a61",
+          "doc_count": 2
+        },
+        {
+          "key": "f00b6a32-5337-406b-a850-17f5d78470ad",
+          "doc_count": 2
+        },
+        {
+          "key": "02266d50-00a1-4933-bfa3-97abbdb4870a",
+          "doc_count": 1
+        },
+        {
+          "key": "4305303f-976d-4074-accc-91e205435cc8",
+          "doc_count": 1
+        },
+        {
+          "key": "4bec11d1-f8c3-43a7-9e70-ee0256fcedaf",
+          "doc_count": 1
+        },
+        {
+          "key": "518518b7-9e85-42ea-b419-2d23a3ef546a",
+          "doc_count": 1
+        },
+        {
+          "key": "5d7869be-8526-43d8-af53-f16a15ebadb5",
+          "doc_count": 1
+        },
+        {
+          "key": "61a1c0ce-8327-4e2a-9766-449751a49b7a",
+          "doc_count": 1
+        },
+        {
+          "key": "7b0809fb-fd62-4733-8f40-74ceb04cbcac",
+          "doc_count": 1
+        },
+        {
+          "key": "8445ab25-ff89-44b0-90f8-bf0790f50afc",
+          "doc_count": 1
+        },
+        {
+          "key": "85e930bf-6e90-4700-85d1-4c3330efbafb",
+          "doc_count": 1
+        },
+        {
+          "key": "8a54c5fa-2900-4859-a2d6-1b7faedafac4",
+          "doc_count": 1
+        },
+        {
+          "key": "8f3b62fb-56ec-49e8-9f8f-bb257348291f",
+          "doc_count": 1
+        },
+        {
+          "key": "9c5fea92-a28b-4b6e-94b5-9c939f7369a2",
+          "doc_count": 1
+        },
+        {
+          "key": "9ff03c57-ba5a-4127-9439-4bf3e838c4df",
+          "doc_count": 1
+        },
+        {
+          "key": "b26fa674-6300-4ea0-a8e3-fc0ce32b5226",
+          "doc_count": 1
+        },
+        {
+          "key": "b688c17c-3761-4ccd-a42f-88219f5fcff4",
+          "doc_count": 1
+        },
+        {
+          "key": "c5916431-004f-465a-a505-589e2de29c8b",
+          "doc_count": 1
+        },
+        {
+          "key": "df22987f-d20d-41db-b8eb-8b5f5fca6df0",
+          "doc_count": 1
+        },
+        {
+          "key": "e1c7bc41-50a4-4723-b8b3-f970844ffb65",
+          "doc_count": 1
+        },
+        {
+          "key": "f062cb7d-c03e-4762-b1c4-49118fee1a56",
+          "doc_count": 1
+        },
+        {
+          "key": "fc628e53-5fdf-4436-9782-bf637d812b48",
+          "doc_count": 1
+        },
+        {
+          "key": "fdf7bb59-aad2-4f10-879f-6c0e7d3baa64",
+          "doc_count": 1
+        }
+      ]
+    },
+    "max_dm": {
+      "value": 1674654616151,
+      "value_as_string": "2023-01-25T13:50:16.151Z"
+    }
+  }
+}

--- a/__tests__/mock/search-a0b7c9b80fc09d8a28c3353c883f91d8.json
+++ b/__tests__/mock/search-a0b7c9b80fc09d8a28c3353c883f91d8.json
@@ -1,0 +1,4046 @@
+{
+  "timed_out": false,
+  "_shards": {
+    "total": 48,
+    "successful": 48,
+    "failed": 0
+  },
+  "hits": {
+    "total": 114017,
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a04854e2-2a22-433a-8e9a-8bbd14e8105b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lat": 41.76527,
+            "lon": -72.19861
+          },
+          "family": "sapindaceae",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.2463768115942029,
+          "stateprovince": "connecticut",
+          "institutioncode": "uconn",
+          "municipality": "mansfield",
+          "county": "tolland county",
+          "phylum": "tracheophyta",
+          "catalognumber": "conn00070249",
+          "startdayofyear": 50,
+          "taxonrank": "species",
+          "specificepithet": "saccharinum",
+          "continent": "north america",
+          "uuid": "a04854e2-2a22-433a-8e9a-8bbd14e8105b",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "jody foley",
+          "commonnames": [
+            "Silver Maple"
+          ],
+          "mediarecords": [
+            "b51105ab-33eb-457a-bafc-43a57d77643d"
+          ],
+          "datemodified": "2014-09-09T02:54:49.495000+00:00",
+          "datecollected": "1999-02-19T00:00:00+00:00",
+          "etag": "2d2c88d7840bafc1ab38d4d76878a5d6193a6bc1",
+          "recordnumber": "40",
+          "hasImage": true,
+          "kingdom": "plantae",
+          "highertaxon": "plantae; dicotyledonae; sapindales; aceraceae",
+          "commonname": "silver maple",
+          "taxonid": "3189837",
+          "scientificname": "acer saccharinum l.",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "flag_dwc_family_replaced": true,
+            "dwc:specificEpithet": "saccharinum",
+            "idigbio:dateModified": "2014-09-09T02:54:49.495000",
+            "dwc:countryCode": "US",
+            "dwc:county": "Tolland County",
+            "dwc:recordedBy": "Jody Foley",
+            "idigbio:uuid": "a04854e2-2a22-433a-8e9a-8bbd14e8105b",
+            "dwc:locationAccordingTo": "seconds added from gazetteer",
+            "dwc:order": "Sapindales",
+            "flag_gbif_reference_added": true,
+            "idigbio:isocountrycode": "usa",
+            "flag_dwc_scientificnameauthorship_added": true,
+            "dwc:locality": "Mansfield Center, Wolfrock section of Nipmuck Trail, Crane Hill Road.",
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00070249"
+            ],
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00070249",
+            "dwc:scientificName": "Acer saccharinum L.",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189837",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero argentato"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable argenté"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable blanc"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:source": "korean peninsula flora",
+                "dwc:vernacularname": "은단풍"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "plaine blanche"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "plaine de france"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "river maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "silber-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "silber-ahorn",
+                "coreid": "3189837",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "silberahorn"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "silverlönn"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "silver maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "silver maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "silver maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "silver maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "soft maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "soft maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "white maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "white maple"
+              },
+              {
+                "coreid": "3189837",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "witte esdoorn"
+              }
+            ],
+            "flag_dwc_kingdom_replaced": true,
+            "flag_gbif_genericname_added": true,
+            "flag_dwc_parentnameusageid_added": true,
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dwc:stateProvince": "Connecticut",
+            "flag_dwc_taxonomicstatus_added": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:eventDate": "1999-02-19",
+            "dwc:country": "united states",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "gnu free documentation license",
+                "dcterms:title": "blattoberseite",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_saccharinum_002.jpg",
+                "coreid": "3189837",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/0/08/acer_saccharinum_002.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "de: silber-ahorn (acer saccharinum) im neuen botanischen garten marburg, hessen, deutschland en: silver maple (acer saccharinum) in the new botanical garden marburg, hesse, germany",
+                "dcterms:creator": "willow",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:silber-ahorn_(acer_saccharinum).jpg",
+                "coreid": "3189837",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/6/64/silber-ahorn_%28acer_saccharinum%29.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "gnu free documentation license",
+                "dcterms:title": "silber-ahorn (acer saccharinum)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_saccharinum_001.jpg",
+                "coreid": "3189837",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/d/db/acer_saccharinum_001.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "de: silber-ahorn (acer saccharinum) im neuen botanischen garten marburg, hessen, deutschland en: silver maple (acer saccharinum) in the new botanical garden marburg, hesse, germany",
+                "dcterms:creator": "willow",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "2d2c88d7840bafc1ab38d4d76878a5d6193a6bc1",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "41°45' 55\" N",
+            "gbif:reference": [
+              {
+                "coreid": "3189837",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "l. (1753) in: sp. pl. 1055"
+              }
+            ],
+            "dwc:kingdom": "plantae",
+            "dwc:decimalLatitude": "41.76527",
+            "dwc:occurrenceRemarks": "Tree 35 ft. tall by 19 in. wide, south of Wolf Rock, on east side of trail.",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "sapindaceae",
+            "flag_dwc_continent_added": true,
+            "flag_dwc_country_replaced": true,
+            "dwc:class": "magnoliopsida",
+            "dwc:municipality": "Mansfield",
+            "flag_dwc_taxonid_added": true,
+            "dwc:previousIdentifications": "Acer saccharinum L.",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "b51105ab-33eb-457a-bafc-43a57d77643d"
+              ]
+            },
+            "flag_dwc_class_added": true,
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:vernacularName": "Silver Maple",
+            "gbif:canonicalname": "acer saccharinum",
+            "dwc:scientificnameauthorship": "l.",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_phylum_added": true,
+            "gbif:genericname": "acer",
+            "dwc:georeferenceSources": "no date. Topozone. TopoZone.com © Maps a la carte, Inc. - All rights reserved.",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "UConn",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:reproductiveCondition": "winter / dormant condition",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Sapindales; Aceraceae",
+            "dwc:catalogNumber": "CONN00070249",
+            "dwc:taxonid": "3189837",
+            "dwc:taxonrank": "species",
+            "dwc:higherGeography": "USA; Connecticut; Tolland County; Mansfield",
+            "dwc:month": "2",
+            "dwc:decimalLongitude": "-72.19861",
+            "dwc:verbatimLongitude": "72°11' 55\" W",
+            "dwc:verbatimEventDate": "19-Feb-99",
+            "dwc:phylum": "tracheophyta",
+            "dwc:recordNumber": "40",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "flag_dwc_multimedia_added": true,
+            "flag_dwc_datasetid_replaced": true,
+            "dcterms:modified": "2012-04-05T00:00-0500",
+            "dwc:coordinateUncertaintyInMeters": "20000",
+            "dwc:day": "19",
+            "dwc:datasetID": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dwc:year": "1999"
+          },
+          "hasMedia": true,
+          "coordinateuncertainty": 20000,
+          "data": {
+            "dwc:specificEpithet": "saccharinum",
+            "dwc:countryCode": "US",
+            "dwc:county": "Tolland County",
+            "dwc:recordedBy": "Jody Foley",
+            "dwc:georeferenceSources": "no date. Topozone. TopoZone.com © Maps a la carte, Inc. - All rights reserved.",
+            "dwc:order": "Sapindales",
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00070249",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1999-02-19",
+            "dwc:country": "USA",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "41°45' 55\" N",
+            "dwc:kingdom": "Dicotyledonae",
+            "dwc:decimalLatitude": "41.76527",
+            "dwc:occurrenceRemarks": "Tree 35 ft. tall by 19 in. wide, south of Wolf Rock, on east side of trail.",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Aceraceae",
+            "dwc:coordinateUncertaintyInMeters": "20000",
+            "dwc:municipality": "Mansfield",
+            "dwc:previousIdentifications": "Acer saccharinum L.",
+            "dwc:vernacularName": "Silver Maple",
+            "dwc:locationAccordingTo": "seconds added from gazetteer",
+            "dwc:locality": "Mansfield Center, Wolfrock section of Nipmuck Trail, Crane Hill Road.",
+            "dwc:institutionCode": "UConn",
+            "dwc:reproductiveCondition": "winter / dormant condition",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Sapindales; Aceraceae",
+            "dwc:catalogNumber": "CONN00070249",
+            "dwc:higherGeography": "USA; Connecticut; Tolland County; Mansfield",
+            "dwc:month": "2",
+            "dwc:decimalLongitude": "-72.19861",
+            "dwc:verbatimLongitude": "72°11' 55\" W",
+            "dwc:verbatimEventDate": "19-Feb-99",
+            "dwc:recordNumber": "40",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "dcterms:modified": "2012-04-05T00:00-0500",
+            "dwc:scientificName": "Acer saccharinum L.",
+            "dwc:day": "19",
+            "dwc:datasetID": "62967",
+            "dwc:year": "1999"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:catalog:uconn:conn:conn00070249",
+          "country": "united states",
+          "locality": "mansfield center, wolfrock section of nipmuck trail, crane hill road.",
+          "collectioncode": "conn",
+          "canonicalname": "acer saccharinum",
+          "eventdate": "1999-02-19",
+          "flags": [
+            "geopoint_datum_missing",
+            "dwc_taxonrank_added",
+            "dwc_family_replaced",
+            "gbif_reference_added",
+            "dwc_scientificnameauthorship_added",
+            "dwc_kingdom_replaced",
+            "gbif_genericname_added",
+            "dwc_parentnameusageid_added",
+            "dwc_taxonomicstatus_added",
+            "dwc_continent_added",
+            "dwc_country_replaced",
+            "dwc_taxonid_added",
+            "dwc_class_added",
+            "idigbio_isocountrycode_added",
+            "gbif_canonicalname_added",
+            "dwc_phylum_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_multimedia_added",
+            "dwc_datasetid_replaced"
+          ],
+          "verbatimeventdate": "19-feb-99",
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00070249"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9a8fb7bd-de66-499f-a229-366f76d4c08d",
+        "_score": 1,
+        "_source": {
+          "family": "sapindaceae",
+          "recordset": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "dqs": 0.2318840579710145,
+          "stateprovince": "connecticut",
+          "municipality": "cheshire",
+          "county": "new haven county",
+          "phylum": "tracheophyta",
+          "catalognumber": "cbs.026036",
+          "startdayofyear": 269,
+          "taxonrank": "species",
+          "specificepithet": "spicatum",
+          "continent": "north america",
+          "uuid": "9a8fb7bd-de66-499f-a229-366f76d4c08d",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "arthur edmond blewitt",
+          "institutioncode": "yale peabody museum of natural history",
+          "mediarecords": [
+            "f0caf08c-a500-4327-9012-e839d62017ea"
+          ],
+          "datemodified": "2016-03-21T21:43:25.444854+00:00",
+          "datecollected": "1907-09-26T00:00:00+00:00",
+          "etag": "41d85c320a71e032c1fb6eddca3af7ca1daa97fe",
+          "recordnumber": "4290",
+          "hasImage": true,
+          "kingdom": "plantae",
+          "collectionid": "http://grbio.org/cool/x0m9-a3bs",
+          "taxonid": "3189848",
+          "scientificname": "acer spicatum",
+          "indexData": {
+            "dwc:startDayOfYear": "269",
+            "flag_dwc_taxonrank_added": true,
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "creative commons attribution share alike 3.0 unported",
+                "dcterms:title": "blätter",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_spicatum_jpg1l.jpg",
+                "coreid": "3189848",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/e/e3/acer_spicatum_jpg1l.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "français : feuilles d’érable à épis ou plaine bâtarde – acer spicatum année de plantation : 1998 position exacte : arboretum robert lenoir (s28 - 2968) - rendeux (belgique). english: hornbeam maple acer spicatum leaves planting date : 1998 precise location : arboretum robert lenoir (s28 - 2968) rendeux (belgium). walon: fouyes di bastaurde plane acer carpinifolium annéye do plantis' : 1998 place rècta : arboretum robert lenoir (s28 - 2968) - rindeu (bèljike).",
+                "dcterms:creator": "jean-pol grandmont",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "creative commons attribution share alike 3.0 unported",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_spicatum_jpg1l.jpg",
+                "coreid": "3189848",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/e/e3/acer_spicatum_jpg1l.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "français : feuilles d’érable à épis ou plaine bâtarde – acer spicatum année de plantation : 1998 position exacte : arboretum robert lenoir (s28 - 2968) - rendeux (belgique). english: hornbeam maple acer spicatum leaves planting date : 1998 precise location : arboretum robert lenoir (s28 - 2968) rendeux (belgium). walon: fouyes di bastaurde plane acer carpinifolium annéye do plantis' : 1998 place rècta : arboretum robert lenoir (s28 - 2968) - rindeu (bèljike).",
+                "dcterms:creator": "jean-pol grandmont",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "dwc:specificEpithet": "spicatum",
+            "idigbio:dateModified": "2016-03-21T21:43:25.444854",
+            "dwc:county": "New Haven County",
+            "dwc:recordedBy": "Arthur Edmond Blewitt",
+            "idigbio:uuid": "9a8fb7bd-de66-499f-a229-366f76d4c08d",
+            "flag_dwc_multimedia_added": true,
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110498",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "lam.",
+            "idigbio:recordIds": [
+              "urn:uuid:6c916224-a076-40d4-bb04-7670f7e7cfa2",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\urn:uuid:9fc10d21-7148-4590-b1bd-259bf1e2548b",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\110498"
+            ],
+            "dwc:occurrenceID": "urn:uuid:9fc10d21-7148-4590-b1bd-259bf1e2548b",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1907-09-26",
+            "flag_dwc_scientificnameauthorship_replaced": true,
+            "dwc:collectionID": "http://grbio.org/cool/x0m9-a3bs",
+            "dwc:country": "united states",
+            "idigbio:recordId": "urn:uuid:6c916224-a076-40d4-bb04-7670f7e7cfa2",
+            "idigbio:etag": "41d85c320a71e032c1fb6eddca3af7ca1daa97fe",
+            "dwc:collectionCode": "CBS",
+            "id": "110498",
+            "dwc:kingdom": "Plantae",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_phylum_replaced": true,
+            "dwc:municipality": "Cheshire",
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "usa",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "f0caf08c-a500-4327-9012-e839d62017ea"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "gbif:canonicalname": "acer spicatum",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "acer",
+            "dwc:locality": "The Notch",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "CBS.026036",
+            "dwc:taxonid": "3189848",
+            "dwc:taxonrank": "species",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189848",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "axlönn"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable à épis"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable bâtard"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "moose maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "moose maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "moose maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "mountain maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "mountain maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "mountain maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "mountain maple"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "plaine bâtarde"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "plaine bleue"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "vermont-ahorn"
+              },
+              {
+                "coreid": "3189848",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "white maple"
+              }
+            ],
+            "dwc:month": "9",
+            "flag_dwc_class_replaced": true,
+            "gbif:reference": [
+              {
+                "coreid": "3189848",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "lam. (1786) in: encyc. 2: 381"
+              }
+            ],
+            "flag_dwc_continent_added": true,
+            "dwc:recordNumber": "4290",
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dcterms:modified": "2011-07-23 00:00:00",
+            "dwc:scientificName": "Acer spicatum",
+            "dwc:day": "26",
+            "dwc:year": "1907"
+          },
+          "hasMedia": true,
+          "data": {
+            "dwc:startDayOfYear": "269",
+            "dwc:specificEpithet": "spicatum",
+            "dwc:county": "New Haven County",
+            "dwc:recordedBy": "Arthur Edmond Blewitt",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110498",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:occurrenceID": "urn:uuid:9fc10d21-7148-4590-b1bd-259bf1e2548b",
+            "dwc:scientificNameAuthorship": "Lam.",
+            "id": "110498",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1907-09-26",
+            "dwc:collectionID": "http://grbio.org/cool/x0m9-a3bs",
+            "dwc:country": "USA",
+            "idigbio:recordId": "urn:uuid:6c916224-a076-40d4-bb04-7670f7e7cfa2",
+            "dwc:collectionCode": "CBS",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:kingdom": "Plantae",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:municipality": "Cheshire",
+            "dwc:phylum": "Charophyta",
+            "dwc:locality": "The Notch",
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "dwc:class": "Equisetopsida",
+            "dwc:catalogNumber": "CBS.026036",
+            "dwc:month": "9",
+            "dwc:recordNumber": "4290",
+            "dcterms:modified": "2011-07-23 00:00:00",
+            "dwc:scientificName": "Acer spicatum",
+            "dwc:day": "26",
+            "dwc:year": "1907"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:9fc10d21-7148-4590-b1bd-259bf1e2548b",
+          "country": "united states",
+          "locality": "the notch",
+          "collectioncode": "cbs",
+          "canonicalname": "acer spicatum",
+          "eventdate": "1907-09-26",
+          "flags": [
+            "dwc_taxonrank_added",
+            "dwc_multimedia_added",
+            "gbif_reference_added",
+            "gbif_canonicalname_added",
+            "dwc_country_replaced",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_scientificnameauthorship_replaced",
+            "dwc_parentnameusageid_added",
+            "dwc_phylum_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_class_replaced",
+            "dwc_continent_added"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "urn:uuid:6c916224-a076-40d4-bb04-7670f7e7cfa2",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\urn:uuid:9fc10d21-7148-4590-b1bd-259bf1e2548b",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\110498"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e81e2a6e-36f8-44e1-a80a-dbabcf7c1a41",
+        "_score": 1,
+        "_source": {
+          "family": "sapindaceae",
+          "recordset": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+          "dqs": 0.13043478260869565,
+          "stateprovince": "75 paris",
+          "phylum": "tracheophyta",
+          "catalognumber": "p00047742",
+          "taxonrank": "species",
+          "specificepithet": "pseudoplatanus",
+          "verbatimlocality": "terrasse du collège henry iv",
+          "datemodified": "2021-04-19T22:06:14.550973+00:00",
+          "uuid": "e81e2a6e-36f8-44e1-a80a-dbabcf7c1a41",
+          "countrycode": "fra",
+          "basisofrecord": "preservedspecimen",
+          "collector": "crevoisier, e.",
+          "institutioncode": "mnhn",
+          "mediarecords": [
+            "39c5f12d-5933-4def-97d6-3019f6bf54d4",
+            "42747526-ebb3-4959-ae2b-7607c00281b1"
+          ],
+          "continent": "europe",
+          "etag": "68040292ab2202cd6418889587e8cf35fa856f82",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "taxonid": "3189870",
+          "scientificname": "acer pseudoplatanus l.",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "idigbio:dateModified": "2021-04-19T22:06:14.550973",
+            "dwc:countryCode": "fr",
+            "dwc:kingdom": "plantae",
+            "dwc:recordedBy": "Crevoisier, E.",
+            "idigbio:uuid": "e81e2a6e-36f8-44e1-a80a-dbabcf7c1a41",
+            "flag_dwc_multimedia_added": true,
+            "gbif:canonicalname": "acer pseudoplatanus",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "L.",
+            "idigbio:recordIds": [
+              "616857b7-f952-44ef-9b6f-576dc1e65b51\\http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742"
+            ],
+            "dwc:occurrenceID": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+            "flag_dwc_specificepithet_added": true,
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "id": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+            "dwc:stateProvince": "75 Paris",
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dwc:country": "France",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "gnu free documentation license",
+                "dcterms:title": "a. pseudoplatanus in the bergpark wilhelmshöhe, kassel",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pseudoplatanus_005.jpg",
+                "coreid": "3189870",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/c/cd/acer_pseudoplatanus_005.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "deutsch: bergahorn (acer pseudoplatanus) im schlosspark wilhelmshöhe, kassel, hessen, deutschland english: sycamore maple (acer pseudoplatanus) in the schlosspark wilhelmshöhe, kassel, hesse, germany",
+                "dcterms:creator": "willow",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "public domain mark 1.0",
+                "dcterms:title": "berg-ahorn (acer pseudoplatanus)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pseudoplatanusaa.jpg",
+                "coreid": "3189870",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/f/fb/acer_pseudoplatanusaa.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "amsterdam, johannes allart, 1802 [-1808]",
+                "dcterms:creator": "user:mpf",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "68040292ab2202cd6418889587e8cf35fa856f82",
+            "dwc:collectionCode": "P",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "europe",
+            "dwc:family": "Sapindaceae",
+            "flag_dwc_continent_added": true,
+            "flag_dwc_parentnameusageid_added": true,
+            "dwc:specificepithet": "pseudoplatanus",
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "fra",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "39c5f12d-5933-4def-97d6-3019f6bf54d4",
+                "42747526-ebb3-4959-ae2b-7607c00281b1"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:order": "sapindales",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_phylum_added": true,
+            "gbif:genericname": "acer",
+            "dwc:locality": "Paris",
+            "dwc:fieldNotes": "Dicotylédone - acérinée - acer / fleurs en panicules racémiformes pendantes . feuilles blanches en dessous.",
+            "dwc:institutionCode": "MNHN",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "P00047742",
+            "dwc:taxonid": "3189870",
+            "gbif:Identifier": [
+              {
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+                "dcterms:identifier": "E6046C4ADB0D4075BF7D0D7AF082DCF0",
+                "dcterms:subject": "e-recolnat"
+              }
+            ],
+            "dwc:taxonrank": "species",
+            "dwc:Identification": [
+              {
+                "dwc:taxonID": "SONNERAT|13980",
+                "dwc:identificationVerificationStatus": "1",
+                "dwc:specificEpithet": "pseudoplatanus",
+                "dwc:scientificNameAuthorship": "L.",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+                "dwc:identificationID": "SONNERAT|66764",
+                "dwc:genus": "Acer",
+                "dwc:scientificName": "Acer pseudoplatanus L.",
+                "dwc:higherClassification": "Acer;Sapindaceae",
+                "dwc:family": "Sapindaceae"
+              },
+              {
+                "dwc:taxonID": "SONNERAT|13980",
+                "dwc:identificationRemarks": "operation de numerisation 2010-2012",
+                "dwc:specificEpithet": "pseudoplatanus",
+                "dwc:identificationID": "SONNERAT|7170284",
+                "dwc:identificationVerificationStatus": "0",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+                "dwc:scientificNameAuthorship": "L.",
+                "dwc:genus": "Acer",
+                "dwc:scientificName": "Acer pseudoplatanus L.",
+                "dwc:higherClassification": "Acer;Sapindaceae",
+                "dwc:family": "Sapindaceae"
+              }
+            ],
+            "dwc:month": "5",
+            "flag_dwc_order_added": true,
+            "dwc:verbatimLocality": "terrasse du collège Henry IV",
+            "gbif:reference": [
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "l. (1753) in: sp. pl.: 1054"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "dwc:phylum": "tracheophyta",
+            "dwc:preparations": "hb",
+            "flag_dwc_class_added": true,
+            "dcterms:modified": "2015-09-15 16:03:36.0",
+            "dwc:scientificName": "Acer pseudoplatanus L.",
+            "dwc:day": "20",
+            "flag_dwc_kingdom_added": true,
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189870",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero montano"
+              },
+              {
+                "dwc:countrycode": "dk",
+                "dwc:country": "denmark",
+                "dwc:vernacularname": "ahorn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "da"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "bergahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "bergahorn",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "berg-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "berg-ahorn",
+                "coreid": "3189870",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "bergahorn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "berg-ahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "érable sycomore",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable sycomore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "fr",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "érable sycomore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "false planetree"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "gewone esdoorn",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "gewone esdoorn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "great maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen lo&zcaron;noplatanovyj"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "platanlønn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nb"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "platanlønn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "scottish maple"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "sycamore",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sycamore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sycamore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "tysklönn"
+              },
+              {
+                "dwc:countrycode": "se",
+                "dwc:country": "sweden",
+                "dwc:vernacularname": "tysklönn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "vuorivaahtera",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "fi"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "vuorivaahtera",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              }
+            ]
+          },
+          "data": {
+            "dwc:countryCode": "fr",
+            "dwc:recordedBy": "Crevoisier, E.",
+            "dwc:scientificNameAuthorship": "L.",
+            "dwc:occurrenceID": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+            "id": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+            "dwc:stateProvince": "75 Paris",
+            "dwc:country": "France",
+            "dwc:collectionCode": "P",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:preparations": "hb",
+            "dwc:locality": "Paris",
+            "dwc:fieldNotes": "Dicotylédone - acérinée - acer / fleurs en panicules racémiformes pendantes . feuilles blanches en dessous.",
+            "dwc:institutionCode": "MNHN",
+            "dwc:catalogNumber": "P00047742",
+            "gbif:Identifier": [
+              {
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+                "dcterms:identifier": "E6046C4ADB0D4075BF7D0D7AF082DCF0",
+                "dcterms:subject": "e-recolnat"
+              }
+            ],
+            "dwc:Identification": [
+              {
+                "dwc:taxonID": "SONNERAT|13980",
+                "dwc:identificationVerificationStatus": "1",
+                "dwc:specificEpithet": "pseudoplatanus",
+                "dwc:scientificNameAuthorship": "L.",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+                "dwc:identificationID": "SONNERAT|66764",
+                "dwc:genus": "Acer",
+                "dwc:scientificName": "Acer pseudoplatanus L.",
+                "dwc:higherClassification": "Acer;Sapindaceae",
+                "dwc:family": "Sapindaceae"
+              },
+              {
+                "dwc:taxonID": "SONNERAT|13980",
+                "dwc:identificationRemarks": "operation de numerisation 2010-2012",
+                "dwc:specificEpithet": "pseudoplatanus",
+                "dwc:scientificNameAuthorship": "L.",
+                "dwc:identificationVerificationStatus": "0",
+                "coreid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+                "dwc:identificationID": "SONNERAT|7170284",
+                "dwc:genus": "Acer",
+                "dwc:scientificName": "Acer pseudoplatanus L.",
+                "dwc:higherClassification": "Acer;Sapindaceae",
+                "dwc:family": "Sapindaceae"
+              }
+            ],
+            "dwc:month": "5",
+            "dwc:verbatimLocality": "terrasse du collège Henry IV",
+            "dwc:family": "Sapindaceae",
+            "dcterms:modified": "2015-09-15 16:03:36.0",
+            "dwc:scientificName": "Acer pseudoplatanus L.",
+            "dwc:day": "20"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742",
+          "country": "france",
+          "locality": "paris",
+          "collectioncode": "p",
+          "canonicalname": "acer pseudoplatanus",
+          "flags": [
+            "dwc_taxonrank_added",
+            "dwc_multimedia_added",
+            "gbif_reference_added",
+            "dwc_specificepithet_added",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "gbif_vernacularname_added",
+            "dwc_continent_added",
+            "dwc_parentnameusageid_added",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "gbif_canonicalname_added",
+            "dwc_phylum_added",
+            "gbif_taxon_corrected",
+            "dwc_order_added",
+            "dwc_class_added",
+            "dwc_kingdom_added"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "616857b7-f952-44ef-9b6f-576dc1e65b51\\http://coldb.mnhn.fr/catalognumber/mnhn/p/p00047742"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "de605db9-65a3-4fd0-950b-82a88c6d2828",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lat": 41.56444,
+            "lon": -72.79527
+          },
+          "family": "sapindaceae",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.2463768115942029,
+          "stateprovince": "connecticut",
+          "institutioncode": "uconn",
+          "municipality": "meriden",
+          "county": "new haven county",
+          "phylum": "tracheophyta",
+          "catalognumber": "conn00078635",
+          "startdayofyear": 138,
+          "taxonrank": "species",
+          "specificepithet": "pensylvanicum",
+          "continent": "north america",
+          "uuid": "de605db9-65a3-4fd0-950b-82a88c6d2828",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "g.s. torrey",
+          "commonnames": [
+            "Moosewood; Snake-Bark Maple; Striped Maple"
+          ],
+          "mediarecords": [
+            "8ad43dd0-da79-4834-bcb6-442793fbbaa2"
+          ],
+          "datemodified": "2014-09-09T02:58:24.436000+00:00",
+          "datecollected": "1958-05-18T00:00:00+00:00",
+          "etag": "f5d5c7a1a14fc111ff24aeecb39c9ec51e4d431d",
+          "recordnumber": "5528",
+          "hasImage": true,
+          "kingdom": "plantae",
+          "highertaxon": "plantae; dicotyledonae; sapindales; aceraceae",
+          "commonname": "moosewood; snake-bark maple; striped maple",
+          "taxonid": "3189836",
+          "scientificname": "acer pensylvanicum l.",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "flag_dwc_family_replaced": true,
+            "dwc:specificEpithet": "pensylvanicum",
+            "idigbio:dateModified": "2014-09-09T02:58:24.436000",
+            "dwc:countryCode": "US",
+            "dwc:county": "New Haven County",
+            "dwc:recordedBy": "G.S. Torrey",
+            "idigbio:uuid": "de605db9-65a3-4fd0-950b-82a88c6d2828",
+            "dwc:georeferenceSources": "no date. Topozone. TopoZone.com © Maps a la carte, Inc. - All rights reserved.",
+            "dwc:order": "Sapindales",
+            "flag_gbif_reference_added": true,
+            "idigbio:isocountrycode": "usa",
+            "flag_dwc_scientificnameauthorship_added": true,
+            "dwc:locality": "Trap ridge woods, Cathole Pass, Meriden, CT.",
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00078635"
+            ],
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00078635",
+            "dwc:scientificName": "Acer pensylvanicum L.",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189836",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "amerikansk strimlönn"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "bois barré"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "bois d'orignal"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable bois-barré"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable de pennsylvanie"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "goosefoot"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "moose maple"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "moosewood"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "moosewood"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "moosewood"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "pennsylvanischer ahorn"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "snakebark maple"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "snakebark maple"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "streifen-ahorn"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "streifenahorn"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "striped maple"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "striped maple"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "striped maple"
+              },
+              {
+                "coreid": "3189836",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "striped maple"
+              }
+            ],
+            "flag_dwc_kingdom_replaced": true,
+            "flag_gbif_genericname_added": true,
+            "flag_dwc_parentnameusageid_added": true,
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dwc:stateProvince": "Connecticut",
+            "flag_dwc_taxonomicstatus_added": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:eventDate": "1958-05-18",
+            "dwc:country": "united states",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "public domain",
+                "dcterms:title": "striped maple leaves, cranberry wilderness, west virginia",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:moosewood_leaves.jpg",
+                "coreid": "3189836",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/7/72/moosewood_leaves.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "english: photo taken july, 2005, cranberry wilderness, west virginia",
+                "dcterms:creator": "original uploader was jaknouse at en.wikipedia",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "creative commons attribution share alike 3.0 migrated",
+                "dcterms:title": "streifen-ahorn (acer pensylvanicum)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pensylvanicum3.jpg",
+                "coreid": "3189836",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/7/74/acer_pensylvanicum3.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "f5d5c7a1a14fc111ff24aeecb39c9ec51e4d431d",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "41°32' 112\" N",
+            "gbif:reference": [
+              {
+                "coreid": "3189836",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "l. (1753) in: sp. pl. 1055"
+              }
+            ],
+            "dwc:kingdom": "plantae",
+            "dwc:decimalLatitude": "41.56444",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "sapindaceae",
+            "flag_dwc_continent_added": true,
+            "flag_dwc_country_replaced": true,
+            "dwc:class": "magnoliopsida",
+            "dwc:municipality": "Meriden",
+            "flag_dwc_taxonid_added": true,
+            "dwc:previousIdentifications": "Acer pensylvanicum L.",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "8ad43dd0-da79-4834-bcb6-442793fbbaa2"
+              ]
+            },
+            "flag_dwc_class_added": true,
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:vernacularName": "Moosewood; Snake-Bark Maple; Striped Maple",
+            "gbif:canonicalname": "acer pensylvanicum",
+            "dwc:scientificnameauthorship": "l.",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_phylum_added": true,
+            "gbif:genericname": "acer",
+            "dwc:locationAccordingTo": "seconds added from gazetteer",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "UConn",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:reproductiveCondition": "flowering",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Sapindales; Aceraceae",
+            "dwc:catalogNumber": "CONN00078635",
+            "dwc:taxonid": "3189836",
+            "dwc:taxonrank": "species",
+            "dwc:higherGeography": "USA; Connecticut; New Haven County; Meriden",
+            "dwc:month": "5",
+            "dwc:decimalLongitude": "-72.79527",
+            "dwc:verbatimLongitude": "72°47' 43\" W",
+            "dwc:verbatimEventDate": "18-May-58",
+            "dwc:phylum": "tracheophyta",
+            "dwc:recordNumber": "5528",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "flag_dwc_multimedia_added": true,
+            "flag_dwc_datasetid_replaced": true,
+            "dcterms:modified": "2009-05-21T00:00-0500",
+            "dwc:coordinateUncertaintyInMeters": "20000",
+            "dwc:day": "18",
+            "dwc:datasetID": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dwc:year": "1958"
+          },
+          "hasMedia": true,
+          "coordinateuncertainty": 20000,
+          "data": {
+            "dwc:specificEpithet": "pensylvanicum",
+            "dwc:countryCode": "US",
+            "dwc:county": "New Haven County",
+            "dwc:recordedBy": "G.S. Torrey",
+            "dwc:georeferenceSources": "no date. Topozone. TopoZone.com © Maps a la carte, Inc. - All rights reserved.",
+            "dwc:order": "Sapindales",
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00078635",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1958-05-18",
+            "dwc:country": "USA",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "41°32' 112\" N",
+            "dwc:kingdom": "Dicotyledonae",
+            "dwc:decimalLatitude": "41.56444",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Aceraceae",
+            "dwc:coordinateUncertaintyInMeters": "20000",
+            "dwc:municipality": "Meriden",
+            "dwc:previousIdentifications": "Acer pensylvanicum L.",
+            "dwc:vernacularName": "Moosewood; Snake-Bark Maple; Striped Maple",
+            "dwc:locationAccordingTo": "seconds added from gazetteer",
+            "dwc:locality": "Trap ridge woods, Cathole Pass, Meriden, CT.",
+            "dwc:institutionCode": "UConn",
+            "dwc:reproductiveCondition": "flowering",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Sapindales; Aceraceae",
+            "dwc:catalogNumber": "CONN00078635",
+            "dwc:higherGeography": "USA; Connecticut; New Haven County; Meriden",
+            "dwc:month": "5",
+            "dwc:decimalLongitude": "-72.79527",
+            "dwc:verbatimLongitude": "72°47' 43\" W",
+            "dwc:verbatimEventDate": "18-May-58",
+            "dwc:recordNumber": "5528",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "dcterms:modified": "2009-05-21T00:00-0500",
+            "dwc:scientificName": "Acer pensylvanicum L.",
+            "dwc:day": "18",
+            "dwc:datasetID": "68670",
+            "dwc:year": "1958"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:catalog:uconn:conn:conn00078635",
+          "country": "united states",
+          "locality": "trap ridge woods, cathole pass, meriden, ct.",
+          "collectioncode": "conn",
+          "canonicalname": "acer pensylvanicum",
+          "eventdate": "1958-05-18",
+          "flags": [
+            "geopoint_datum_missing",
+            "dwc_taxonrank_added",
+            "dwc_family_replaced",
+            "gbif_reference_added",
+            "dwc_scientificnameauthorship_added",
+            "dwc_kingdom_replaced",
+            "gbif_genericname_added",
+            "dwc_parentnameusageid_added",
+            "dwc_taxonomicstatus_added",
+            "dwc_continent_added",
+            "dwc_country_replaced",
+            "dwc_taxonid_added",
+            "dwc_class_added",
+            "idigbio_isocountrycode_added",
+            "gbif_canonicalname_added",
+            "dwc_phylum_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_multimedia_added",
+            "dwc_datasetid_replaced"
+          ],
+          "verbatimeventdate": "18-may-58",
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00078635"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "df6e800e-e2e1-4fcf-9940-fb738b70e7ed",
+        "_score": 1,
+        "_source": {
+          "family": "sapindaceae",
+          "recordset": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "stateprovince": "massachusetts",
+          "phylum": "tracheophyta",
+          "catalognumber": "yu.076227",
+          "startdayofyear": 134,
+          "taxonrank": "species",
+          "specificepithet": "saccharum",
+          "continent": "north america",
+          "uuid": "df6e800e-e2e1-4fcf-9940-fb738b70e7ed",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "c. w. swan",
+          "institutioncode": "yale peabody museum of natural history",
+          "mediarecords": [
+            "ef158cc6-2f94-48e5-92be-e608631f990f"
+          ],
+          "datemodified": "2016-01-27T21:25:22.884015+00:00",
+          "datecollected": "1883-05-14T00:00:00+00:00",
+          "etag": "40afcc8743e5335c309c3e97915d13e0c8ec57eb",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "collectionid": "urn:lsid:biocol.org:col:14791",
+          "taxonid": "3189859",
+          "scientificname": "acer saccharum",
+          "indexData": {
+            "dwc:startDayOfYear": "134",
+            "flag_dwc_taxonrank_added": true,
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:title": "zucker-ahorn (acer saccharum)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_saccharum_jpg01.jpg",
+                "coreid": "3189859",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/0/04/acer_saccharum_jpg01.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "français : meise (belgique), jardin national botanique de belgique - acer saccharum - Érable à sucre. english: meise (belgium), national garden of belgium - plant palace - acer saccharum - sugarmaple. nederlands: meise (belgië), nationale plantentuin van belgië - plantenpaleis – acer saccharum - suikeresdoorn. walon: meise (bèljike), djârdin national di bèljike - acer saccharum - aube a suke.",
+                "dcterms:creator": "jean-pol grandmont",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:title": "sugar maple in morton arboretum",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_saccharum.jpg",
+                "coreid": "3189859",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/2/26/acer_saccharum.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "sugar maple tree, acer saccharum. specimen at morton arboretum, lisle, illinois. accession 258-78-1.",
+                "dcterms:creator": "bruce marlin",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "dwc:specificEpithet": "saccharum",
+            "idigbio:dateModified": "2016-01-27T21:25:22.884015",
+            "dwc:kingdom": "Plantae",
+            "dwc:recordedBy": "C. W. Swan",
+            "idigbio:uuid": "df6e800e-e2e1-4fcf-9940-fb738b70e7ed",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807945",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "marshall",
+            "idigbio:recordIds": [
+              "urn:uuid:3e7dd858-0ee0-44c4-98c4-72a95a275b0c",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\urn:uuid:6504d3db-a170-45ef-af81-c01de16d6f85",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\807945"
+            ],
+            "dwc:occurrenceID": "urn:uuid:6504d3db-a170-45ef-af81-c01de16d6f85",
+            "flag_gbif_canonicalname_added": true,
+            "id": "807945",
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "symbiota:recordEnteredBy": "Bob Swerling",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+            "dwc:stateProvince": "Massachusetts",
+            "dwc:eventDate": "1883-05-14",
+            "flag_dwc_scientificnameauthorship_replaced": true,
+            "dwc:collectionID": "urn:lsid:biocol.org:col:14791",
+            "dwc:country": "united states",
+            "idigbio:recordId": "urn:uuid:3e7dd858-0ee0-44c4-98c4-72a95a275b0c",
+            "idigbio:etag": "40afcc8743e5335c309c3e97915d13e0c8ec57eb",
+            "dwc:collectionCode": "YU",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_phylum_replaced": true,
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "usa",
+            "gbif:reference": [
+              {
+                "coreid": "3189834",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "idigbio:siblings": {
+              "mediarecord": [
+                "ef158cc6-2f94-48e5-92be-e608631f990f"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "gbif:canonicalname": "acer saccharum",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "acer",
+            "flag_dwc_multimedia_added": true,
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "YU.076227",
+            "dwc:taxonid": "3189859",
+            "dwc:taxonrank": "species",
+            "dwc:Identification": [
+              {
+                "coreid": "807945",
+                "dwc:identificationRemarks": "0",
+                "idigbio:recordId": "urn:uuid:f82d1222-8a7b-4349-9b71-189e31334b13",
+                "dwc:scientificName": "Acer saccharum Marsh.",
+                "dwc:scientificNameAuthorship": "Marsh."
+              }
+            ],
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189859",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable à sucre"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable franc"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable franche"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "hard maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:source": "korean peninsula flora",
+                "dwc:vernacularname": "설탕단풍"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "rock maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "sugar maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "sugar maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "en",
+                "dcterms:source": "english wikipedia - species pages",
+                "dwc:vernacularname": "sugar maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sugar maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sugar maple"
+              },
+              {
+                "coreid": "3189859",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "zucker-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "zucker-ahorn",
+                "coreid": "3189859",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              }
+            ],
+            "dwc:month": "5",
+            "flag_dwc_class_replaced": true,
+            "dwc:verbatimEventDate": "5-14-83",
+            "flag_dwc_continent_added": true,
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dcterms:modified": "2015-06-17 13:01:45",
+            "dwc:scientificName": "Acer saccharum",
+            "dwc:day": "14",
+            "dwc:year": "1883"
+          },
+          "data": {
+            "dwc:startDayOfYear": "134",
+            "dwc:specificEpithet": "saccharum",
+            "dwc:kingdom": "Plantae",
+            "dwc:recordedBy": "C. W. Swan",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807945",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:occurrenceID": "urn:uuid:6504d3db-a170-45ef-af81-c01de16d6f85",
+            "dwc:scientificNameAuthorship": "Marsh.",
+            "id": "807945",
+            "symbiota:recordEnteredBy": "Bob Swerling",
+            "dwc:stateProvince": "Massachusetts",
+            "dwc:eventDate": "1883-05-14",
+            "dwc:collectionID": "urn:lsid:biocol.org:col:14791",
+            "dwc:country": "United States of America",
+            "idigbio:recordId": "urn:uuid:3e7dd858-0ee0-44c4-98c4-72a95a275b0c",
+            "dwc:collectionCode": "YU",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:phylum": "Charophyta",
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "dwc:class": "Equisetopsida",
+            "dwc:catalogNumber": "YU.076227",
+            "dwc:Identification": [
+              {
+                "coreid": "807945",
+                "dwc:identificationRemarks": "0",
+                "idigbio:recordId": "urn:uuid:f82d1222-8a7b-4349-9b71-189e31334b13",
+                "dwc:scientificName": "Acer saccharum Marsh.",
+                "dwc:scientificNameAuthorship": "Marsh."
+              }
+            ],
+            "dwc:month": "5",
+            "dwc:verbatimEventDate": "5-14-83",
+            "dcterms:modified": "2015-06-17 13:01:45",
+            "dwc:scientificName": "Acer saccharum",
+            "dwc:day": "14",
+            "dwc:year": "1883"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:6504d3db-a170-45ef-af81-c01de16d6f85",
+          "country": "united states",
+          "dqs": 0.18840579710144928,
+          "collectioncode": "yu",
+          "canonicalname": "acer saccharum",
+          "eventdate": "1883-05-14",
+          "flags": [
+            "dwc_taxonrank_added",
+            "gbif_reference_added",
+            "gbif_canonicalname_added",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_scientificnameauthorship_replaced",
+            "dwc_parentnameusageid_added",
+            "dwc_phylum_replaced",
+            "dwc_country_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "dwc_multimedia_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_class_replaced",
+            "dwc_continent_added"
+          ],
+          "verbatimeventdate": "5-14-83",
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "urn:uuid:3e7dd858-0ee0-44c4-98c4-72a95a275b0c",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\urn:uuid:6504d3db-a170-45ef-af81-c01de16d6f85",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\807945"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e0690554-8c60-494b-85f0-d07553b9e59e",
+        "_score": 1,
+        "_source": {
+          "family": "sapindaceae",
+          "recordset": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "dqs": 0.2463768115942029,
+          "stateprovince": "connecticut",
+          "municipality": "wethersfield",
+          "county": "hartford county",
+          "phylum": "tracheophyta",
+          "catalognumber": "cbs.025833",
+          "startdayofyear": 145,
+          "taxonrank": "species",
+          "specificepithet": "pseudoplatanus",
+          "continent": "north america",
+          "uuid": "e0690554-8c60-494b-85f0-d07553b9e59e",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "hugh s. clark",
+          "institutioncode": "yale peabody museum of natural history",
+          "mediarecords": [
+            "c9f1880b-39de-4aaf-95d1-2365f9cae04d"
+          ],
+          "datemodified": "2016-03-21T21:43:25.444854+00:00",
+          "datecollected": "1901-05-25T00:00:00+00:00",
+          "etag": "10b5d8c49419e7524281708a71780f39e898f68c",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "collectionid": "http://grbio.org/cool/x0m9-a3bs",
+          "taxonid": "3189870",
+          "scientificname": "acer pseudoplatanus",
+          "indexData": {
+            "dwc:startDayOfYear": "145",
+            "flag_dwc_taxonrank_added": true,
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "gnu free documentation license",
+                "dcterms:title": "a. pseudoplatanus in the bergpark wilhelmshöhe, kassel",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pseudoplatanus_005.jpg",
+                "coreid": "3189870",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/c/cd/acer_pseudoplatanus_005.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "deutsch: bergahorn (acer pseudoplatanus) im schlosspark wilhelmshöhe, kassel, hessen, deutschland english: sycamore maple (acer pseudoplatanus) in the schlosspark wilhelmshöhe, kassel, hesse, germany",
+                "dcterms:creator": "willow",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "public domain mark 1.0",
+                "dcterms:title": "berg-ahorn (acer pseudoplatanus)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pseudoplatanusaa.jpg",
+                "coreid": "3189870",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/f/fb/acer_pseudoplatanusaa.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "amsterdam, johannes allart, 1802 [-1808]",
+                "dcterms:creator": "user:mpf",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "dwc:specificEpithet": "pseudoplatanus",
+            "idigbio:dateModified": "2016-03-21T21:43:25.444854",
+            "dwc:county": "Hartford County",
+            "dwc:recordedBy": "Hugh S. Clark",
+            "idigbio:uuid": "e0690554-8c60-494b-85f0-d07553b9e59e",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110335",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "L.",
+            "idigbio:recordIds": [
+              "urn:uuid:c183a846-5fe6-4901-8e6a-79147feead7d",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\urn:uuid:bc642633-9440-430f-a6e4-b2c21fc10237",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\110335"
+            ],
+            "dwc:occurrenceID": "urn:uuid:bc642633-9440-430f-a6e4-b2c21fc10237",
+            "flag_gbif_canonicalname_added": true,
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189870",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero montano"
+              },
+              {
+                "dwc:countrycode": "dk",
+                "dwc:country": "denmark",
+                "dwc:vernacularname": "ahorn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "da"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "bergahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "bergahorn",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "berg-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "berg-ahorn",
+                "coreid": "3189870",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "bergahorn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "berg-ahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "érable sycomore",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable sycomore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "fr",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "érable sycomore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "false planetree"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "gewone esdoorn",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "gewone esdoorn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "great maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen lo&zcaron;noplatanovyj"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "platanlønn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nb"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "platanlønn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "scottish maple"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "sycamore",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sycamore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sycamore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "tysklönn"
+              },
+              {
+                "dwc:countrycode": "se",
+                "dwc:country": "sweden",
+                "dwc:vernacularname": "tysklönn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "vuorivaahtera",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "fi"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "vuorivaahtera",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              }
+            ],
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1901-05-25",
+            "dwc:collectionID": "http://grbio.org/cool/x0m9-a3bs",
+            "dwc:country": "united states",
+            "idigbio:recordId": "urn:uuid:c183a846-5fe6-4901-8e6a-79147feead7d",
+            "idigbio:etag": "10b5d8c49419e7524281708a71780f39e898f68c",
+            "dwc:collectionCode": "CBS",
+            "id": "110335",
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "41.7012",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_phylum_replaced": true,
+            "dwc:municipality": "Wethersfield",
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "usa",
+            "dwc:geodeticDatum": "WGS84",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "c9f1880b-39de-4aaf-95d1-2365f9cae04d"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "gbif:canonicalname": "acer pseudoplatanus",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "acer",
+            "flag_dwc_multimedia_added": true,
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "CBS.025833",
+            "dwc:taxonid": "3189870",
+            "dwc:taxonrank": "species",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:decimalLongitude": "-72.6704",
+            "dwc:scientificName": "Acer pseudoplatanus",
+            "dwc:month": "5",
+            "flag_dwc_class_replaced": true,
+            "gbif:reference": [
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "l. (1753) in: sp. pl.: 1054"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "flag_dwc_continent_added": true,
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dcterms:modified": "2011-07-20 00:00:00",
+            "dwc:coordinateUncertaintyInMeters": "4657",
+            "dwc:day": "25",
+            "dwc:year": "1901"
+          },
+          "coordinateuncertainty": 4657,
+          "data": {
+            "dwc:startDayOfYear": "145",
+            "dwc:specificEpithet": "pseudoplatanus",
+            "dwc:county": "Hartford County",
+            "dwc:recordedBy": "Hugh S. Clark",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110335",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:occurrenceID": "urn:uuid:bc642633-9440-430f-a6e4-b2c21fc10237",
+            "dwc:scientificNameAuthorship": "L.",
+            "id": "110335",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1901-05-25",
+            "dwc:collectionID": "http://grbio.org/cool/x0m9-a3bs",
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "dwc:country": "USA",
+            "idigbio:recordId": "urn:uuid:c183a846-5fe6-4901-8e6a-79147feead7d",
+            "dwc:collectionCode": "CBS",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "41.7012",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:municipality": "Wethersfield",
+            "dwc:phylum": "Charophyta",
+            "dwc:geodeticDatum": "WGS84",
+            "dwc:class": "Equisetopsida",
+            "dwc:catalogNumber": "CBS.025833",
+            "dwc:month": "5",
+            "dwc:decimalLongitude": "-72.6704",
+            "dwc:coordinateUncertaintyInMeters": "4657",
+            "dcterms:modified": "2011-07-20 00:00:00",
+            "dwc:scientificName": "Acer pseudoplatanus",
+            "dwc:day": "25",
+            "dwc:year": "1901"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:bc642633-9440-430f-a6e4-b2c21fc10237",
+          "country": "united states",
+          "geopoint": {
+            "lat": 41.7012,
+            "lon": -72.6704
+          },
+          "collectioncode": "cbs",
+          "canonicalname": "acer pseudoplatanus",
+          "eventdate": "1901-05-25",
+          "flags": [
+            "dwc_taxonrank_added",
+            "gbif_reference_added",
+            "gbif_canonicalname_added",
+            "dwc_country_replaced",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_parentnameusageid_added",
+            "dwc_phylum_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "dwc_multimedia_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_class_replaced",
+            "dwc_continent_added"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "urn:uuid:c183a846-5fe6-4901-8e6a-79147feead7d",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\urn:uuid:bc642633-9440-430f-a6e4-b2c21fc10237",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\110335"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7a9fda29-5231-456c-8d59-bef531e36e8e",
+        "_score": 1,
+        "_source": {
+          "family": "sapindaceae",
+          "recordset": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "stateprovince": "massachusetts",
+          "municipality": "milton",
+          "county": "norfolk",
+          "phylum": "tracheophyta",
+          "catalognumber": "yu.076200",
+          "startdayofyear": 127,
+          "taxonrank": "species",
+          "specificepithet": "platanoides",
+          "continent": "north america",
+          "uuid": "7a9fda29-5231-456c-8d59-bef531e36e8e",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "c. w. swan",
+          "institutioncode": "yale peabody museum of natural history",
+          "mediarecords": [
+            "8e25027c-64e7-445c-aaae-e80df0c67e72"
+          ],
+          "datemodified": "2016-01-27T21:25:22.884015+00:00",
+          "datecollected": "1883-05-07T00:00:00+00:00",
+          "etag": "1f631099cc371c214fff4041e849dddb1c5078f7",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "collectionid": "urn:lsid:biocol.org:col:14791",
+          "taxonid": "3189846",
+          "scientificname": "acer platanoides",
+          "indexData": {
+            "dwc:startDayOfYear": "127",
+            "flag_dwc_taxonrank_added": true,
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:title": "spitz-ahorn (acer platanoides)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:spitz-ahorn_(acer_platanoides)_1.jpg",
+                "coreid": "3189846",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/0/0e/spitz-ahorn_%28acer_platanoides%29_1.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:title": "norway maple leaves",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:spitz-ahorn(mbo).jpg",
+                "coreid": "3189846",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/6/60/spitz-ahorn%28mbo%29.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "deutsch: spitz-ahorn (acer platanoides)",
+                "dcterms:creator": "martin bobka (= martin120)",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "dwc:specificEpithet": "platanoides",
+            "idigbio:dateModified": "2016-01-27T21:25:22.884015",
+            "dwc:county": "Norfolk",
+            "dwc:recordedBy": "C. W. Swan",
+            "idigbio:uuid": "7a9fda29-5231-456c-8d59-bef531e36e8e",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807914",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "L.",
+            "idigbio:recordIds": [
+              "urn:uuid:f0ea36c3-e71f-45ff-be75-61138b7ecec3",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\urn:uuid:c6b0657c-34e4-46bf-b303-844dd2828b22",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\807914"
+            ],
+            "dwc:occurrenceID": "urn:uuid:c6b0657c-34e4-46bf-b303-844dd2828b22",
+            "flag_gbif_canonicalname_added": true,
+            "id": "807914",
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "symbiota:recordEnteredBy": "Bob Swerling",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+            "dwc:stateProvince": "Massachusetts",
+            "dwc:eventDate": "1883-05-07",
+            "dwc:collectionID": "urn:lsid:biocol.org:col:14791",
+            "dwc:country": "united states",
+            "idigbio:recordId": "urn:uuid:f0ea36c3-e71f-45ff-be75-61138b7ecec3",
+            "idigbio:etag": "1f631099cc371c214fff4041e849dddb1c5078f7",
+            "dwc:collectionCode": "YU",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:kingdom": "Plantae",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_phylum_replaced": true,
+            "dwc:municipality": "Milton",
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "usa",
+            "gbif:reference": [
+              {
+                "coreid": "3189846",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "idigbio:siblings": {
+              "mediarecord": [
+                "8e25027c-64e7-445c-aaae-e80df0c67e72"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "gbif:canonicalname": "acer platanoides",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "acer",
+            "flag_dwc_multimedia_added": true,
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "YU.076200",
+            "dwc:taxonid": "3189846",
+            "dwc:taxonrank": "species",
+            "dwc:Identification": [
+              {
+                "coreid": "807914",
+                "dwc:identificationRemarks": "0",
+                "idigbio:recordId": "urn:uuid:b484aab4-0821-4654-926b-a986ee01b640",
+                "dwc:scientificName": "Acer platanoides L.",
+                "dwc:scientificNameAuthorship": "L."
+              }
+            ],
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189846",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero riccio"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable de norvège"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "érable plane",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable plane"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "érable plane"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "global invasive species database",
+                "dwc:vernacularname": "érable plane"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable platanoïde"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen ostrolistnyj"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen platanovidnyj"
+              },
+              {
+                "dwc:countrycode": "se",
+                "dwc:country": "sweden",
+                "dwc:vernacularname": "lönn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "(metsä)vaahtera",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "fi"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "(metsä)vaahtera",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "noorse esdoorn",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "noorse esdoorn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "norway maple",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "global invasive species database",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "skogslönn"
+              },
+              {
+                "dwc:countrycode": "dk",
+                "dwc:country": "denmark",
+                "dwc:vernacularname": "spids-løn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "da"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "spisslønn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nb"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "spisslønn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "spitzahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "spitzahorn",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "spitz-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "spitz-ahorn",
+                "coreid": "3189846",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "spitzahorn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "spitz-ahorn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "global invasive species database",
+                "dwc:vernacularname": "spitzahorn"
+              }
+            ],
+            "dwc:month": "5",
+            "flag_dwc_class_replaced": true,
+            "dwc:verbatimEventDate": "5-7-83 | 6-28-83",
+            "flag_dwc_continent_added": true,
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dcterms:modified": "2015-10-29 10:04:57",
+            "dwc:scientificName": "Acer platanoides",
+            "dwc:day": "7",
+            "dwc:year": "1883"
+          },
+          "data": {
+            "dwc:startDayOfYear": "127",
+            "dwc:specificEpithet": "platanoides",
+            "dwc:county": "Norfolk",
+            "dwc:recordedBy": "C. W. Swan",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807914",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:occurrenceID": "urn:uuid:c6b0657c-34e4-46bf-b303-844dd2828b22",
+            "dwc:scientificNameAuthorship": "L.",
+            "id": "807914",
+            "symbiota:recordEnteredBy": "Bob Swerling",
+            "dwc:stateProvince": "Massachusetts",
+            "dwc:eventDate": "1883-05-07",
+            "dwc:collectionID": "urn:lsid:biocol.org:col:14791",
+            "dwc:country": "United States of America",
+            "idigbio:recordId": "urn:uuid:f0ea36c3-e71f-45ff-be75-61138b7ecec3",
+            "dwc:collectionCode": "YU",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:kingdom": "Plantae",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:municipality": "Milton",
+            "dwc:phylum": "Charophyta",
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "dwc:class": "Equisetopsida",
+            "dwc:catalogNumber": "YU.076200",
+            "dwc:Identification": [
+              {
+                "coreid": "807914",
+                "dwc:identificationRemarks": "0",
+                "idigbio:recordId": "urn:uuid:b484aab4-0821-4654-926b-a986ee01b640",
+                "dwc:scientificName": "Acer platanoides L.",
+                "dwc:scientificNameAuthorship": "L."
+              }
+            ],
+            "dwc:month": "5",
+            "dwc:verbatimEventDate": "5-7-83 | 6-28-83",
+            "dcterms:modified": "2015-10-29 10:04:57",
+            "dwc:scientificName": "Acer platanoides",
+            "dwc:day": "7",
+            "dwc:year": "1883"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:c6b0657c-34e4-46bf-b303-844dd2828b22",
+          "country": "united states",
+          "dqs": 0.2318840579710145,
+          "collectioncode": "yu",
+          "canonicalname": "acer platanoides",
+          "eventdate": "1883-05-07",
+          "flags": [
+            "dwc_taxonrank_added",
+            "gbif_reference_added",
+            "gbif_canonicalname_added",
+            "dwc_country_replaced",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_parentnameusageid_added",
+            "dwc_phylum_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "dwc_multimedia_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_class_replaced",
+            "dwc_continent_added"
+          ],
+          "verbatimeventdate": "5-7-83 | 6-28-83",
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "urn:uuid:f0ea36c3-e71f-45ff-be75-61138b7ecec3",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\urn:uuid:c6b0657c-34e4-46bf-b303-844dd2828b22",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\807914"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "af9e5711-eaeb-4d07-8dd7-f7df02829377",
+        "_score": 1,
+        "_source": {
+          "family": "sapindaceae",
+          "recordset": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "dqs": 0.2463768115942029,
+          "stateprovince": "connecticut",
+          "municipality": "bridgeport",
+          "county": "fairfield county",
+          "phylum": "tracheophyta",
+          "catalognumber": "cbs.025830",
+          "startdayofyear": 151,
+          "taxonrank": "species",
+          "specificepithet": "pseudoplatanus",
+          "continent": "north america",
+          "uuid": "af9e5711-eaeb-4d07-8dd7-f7df02829377",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "hugh s. clark",
+          "institutioncode": "yale peabody museum of natural history",
+          "mediarecords": [
+            "cd8c9545-8adf-4de8-afe9-ffd8c9c265e2"
+          ],
+          "datemodified": "2016-03-21T21:43:25.444854+00:00",
+          "datecollected": "1910-05-31T00:00:00+00:00",
+          "etag": "e3c07a0a409c5f3f2582ce46d399e94a3b9581df",
+          "hasMedia": true,
+          "hasImage": true,
+          "kingdom": "plantae",
+          "collectionid": "http://grbio.org/cool/x0m9-a3bs",
+          "taxonid": "3189870",
+          "scientificname": "acer pseudoplatanus",
+          "indexData": {
+            "dwc:startDayOfYear": "151",
+            "flag_dwc_taxonrank_added": true,
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "gnu free documentation license",
+                "dcterms:title": "a. pseudoplatanus in the bergpark wilhelmshöhe, kassel",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pseudoplatanus_005.jpg",
+                "coreid": "3189870",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/c/cd/acer_pseudoplatanus_005.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "deutsch: bergahorn (acer pseudoplatanus) im schlosspark wilhelmshöhe, kassel, hessen, deutschland english: sycamore maple (acer pseudoplatanus) in the schlosspark wilhelmshöhe, kassel, hesse, germany",
+                "dcterms:creator": "willow",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "public domain mark 1.0",
+                "dcterms:title": "berg-ahorn (acer pseudoplatanus)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_pseudoplatanusaa.jpg",
+                "coreid": "3189870",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/f/fb/acer_pseudoplatanusaa.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "amsterdam, johannes allart, 1802 [-1808]",
+                "dcterms:creator": "user:mpf",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "dwc:specificEpithet": "pseudoplatanus",
+            "idigbio:dateModified": "2016-03-21T21:43:25.444854",
+            "dwc:county": "Fairfield County",
+            "dwc:recordedBy": "Hugh S. Clark",
+            "idigbio:uuid": "af9e5711-eaeb-4d07-8dd7-f7df02829377",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110334",
+            "flag_gbif_reference_added": true,
+            "dwc:scientificNameAuthorship": "L.",
+            "idigbio:recordIds": [
+              "urn:uuid:3f201839-a9b2-4869-a659-39b8509e2c8b",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\urn:uuid:c64bcab2-95df-47ed-b910-e78a8a5a9f85",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\110334"
+            ],
+            "dwc:occurrenceID": "urn:uuid:c64bcab2-95df-47ed-b910-e78a8a5a9f85",
+            "flag_gbif_canonicalname_added": true,
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189870",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero montano"
+              },
+              {
+                "dwc:countrycode": "dk",
+                "dwc:country": "denmark",
+                "dwc:vernacularname": "ahorn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "da"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "bergahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "bergahorn",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "berg-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "berg-ahorn",
+                "coreid": "3189870",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "bergahorn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "berg-ahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "érable sycomore",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable sycomore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "fr",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "érable sycomore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "false planetree"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "gewone esdoorn",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "gewone esdoorn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "great maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen lo&zcaron;noplatanovyj"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "platanlønn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nb"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "platanlønn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nn"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "scottish maple"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "sycamore",
+                "coreid": "3189870",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sycamore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sycamore"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "sycamore maple"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "tysklönn"
+              },
+              {
+                "dwc:countrycode": "se",
+                "dwc:country": "sweden",
+                "dwc:vernacularname": "tysklönn",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "vuorivaahtera",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "fi"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "vuorivaahtera",
+                "coreid": "3189870",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              }
+            ],
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1910-05-31",
+            "dwc:collectionID": "http://grbio.org/cool/x0m9-a3bs",
+            "dwc:country": "united states",
+            "idigbio:recordId": "urn:uuid:3f201839-a9b2-4869-a659-39b8509e2c8b",
+            "idigbio:etag": "e3c07a0a409c5f3f2582ce46d399e94a3b9581df",
+            "dwc:collectionCode": "CBS",
+            "id": "110334",
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "41.1932",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_phylum_replaced": true,
+            "dwc:municipality": "Bridgeport",
+            "flag_dwc_taxonid_added": true,
+            "idigbio:isocountrycode": "usa",
+            "dwc:geodeticDatum": "WGS84",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "cd8c9545-8adf-4de8-afe9-ffd8c9c265e2"
+              ]
+            },
+            "flag_idigbio_isocountrycode_added": true,
+            "gbif:canonicalname": "acer pseudoplatanus",
+            "dwc:phylum": "tracheophyta",
+            "gbif:genericname": "acer",
+            "flag_dwc_multimedia_added": true,
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "CBS.025830",
+            "dwc:taxonid": "3189870",
+            "dwc:taxonrank": "species",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:decimalLongitude": "-73.196",
+            "dwc:scientificName": "Acer pseudoplatanus",
+            "dwc:month": "5",
+            "flag_dwc_class_replaced": true,
+            "gbif:reference": [
+              {
+                "coreid": "3189870",
+                "dcterms:source": "catalogue of life",
+                "dcterms:bibliographiccitation": "l. (1753) in: sp. pl.: 1054"
+              },
+              {
+                "coreid": "3189870",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "flag_dwc_continent_added": true,
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dcterms:modified": "2011-07-21 00:00:00",
+            "dwc:coordinateUncertaintyInMeters": "6473",
+            "dwc:day": "31",
+            "dwc:year": "1910"
+          },
+          "coordinateuncertainty": 6473,
+          "data": {
+            "dwc:startDayOfYear": "151",
+            "dwc:specificEpithet": "pseudoplatanus",
+            "dwc:county": "Fairfield County",
+            "dwc:recordedBy": "Hugh S. Clark",
+            "dwc:order": "Sapindales",
+            "dcterms:references": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110334",
+            "dcterms:accessRights": "Open Access, http://creativecommons.org/publicdomain/zero/1.0/; see Yale Peabody policies at: http://hdl.handle.net/10079/8931zqj",
+            "dwc:occurrenceID": "urn:uuid:c64bcab2-95df-47ed-b910-e78a8a5a9f85",
+            "dwc:scientificNameAuthorship": "L.",
+            "id": "110334",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1910-05-31",
+            "dwc:collectionID": "http://grbio.org/cool/x0m9-a3bs",
+            "dwc:institutionCode": "Yale Peabody Museum of Natural History",
+            "dwc:country": "USA",
+            "idigbio:recordId": "urn:uuid:3f201839-a9b2-4869-a659-39b8509e2c8b",
+            "dwc:collectionCode": "CBS",
+            "dcterms:rightsHolder": "Yale Peabody Museum of Natural History",
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "41.1932",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Sapindaceae",
+            "dc:rights": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:municipality": "Bridgeport",
+            "dwc:phylum": "Charophyta",
+            "dwc:geodeticDatum": "WGS84",
+            "dwc:class": "Equisetopsida",
+            "dwc:catalogNumber": "CBS.025830",
+            "dwc:month": "5",
+            "dwc:decimalLongitude": "-73.196",
+            "dwc:coordinateUncertaintyInMeters": "6473",
+            "dcterms:modified": "2011-07-21 00:00:00",
+            "dwc:scientificName": "Acer pseudoplatanus",
+            "dwc:day": "31",
+            "dwc:year": "1910"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:uuid:c64bcab2-95df-47ed-b910-e78a8a5a9f85",
+          "country": "united states",
+          "geopoint": {
+            "lat": 41.1932,
+            "lon": -73.196
+          },
+          "collectioncode": "cbs",
+          "canonicalname": "acer pseudoplatanus",
+          "eventdate": "1910-05-31",
+          "flags": [
+            "dwc_taxonrank_added",
+            "gbif_reference_added",
+            "gbif_canonicalname_added",
+            "dwc_country_replaced",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_parentnameusageid_added",
+            "dwc_phylum_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "dwc_multimedia_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_class_replaced",
+            "dwc_continent_added"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "urn:uuid:3f201839-a9b2-4869-a659-39b8509e2c8b",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\urn:uuid:c64bcab2-95df-47ed-b910-e78a8a5a9f85",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\110334"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b35dc163-b67a-4b9d-9185-75460b7936f0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lat": 41.905,
+            "lon": -72.7025
+          },
+          "family": "sapindaceae",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.2463768115942029,
+          "stateprovince": "connecticut",
+          "institutioncode": "uconn",
+          "municipality": "windsor",
+          "county": "hartford county",
+          "phylum": "tracheophyta",
+          "catalognumber": "conn00032766",
+          "startdayofyear": 119,
+          "taxonrank": "species",
+          "specificepithet": "platanoides",
+          "continent": "north america",
+          "uuid": "b35dc163-b67a-4b9d-9185-75460b7936f0",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "tad m. zebryk",
+          "commonnames": [
+            "Norway Maple"
+          ],
+          "mediarecords": [
+            "bb3b39b6-adbe-459f-88ea-f793e6b45ccf"
+          ],
+          "datemodified": "2014-09-09T01:35:10.885000+00:00",
+          "datecollected": "1998-04-29T00:00:00+00:00",
+          "etag": "24e8f6129d6b7fd632afc0294b74700345b7123c",
+          "recordnumber": "4388",
+          "hasImage": true,
+          "kingdom": "plantae",
+          "highertaxon": "plantae; dicotyledonae; sapindales; aceraceae",
+          "commonname": "norway maple",
+          "taxonid": "3189846",
+          "scientificname": "acer platanoides l.",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "flag_dwc_family_replaced": true,
+            "dwc:specificEpithet": "platanoides",
+            "idigbio:dateModified": "2014-09-09T01:35:10.885000",
+            "dwc:countryCode": "US",
+            "dwc:county": "Hartford County",
+            "dwc:recordedBy": "Tad M. Zebryk",
+            "idigbio:uuid": "b35dc163-b67a-4b9d-9185-75460b7936f0",
+            "flag_dwc_multimedia_added": true,
+            "dwc:order": "Sapindales",
+            "dwc:habitat": "Edge Of Woods",
+            "flag_gbif_reference_added": true,
+            "idigbio:isocountrycode": "usa",
+            "flag_dwc_scientificnameauthorship_added": true,
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00032766"
+            ],
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00032766",
+            "dwc:scientificName": "Acer platanoides L.",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189846",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero riccio"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable de norvège"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "érable plane",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable plane"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "érable plane"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "global invasive species database",
+                "dwc:vernacularname": "érable plane"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable platanoïde"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen ostrolistnyj"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen platanovidnyj"
+              },
+              {
+                "dwc:countrycode": "se",
+                "dwc:country": "sweden",
+                "dwc:vernacularname": "lönn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "(metsä)vaahtera",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "fi"
+              },
+              {
+                "dwc:countrycode": "fi",
+                "dwc:country": "finland",
+                "dwc:vernacularname": "(metsä)vaahtera",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "sv"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "noorse esdoorn",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "noorse esdoorn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "norway maple",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "global invasive species database",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "norway maple"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "skogslönn"
+              },
+              {
+                "dwc:countrycode": "dk",
+                "dwc:country": "denmark",
+                "dwc:vernacularname": "spids-løn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "da"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "spisslønn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nb"
+              },
+              {
+                "dwc:countrycode": "no",
+                "dwc:country": "norway",
+                "dwc:vernacularname": "spisslønn",
+                "coreid": "3189846",
+                "dcterms:source": "nordic crop wild relative (cwr) checklist",
+                "dcterms:language": "nn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "spitzahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "spitzahorn",
+                "coreid": "3189846",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "spitz-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "spitz-ahorn",
+                "coreid": "3189846",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "spitzahorn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "spitz-ahorn"
+              },
+              {
+                "coreid": "3189846",
+                "dcterms:source": "global invasive species database",
+                "dwc:vernacularname": "spitzahorn"
+              }
+            ],
+            "flag_dwc_kingdom_replaced": true,
+            "flag_gbif_genericname_added": true,
+            "flag_dwc_parentnameusageid_added": true,
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dwc:stateProvince": "Connecticut",
+            "flag_dwc_taxonomicstatus_added": true,
+            "dwc:eventDate": "1998-04-29",
+            "dwc:country": "united states",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:title": "spitz-ahorn (acer platanoides)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:spitz-ahorn_(acer_platanoides)_1.jpg",
+                "coreid": "3189846",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/0/0e/spitz-ahorn_%28acer_platanoides%29_1.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "cc-by-sa-2.5",
+                "dcterms:title": "norway maple leaves",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:spitz-ahorn(mbo).jpg",
+                "coreid": "3189846",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/6/60/spitz-ahorn%28mbo%29.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:description": "deutsch: spitz-ahorn (acer platanoides)",
+                "dcterms:creator": "martin bobka (= martin120)",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "24e8f6129d6b7fd632afc0294b74700345b7123c",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "41°54' 18\" N",
+            "gbif:reference": [
+              {
+                "coreid": "3189846",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "dwc:kingdom": "plantae",
+            "dwc:decimalLatitude": "41.905",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "north america",
+            "dwc:family": "sapindaceae",
+            "flag_dwc_continent_added": true,
+            "flag_dwc_country_replaced": true,
+            "dwc:class": "magnoliopsida",
+            "dwc:municipality": "Windsor",
+            "flag_dwc_taxonid_added": true,
+            "dwc:previousIdentifications": "Acer platanoides L.",
+            "idigbio:siblings": {
+              "mediarecord": [
+                "bb3b39b6-adbe-459f-88ea-f793e6b45ccf"
+              ]
+            },
+            "flag_dwc_class_added": true,
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:vernacularName": "Norway Maple",
+            "gbif:canonicalname": "acer platanoides",
+            "dwc:scientificnameauthorship": "l.",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_phylum_added": true,
+            "gbif:genericname": "acer",
+            "dwc:locality": "Northwest Park, edge of oak woods near Town Tree Nursery",
+            "flag_gbif_vernacularname_added": true,
+            "dwc:institutionCode": "UConn",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Sapindales; Aceraceae",
+            "dwc:catalogNumber": "CONN00032766",
+            "dwc:taxonid": "3189846",
+            "dwc:taxonrank": "species",
+            "dwc:higherGeography": "USA; Connecticut; Hartford County; Windsor",
+            "dwc:month": "4",
+            "dwc:decimalLongitude": "-72.7025",
+            "dwc:verbatimLongitude": "72°42' 09\" W",
+            "dwc:verbatimEventDate": "29-Apr-98",
+            "dwc:phylum": "tracheophyta",
+            "dwc:recordNumber": "4388",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "flag_dwc_datasetid_replaced": true,
+            "dcterms:modified": "2004-03-23T00:00-0500",
+            "dwc:coordinateUncertaintyInMeters": "5000",
+            "dwc:day": "29",
+            "dwc:datasetID": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "dwc:year": "1998"
+          },
+          "hasMedia": true,
+          "coordinateuncertainty": 5000,
+          "data": {
+            "dwc:specificEpithet": "platanoides",
+            "dwc:countryCode": "US",
+            "dwc:county": "Hartford County",
+            "dwc:recordedBy": "Tad M. Zebryk",
+            "dwc:order": "Sapindales",
+            "dwc:habitat": "Edge Of Woods",
+            "dwc:occurrenceID": "urn:catalog:UConn:CONN:CONN00032766",
+            "dwc:stateProvince": "Connecticut",
+            "dwc:eventDate": "1998-04-29",
+            "dwc:country": "USA",
+            "dwc:collectionCode": "CONN",
+            "dwc:verbatimLatitude": "41°54' 18\" N",
+            "dwc:kingdom": "Dicotyledonae",
+            "dwc:decimalLatitude": "41.905",
+            "dwc:basisOfRecord": "Preserved Specimen",
+            "dwc:genus": "Acer",
+            "dwc:family": "Aceraceae",
+            "dwc:coordinateUncertaintyInMeters": "5000",
+            "dwc:municipality": "Windsor",
+            "dwc:previousIdentifications": "Acer platanoides L.",
+            "dwc:vernacularName": "Norway Maple",
+            "dwc:locality": "Northwest Park, edge of oak woods near Town Tree Nursery",
+            "dwc:institutionCode": "UConn",
+            "dwc:higherClassification": "Plantae; Dicotyledonae; Sapindales; Aceraceae",
+            "dwc:catalogNumber": "CONN00032766",
+            "dwc:higherGeography": "USA; Connecticut; Hartford County; Windsor",
+            "dwc:month": "4",
+            "dwc:decimalLongitude": "-72.7025",
+            "dwc:verbatimLongitude": "72°42' 09\" W",
+            "dwc:verbatimEventDate": "29-Apr-98",
+            "dwc:recordNumber": "4388",
+            "dcterms:rights": "This work is licensed under a Creative Commons CCZero 1.0 License http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+            "dcterms:modified": "2004-03-23T00:00-0500",
+            "dwc:scientificName": "Acer platanoides L.",
+            "dwc:day": "29",
+            "dwc:datasetID": "11919",
+            "dwc:year": "1998"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "urn:catalog:uconn:conn:conn00032766",
+          "country": "united states",
+          "locality": "northwest park, edge of oak woods near town tree nursery",
+          "collectioncode": "conn",
+          "canonicalname": "acer platanoides",
+          "eventdate": "1998-04-29",
+          "flags": [
+            "geopoint_datum_missing",
+            "dwc_taxonrank_added",
+            "dwc_family_replaced",
+            "dwc_multimedia_added",
+            "gbif_reference_added",
+            "dwc_scientificnameauthorship_added",
+            "dwc_kingdom_replaced",
+            "gbif_genericname_added",
+            "dwc_parentnameusageid_added",
+            "dwc_taxonomicstatus_added",
+            "dwc_continent_added",
+            "dwc_country_replaced",
+            "dwc_taxonid_added",
+            "dwc_class_added",
+            "idigbio_isocountrycode_added",
+            "gbif_canonicalname_added",
+            "dwc_phylum_added",
+            "gbif_vernacularname_added",
+            "gbif_taxon_corrected",
+            "dwc_datasetid_replaced"
+          ],
+          "verbatimeventdate": "29-apr-98",
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\urn:catalog:uconn:conn:conn00032766"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bc9fd701-bb9d-490c-a5bf-da5177b49ae0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lat": 38.53262,
+            "lon": -95.96472
+          },
+          "family": "sapindaceae",
+          "recordset": "5baa1d0c-cfc0-4c89-8e3e-7a49359b0caa",
+          "dqs": 0.21739130434782608,
+          "stateprovince": "kansas",
+          "county": "lyon",
+          "phylum": "tracheophyta",
+          "catalognumber": "17301",
+          "startdayofyear": 112,
+          "taxonrank": "species",
+          "specificepithet": "negundo",
+          "continent": "north america",
+          "uuid": "bc9fd701-bb9d-490c-a5bf-da5177b49ae0",
+          "countrycode": "usa",
+          "basisofrecord": "preservedspecimen",
+          "collector": "melander, m.",
+          "institutioncode": "kstc",
+          "datemodified": "2017-01-08T07:47:53.556726+00:00",
+          "datecollected": "1975-04-22T00:00:00+00:00",
+          "etag": "9a5a189ccbdbd748d5da7d3fbea1f2bee1137565",
+          "recordnumber": "27",
+          "hasImage": false,
+          "kingdom": "plantae",
+          "taxonid": "3189866",
+          "scientificname": "acer negundo",
+          "indexData": {
+            "flag_dwc_taxonrank_added": true,
+            "dwc:specificEpithet": "negundo",
+            "idigbio:dateModified": "2017-01-08T07:47:53.556726",
+            "dwc:county": "Lyon",
+            "dwc:recordedBy": "Melander, M.",
+            "idigbio:uuid": "bc9fd701-bb9d-490c-a5bf-da5177b49ae0",
+            "dwc:georeferencedDate": "2015-02-12",
+            "gbif:canonicalname": "acer negundo",
+            "flag_gbif_reference_added": true,
+            "flag_dwc_scientificnameauthorship_added": true,
+            "dwc:locality": "Reading Woods",
+            "idigbio:recordIds": [
+              "5baa1d0c-cfc0-4c89-8e3e-7a49359b0caa\\4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2"
+            ],
+            "dwc:occurrenceID": "4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2",
+            "flag_dwc_taxonomicstatus_added": true,
+            "flag_gbif_genericname_added": true,
+            "id": "4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2",
+            "flag_dwc_datasetid_added": true,
+            "idigbio:parent": "5baa1d0c-cfc0-4c89-8e3e-7a49359b0caa",
+            "dwc:stateProvince": "Kansas",
+            "dwc:eventDate": "1975-04-22",
+            "dwc:country": "united states",
+            "dwc:multimedia": [
+              {
+                "dcterms:license": "public domain from united states department of agriculture",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acnegundo.jpg",
+                "coreid": "3189866",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/1/18/acnegundo.jpg",
+                "dcterms:source": "english wikipedia - species pages",
+                "dcterms:publisher": "wikimedia commons"
+              },
+              {
+                "dcterms:license": "creative commons attribution share alike 3.0 migrated",
+                "dcterms:title": "eschen-ahorn (acer negundo)",
+                "dcterms:references": "http://commons.wikimedia.org/wiki/file:acer_negundo.jpg",
+                "coreid": "3189866",
+                "dcterms:identifier": "http://upload.wikimedia.org/wikipedia/commons/8/82/acer_negundo.jpg",
+                "dcterms:source": "german wikipedia - species pages",
+                "dcterms:description": "deutsch: eschen-ahorn (acer negundo) polski: klon jesionolistny (acer negundo)",
+                "dcterms:creator": "agnieszka kwiecień - nova at pl.wikipedia",
+                "dcterms:publisher": "wikimedia commons"
+              }
+            ],
+            "idigbio:etag": "9a5a189ccbdbd748d5da7d3fbea1f2bee1137565",
+            "dwc:collectionCode": "Plants",
+            "flag_dwc_multimedia_added": true,
+            "flag_gbif_vernacularname_added": true,
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "38.5326200",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:taxonomicstatus": "accepted",
+            "dwc:genus": "Acer",
+            "dwc:continent": "North America",
+            "dwc:family": "Sapindaceae",
+            "idigbio:isocountrycode": "usa",
+            "dwc:identifiedBy": "Melander, M.",
+            "flag_dwc_country_replaced": true,
+            "flag_dwc_taxonid_added": true,
+            "dcterms:license": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "idigbio:siblings": {},
+            "flag_idigbio_isocountrycode_added": true,
+            "dwc:order": "sapindales",
+            "dwc:scientificnameauthorship": "l.",
+            "flag_gbif_canonicalname_added": true,
+            "flag_dwc_phylum_added": true,
+            "gbif:genericname": "acer",
+            "dwc:georeferenceSources": "GEOLocate",
+            "dwc:institutionID": "http://biocol.org/urn:lsid:biocol.org:col:12991",
+            "dwc:institutionCode": "KSTC",
+            "flag_gbif_taxon_corrected": true,
+            "dwc:parentnameusageid": "3189834",
+            "dwc:class": "magnoliopsida",
+            "dwc:catalogNumber": "17301",
+            "dwc:taxonid": "3189866",
+            "dwc:taxonrank": "species",
+            "dwc:month": "4",
+            "dwc:decimalLongitude": "-95.9647200",
+            "gbif:vernacularname": [
+              {
+                "coreid": "3189866",
+                "dcterms:language": "it",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "acero americano"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "ash-leaf maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "ashleaf maple"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "ash-leaved maple, box-elder",
+                "coreid": "3189866",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "ash-leaved maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "sv",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "asklönn"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "aulne-buis"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "box-elder, ash-leaved maple",
+                "coreid": "3189866",
+                "dcterms:source": "invasive alien species in belgium - harmonia database",
+                "dcterms:language": "en"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "boxelder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "box-elder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "box-elder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "box elder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "boxelder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "box-elder maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "boxelder maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "california box-elder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "california boxelder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable à feuilles composées"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable à feuilles de frêne"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable à giguère"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable argilière"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable négondo"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "erable negundo",
+                "coreid": "3189866",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "fr"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "erable negundo",
+                "coreid": "3189866",
+                "dcterms:source": "invasive alien species in belgium - harmonia database",
+                "dcterms:language": "fr"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "érable négundo"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "catalogue of life",
+                "dwc:vernacularname": "eschen-ahorn"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "eschenahorn",
+                "coreid": "3189866",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "de",
+                "dcterms:source": "german wikipedia - species pages",
+                "dwc:vernacularname": "eschen-ahorn"
+              },
+              {
+                "dwc:countrycode": "de",
+                "dwc:country": "germany",
+                "dwc:vernacularname": "eschen-ahorn",
+                "coreid": "3189866",
+                "dcterms:source": "taxon list of vascular plants from bavaria, germany compiled in the context of the bfl project",
+                "dcterms:language": "de"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "de",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "eschenahorn"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "de",
+                "dcterms:source": "the european nature information system (eunis)",
+                "dwc:vernacularname": "eschen-ahorn"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "af",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "essenblaarahorn"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "fu ye feng"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "af",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "kaliforniese esdoring"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "klen âsenelistnyj"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "korean peninsula flora",
+                "dwc:vernacularname": "네군도단풍"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "manitoba maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "manitoba maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "négondo"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "negundodanpung"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "fr",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "plaine à giguère"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "three-leaf maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "three-leaved maple"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "grin taxonomy",
+                "dwc:vernacularname": "tonerikoba-no-kaede"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "vederesdoorn",
+                "coreid": "3189866",
+                "dcterms:source": "belgian species list",
+                "dcterms:language": "nl"
+              },
+              {
+                "dwc:countrycode": "be",
+                "dwc:country": "belgium",
+                "dwc:vernacularname": "vederesdoorn",
+                "coreid": "3189866",
+                "dcterms:source": "invasive alien species in belgium - harmonia database",
+                "dcterms:language": "nl"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "nl",
+                "dcterms:source": "checklist dutch species catalog - nederlands soortenregister",
+                "dwc:vernacularname": "vederesdoorn"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:language": "en",
+                "dcterms:source": "database of vascular plants of canada (vascan)",
+                "dwc:vernacularname": "western box-elder"
+              },
+              {
+                "coreid": "3189866",
+                "dcterms:source": "integrated taxonomic information system (itis)",
+                "dwc:vernacularname": "western boxelder"
+              }
+            ],
+            "flag_dwc_order_added": true,
+            "dwc:georeferencedBy": "Kerbs, Benjamin",
+            "gbif:reference": [
+              {
+                "coreid": "3189866",
+                "dcterms:source": "taxa watermanagement the netherlands (twn)",
+                "dcterms:bibliographiccitation": "van der meijden, r. (2005)"
+              }
+            ],
+            "dwc:phylum": "tracheophyta",
+            "dwc:recordNumber": "27",
+            "dwc:datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b",
+            "flag_dwc_parentnameusageid_added": true,
+            "flag_dwc_class_added": true,
+            "dwc:georeferenceProtocol": "GEOLocate",
+            "dcterms:modified": "2012-10-27 14:45:54.0",
+            "dwc:scientificName": "Acer negundo",
+            "dwc:day": "22",
+            "dwc:year": "1975"
+          },
+          "hasMedia": false,
+          "data": {
+            "dwc:specificEpithet": "negundo",
+            "dwc:county": "Lyon",
+            "dwc:recordedBy": "Melander, M.",
+            "dwc:georeferencedDate": "2015-02-12",
+            "dwc:occurrenceID": "4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2",
+            "id": "4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2",
+            "dwc:stateProvince": "Kansas",
+            "dwc:eventDate": "1975-04-22",
+            "dwc:country": "USA",
+            "dwc:collectionCode": "Plants",
+            "dwc:kingdom": "Plantae",
+            "dwc:decimalLatitude": "38.5326200",
+            "dwc:basisOfRecord": "PreservedSpecimen",
+            "dwc:genus": "Acer",
+            "dwc:continent": "North America",
+            "dwc:family": "Sapindaceae",
+            "dwc:identifiedBy": "Melander, M.",
+            "dwc:georeferenceSources": "GEOLocate",
+            "dcterms:license": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "dwc:locality": "Reading Woods",
+            "dwc:institutionID": "http://biocol.org/urn:lsid:biocol.org:col:12991",
+            "dwc:institutionCode": "KSTC",
+            "dwc:catalogNumber": "17301",
+            "dwc:month": "4",
+            "dwc:decimalLongitude": "-95.9647200",
+            "dwc:georeferencedBy": "Kerbs, Benjamin",
+            "dwc:recordNumber": "27",
+            "dwc:georeferenceProtocol": "GEOLocate",
+            "dcterms:modified": "2012-10-27 14:45:54.0",
+            "dwc:scientificName": "Acer negundo",
+            "dwc:day": "22",
+            "dwc:year": "1975"
+          },
+          "class": "magnoliopsida",
+          "occurrenceid": "4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2",
+          "institutionid": "http://biocol.org/urn:lsid:biocol.org:col:12991",
+          "country": "united states",
+          "locality": "reading woods",
+          "collectioncode": "plants",
+          "canonicalname": "acer negundo",
+          "eventdate": "1975-04-22",
+          "flags": [
+            "geopoint_datum_missing",
+            "dwc_taxonrank_added",
+            "gbif_reference_added",
+            "dwc_scientificnameauthorship_added",
+            "dwc_taxonomicstatus_added",
+            "gbif_genericname_added",
+            "dwc_datasetid_added",
+            "dwc_multimedia_added",
+            "gbif_vernacularname_added",
+            "dwc_country_replaced",
+            "dwc_taxonid_added",
+            "idigbio_isocountrycode_added",
+            "gbif_canonicalname_added",
+            "dwc_phylum_added",
+            "gbif_taxon_corrected",
+            "dwc_order_added",
+            "dwc_parentnameusageid_added",
+            "dwc_class_added"
+          ],
+          "taxonomicstatus": "accepted",
+          "recordids": [
+            "5baa1d0c-cfc0-4c89-8e3e-7a49359b0caa\\4c305e3a-0e7e-11e3-bd43-2dbe30b5fdd2"
+          ],
+          "genus": "acer",
+          "order": "sapindales",
+          "datasetid": "7ddf754f-d193-4cc9-b351-99906754a03b"
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "top_scientificname": {
+      "doc_count_error_upper_bound": 389,
+      "sum_other_doc_count": 79567,
+      "buckets": [
+        {
+          "key": "acer rubrum",
+          "doc_count": 10939
+        },
+        {
+          "key": "acer negundo",
+          "doc_count": 8715
+        },
+        {
+          "key": "acer saccharum",
+          "doc_count": 5591
+        },
+        {
+          "key": "acer saccharinum",
+          "doc_count": 5419
+        },
+        {
+          "key": "acer spicatum",
+          "doc_count": 3786
+        }
+      ]
+    }
+  }
+}

--- a/__tests__/mock/search-a30238d3acc692e28a3526a007874f8c.json
+++ b/__tests__/mock/search-a30238d3acc692e28a3526a007874f8c.json
@@ -1,0 +1,2806 @@
+{
+  "timed_out": false,
+  "_shards": {
+    "total": 48,
+    "successful": 48,
+    "failed": 0
+  },
+  "hits": {
+    "total": 34046629,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "000992e7-6519-4fae-ab02-d990234e3752",
+        "_score": null,
+        "_routing": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_parent": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=78088&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "003b2287-1f6c-4897-bd59-2e58f6022739",
+        "_score": null,
+        "_routing": "4bd36c58-e935-4c2b-82f5-21a83b359557",
+        "_parent": "4bd36c58-e935-4c2b-82f5-21a83b359557",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=103926&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "007977cb-7a8d-49bd-8450-45800bec15af",
+        "_score": null,
+        "_routing": "599f5853-b35c-43eb-90d3-5143ebbf9d21",
+        "_parent": "599f5853-b35c-43eb-90d3-5143ebbf9d21",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=134681&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0089b314-b365-4244-9f93-8cec2f29be98",
+        "_score": null,
+        "_routing": "9a059a20-1927-4ea0-be70-7b7c5d3a430d",
+        "_parent": "9a059a20-1927-4ea0-be70-7b7c5d3a430d",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=111648&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00b06c30-4949-415b-9a5f-342fe99abca2",
+        "_score": null,
+        "_routing": "95d7ee27-3a69-4f29-b7f9-4e0c6123264a",
+        "_parent": "95d7ee27-3a69-4f29-b7f9-4e0c6123264a",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=99828&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00bda874-9f9d-48d4-b582-c5bcac4a08b5",
+        "_score": null,
+        "_routing": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_parent": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=78097&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00c7c963-860b-4b70-a55e-571bfef030fd",
+        "_score": null,
+        "_routing": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_parent": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=100377&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00edde43-e608-4e84-862c-f9cb9af9b21a",
+        "_score": null,
+        "_routing": "7c5f4753-8a79-42df-b87f-5501f1f1676b",
+        "_parent": "7c5f4753-8a79-42df-b87f-5501f1f1676b",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=661111&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00f8d929-db1c-4478-bef2-ef0babf1d576",
+        "_score": null,
+        "_routing": "53d4865e-8083-4884-8393-08277937e408",
+        "_parent": "53d4865e-8083-4884-8393-08277937e408",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=742849&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0119c9f7-8706-4114-8a26-6d25ccf3964b",
+        "_score": null,
+        "_routing": "3a00b94a-ab08-411b-b781-0df20f0a9379",
+        "_parent": "3a00b94a-ab08-411b-b781-0df20f0a9379",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=755859&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      }
+    ]
+  },
+  "aggregations": {
+    "rs": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "a6eee223-cf3b-4079-8bb2-b77dad8cae9d",
+          "doc_count": 5135183
+        },
+        {
+          "key": "fabcdc12-9d29-4bd2-912b-176e71818144",
+          "doc_count": 4596608
+        },
+        {
+          "key": "36d35b23-113e-4633-90ec-19d265a3b5f6",
+          "doc_count": 3537264
+        },
+        {
+          "key": "0583609b-202f-40d0-8021-4c019635d4c9",
+          "doc_count": 707693
+        },
+        {
+          "key": "205fa34c-2fcb-4492-b992-972b18560f6f",
+          "doc_count": 608981
+        },
+        {
+          "key": "65536dcd-7bb2-44e5-af3f-4a13f08e53d0",
+          "doc_count": 543365
+        },
+        {
+          "key": "285a4be0-5cfe-4d4f-9c8b-b0f0f3571079",
+          "doc_count": 489273
+        },
+        {
+          "key": "271a9ce9-c6d3-4b63-a722-cb0adc48863f",
+          "doc_count": 468247
+        },
+        {
+          "key": "b6ec6203-09db-4d6e-8cba-ee4bebd2934c",
+          "doc_count": 417978
+        },
+        {
+          "key": "4e3043a6-d48a-4a35-b5fb-f67d50cbc158",
+          "doc_count": 408346
+        },
+        {
+          "key": "e60301d9-9b40-483f-92de-065769b9d3dd",
+          "doc_count": 380640
+        },
+        {
+          "key": "a4e6033a-d1eb-46d3-869d-7c0328f09aa7",
+          "doc_count": 343844
+        },
+        {
+          "key": "9e5aede6-bee5-4a3d-a255-513771b20035",
+          "doc_count": 316956
+        },
+        {
+          "key": "4523e216-ee13-4b15-a3f7-a6fd56431604",
+          "doc_count": 306235
+        },
+        {
+          "key": "137ed4cd-5172-45a5-acdb-8e1de9a64e32",
+          "doc_count": 299965
+        },
+        {
+          "key": "2d7910d9-7f63-4bde-918a-9e0265f1c245",
+          "doc_count": 294161
+        },
+        {
+          "key": "9151bc4c-8505-4b22-a16b-9dbf337535fa",
+          "doc_count": 294161
+        },
+        {
+          "key": "beab5209-9628-4d4d-851e-2bc9bb1a0105",
+          "doc_count": 276792
+        },
+        {
+          "key": "3027c437-cdb3-4072-9410-5a46ec3b1fd5",
+          "doc_count": 275401
+        },
+        {
+          "key": "a2b36fdf-50bc-44ef-a6a4-ca6dc1dc148a",
+          "doc_count": 253059
+        },
+        {
+          "key": "72d4c3c7-3413-4588-a803-e1a63e0d7c6c",
+          "doc_count": 252250
+        },
+        {
+          "key": "d53132e6-7997-4850-8607-4fec5a3f9c3f",
+          "doc_count": 241932
+        },
+        {
+          "key": "f1cf8457-237e-487a-9d13-5de7d81b9de4",
+          "doc_count": 238178
+        },
+        {
+          "key": "e2def7e2-1455-4856-9823-6d3738417d24",
+          "doc_count": 214253
+        },
+        {
+          "key": "db6c3db9-1e6d-4def-af29-33aa0339bfa9",
+          "doc_count": 192851
+        },
+        {
+          "key": "70abba3e-5f2a-4276-87f3-261706e24453",
+          "doc_count": 192778
+        },
+        {
+          "key": "40250f4d-7aa6-4fcc-ac38-2868fa4846bd",
+          "doc_count": 187240
+        },
+        {
+          "key": "e881a3e2-f7ba-43c8-ae9a-11fcbfd741bb",
+          "doc_count": 185371
+        },
+        {
+          "key": "0fd6e726-6828-4f62-ba8d-6ec316fe0b52",
+          "doc_count": 180782
+        },
+        {
+          "key": "58402fe3-37c1-4d15-9e07-0ff1c4c9fb11",
+          "doc_count": 171183
+        },
+        {
+          "key": "d4ea4495-c4b2-4d05-b524-163423f17cd7",
+          "doc_count": 168645
+        },
+        {
+          "key": "6c6f34ed-58a4-4ba2-b9c7-34524f79a349",
+          "doc_count": 163095
+        },
+        {
+          "key": "0dab1fc7-ca99-456b-9985-76edbac003e0",
+          "doc_count": 161405
+        },
+        {
+          "key": "1527b668-b797-42be-94d3-0058e1393e94",
+          "doc_count": 147919
+        },
+        {
+          "key": "48b4b812-c52e-4f47-9327-e761f6fc2e28",
+          "doc_count": 138133
+        },
+        {
+          "key": "6258d160-a7aa-4937-bce3-3538eebd374f",
+          "doc_count": 137717
+        },
+        {
+          "key": "cdb6ec43-935e-4da2-8798-71e40ca6d12a",
+          "doc_count": 134508
+        },
+        {
+          "key": "2c00c297-9ebd-498a-b701-d3ebde4b49f3",
+          "doc_count": 133295
+        },
+        {
+          "key": "96662fa9-ff60-495b-912a-284f3b98ed72",
+          "doc_count": 126289
+        },
+        {
+          "key": "cf42855e-a54a-4488-a79e-beac086ba1d4",
+          "doc_count": 123875
+        },
+        {
+          "key": "df22987f-d20d-41db-b8eb-8b5f5fca6df0",
+          "doc_count": 121441
+        },
+        {
+          "key": "beecd160-a96c-46fc-bdce-7dcb7024d473",
+          "doc_count": 120720
+        },
+        {
+          "key": "b531ea59-025d-4c29-9d23-99ae75bcd55f",
+          "doc_count": 118459
+        },
+        {
+          "key": "aca26f37-3ec8-4e9e-b927-50b4944a0096",
+          "doc_count": 102740
+        },
+        {
+          "key": "ba042ffa-8175-4a47-8eb1-08b4d6319ccf",
+          "doc_count": 102728
+        },
+        {
+          "key": "35c43eda-1f4a-4713-bb69-e3fbe1bf792f",
+          "doc_count": 102464
+        },
+        {
+          "key": "31c140bc-e6f1-4acc-beaf-b825cf288ad9",
+          "doc_count": 100206
+        },
+        {
+          "key": "215eeaf0-0a88-409e-a75d-aec98b7c41eb",
+          "doc_count": 100041
+        },
+        {
+          "key": "6cc31636-c3e5-4887-bbee-2e56621771c4",
+          "doc_count": 96684
+        },
+        {
+          "key": "f84d528a-7d08-467e-b532-ace707316f1d",
+          "doc_count": 95826
+        },
+        {
+          "key": "71bf994a-3af5-484d-983b-b146aa1512d1",
+          "doc_count": 93283
+        },
+        {
+          "key": "0bc60df1-a162-4173-9a73-c51e09031843",
+          "doc_count": 92053
+        },
+        {
+          "key": "ccd17772-d220-4088-8fa3-df3729f14df4",
+          "doc_count": 91822
+        },
+        {
+          "key": "995cc7f1-69c3-4317-ab77-28fd48f1e535",
+          "doc_count": 91120
+        },
+        {
+          "key": "02fceae6-c71c-4db9-8b2f-e235ced6624a",
+          "doc_count": 90591
+        },
+        {
+          "key": "f00b6a32-5337-406b-a850-17f5d78470ad",
+          "doc_count": 90018
+        },
+        {
+          "key": "61a1c0ce-8327-4e2a-9766-449751a49b7a",
+          "doc_count": 89789
+        },
+        {
+          "key": "781fd581-7b93-471e-a025-413e4bcd8491",
+          "doc_count": 89195
+        },
+        {
+          "key": "c481fbc6-4bd7-4c50-8537-ba1993d4eb88",
+          "doc_count": 86787
+        },
+        {
+          "key": "d78d13a7-3852-4244-ba34-86ef5765fa99",
+          "doc_count": 86769
+        },
+        {
+          "key": "7644703a-ce24-4f7b-b800-66ddf8812f86",
+          "doc_count": 85277
+        },
+        {
+          "key": "46c11153-2154-495d-89d2-7cdef6425cdb",
+          "doc_count": 85172
+        },
+        {
+          "key": "ee9d38ef-c1db-44de-b8f2-62acb7049370",
+          "doc_count": 82837
+        },
+        {
+          "key": "8b0c1f4b-9de7-4521-98c2-983e0bfd33c7",
+          "doc_count": 81586
+        },
+        {
+          "key": "c569e530-7322-40b8-9b66-1e0ed96fefcb",
+          "doc_count": 81456
+        },
+        {
+          "key": "cf641fbf-fa31-481a-993b-9204f2ee1884",
+          "doc_count": 80738
+        },
+        {
+          "key": "b667cef4-96fe-42e8-a9fa-6298aa80bb14",
+          "doc_count": 80713
+        },
+        {
+          "key": "83ad8494-136b-485a-87d4-8ce01dd6a8de",
+          "doc_count": 79509
+        },
+        {
+          "key": "b9ab58cf-785e-44a7-a873-1966e14a6715",
+          "doc_count": 79181
+        },
+        {
+          "key": "d7540872-1c53-48ac-a617-2d0739eadcbd",
+          "doc_count": 79113
+        },
+        {
+          "key": "ddef79ec-043c-4027-9876-c4a298feff6d",
+          "doc_count": 78656
+        },
+        {
+          "key": "b2b294ed-1742-4479-b0c8-a8891fccd7eb",
+          "doc_count": 77886
+        },
+        {
+          "key": "5e29dbcc-ce45-4f05-9bb0-212baffa8932",
+          "doc_count": 77700
+        },
+        {
+          "key": "264c48ec-8636-451f-a7e0-74131bc6f84c",
+          "doc_count": 77595
+        },
+        {
+          "key": "ba54ba45-caac-4708-a389-ac94642976f8",
+          "doc_count": 77466
+        },
+        {
+          "key": "20360fae-574a-4d63-b9f6-47b1cc07fd22",
+          "doc_count": 76898
+        },
+        {
+          "key": "ff89320d-e232-4edd-9cdd-4b6acc672ad3",
+          "doc_count": 76125
+        },
+        {
+          "key": "ec6cef7d-d8aa-43b4-b352-908f172a378e",
+          "doc_count": 75488
+        },
+        {
+          "key": "5835f642-2560-4e3e-9c25-741a12cc3fe8",
+          "doc_count": 75384
+        },
+        {
+          "key": "8dc14464-57b3-423e-8cb0-950ab8f36b6f",
+          "doc_count": 74455
+        },
+        {
+          "key": "7c1a1d78-aeaa-4501-87e1-83eceb8ca8ea",
+          "doc_count": 74122
+        },
+        {
+          "key": "dd232f5c-7f53-48ec-9bb7-7205702c3dc8",
+          "doc_count": 72999
+        },
+        {
+          "key": "844875a9-9927-48a5-90b4-76c5f227f145",
+          "doc_count": 70991
+        },
+        {
+          "key": "e5f57bb0-07ec-4405-90b6-dc89647a1cb5",
+          "doc_count": 70947
+        },
+        {
+          "key": "5a660a44-afdd-45ac-8c48-1a6c570ce0b5",
+          "doc_count": 70928
+        },
+        {
+          "key": "e48bb88f-9594-461e-8230-522a3a5572fe",
+          "doc_count": 68353
+        },
+        {
+          "key": "4830ffb8-669a-4717-bec8-2f2374f52120",
+          "doc_count": 68346
+        },
+        {
+          "key": "1bb33d2d-0714-4fc9-968e-b66bab1cf3d3",
+          "doc_count": 66199
+        },
+        {
+          "key": "7809d96b-7edf-4ef7-9f12-59967e9a01a6",
+          "doc_count": 65733
+        },
+        {
+          "key": "767c78b4-1c16-4cac-ad04-66333ac5a7f2",
+          "doc_count": 65505
+        },
+        {
+          "key": "8ec76c75-a673-4682-bfde-00a18bc12794",
+          "doc_count": 65365
+        },
+        {
+          "key": "d82fa49b-915e-4aa8-acc6-51df3d431884",
+          "doc_count": 64222
+        },
+        {
+          "key": "5ab348ab-439a-4697-925c-d6abe0c09b92",
+          "doc_count": 63025
+        },
+        {
+          "key": "b26fa674-6300-4ea0-a8e3-fc0ce32b5226",
+          "doc_count": 62139
+        },
+        {
+          "key": "9ef17d55-0498-44cf-9da4-dde3e3acb570",
+          "doc_count": 60669
+        },
+        {
+          "key": "e5b0c46a-5eb6-4b94-9d4c-fb1000f534b0",
+          "doc_count": 58665
+        },
+        {
+          "key": "09a3fcf2-55a1-488f-aa42-f103bdce0536",
+          "doc_count": 58250
+        },
+        {
+          "key": "5626f61a-822e-4692-b432-51f53d053e4d",
+          "doc_count": 58071
+        },
+        {
+          "key": "e1b03497-7632-4ba4-a9e0-dd230d06638c",
+          "doc_count": 56827
+        },
+        {
+          "key": "ec4acc26-ff1b-4131-a1df-a950fe31bb0e",
+          "doc_count": 56622
+        },
+        {
+          "key": "cb33cf97-2a7b-4b45-9b73-5aca568332a6",
+          "doc_count": 55502
+        },
+        {
+          "key": "f0174bc9-0cca-450e-a941-655d80040139",
+          "doc_count": 54865
+        },
+        {
+          "key": "8f3b62fb-56ec-49e8-9f8f-bb257348291f",
+          "doc_count": 54453
+        },
+        {
+          "key": "9ff03c57-ba5a-4127-9439-4bf3e838c4df",
+          "doc_count": 54392
+        },
+        {
+          "key": "471835cc-feb6-4d05-a8d1-62ce71399326",
+          "doc_count": 54131
+        },
+        {
+          "key": "9b725e43-93c9-423b-adf8-a11d08a83d13",
+          "doc_count": 53487
+        },
+        {
+          "key": "1f2b44b8-8556-4d6e-8247-4611689551cf",
+          "doc_count": 53268
+        },
+        {
+          "key": "1701a75c-5a57-48c3-84c2-234a53f4c3e2",
+          "doc_count": 52027
+        },
+        {
+          "key": "b88033dd-5dbb-4377-b374-2210f32ece16",
+          "doc_count": 50850
+        },
+        {
+          "key": "fdf7bb59-aad2-4f10-879f-6c0e7d3baa64",
+          "doc_count": 50838
+        },
+        {
+          "key": "e36691ec-c4f8-4bec-b331-b48ffa82ff49",
+          "doc_count": 50713
+        },
+        {
+          "key": "62254613-2696-4834-8c58-5c465f70df56",
+          "doc_count": 50672
+        },
+        {
+          "key": "72b6dbee-bc4d-4e35-a32c-8df0422771fb",
+          "doc_count": 50672
+        },
+        {
+          "key": "005ac06a-3d9a-46ad-ac3c-062aaa5b7059",
+          "doc_count": 50655
+        },
+        {
+          "key": "667a12e7-c6d8-4de0-933f-ce2f07cb7a92",
+          "doc_count": 50445
+        },
+        {
+          "key": "14f8f83f-7a0c-458c-b6d5-6da7dc8eaa0a",
+          "doc_count": 49996
+        },
+        {
+          "key": "b5f4526b-f4fb-4d90-8ce0-975e0cda8ff6",
+          "doc_count": 49612
+        },
+        {
+          "key": "910eadc8-8131-428c-b28a-91d0e2890f1d",
+          "doc_count": 49530
+        },
+        {
+          "key": "40987883-03cf-494a-a5cf-7c77c7aadb79",
+          "doc_count": 49396
+        },
+        {
+          "key": "2ec3b31e-c86b-4ce9-b265-77c8c3f9643c",
+          "doc_count": 49335
+        },
+        {
+          "key": "3998ec8d-4aae-46db-9370-179c19b69356",
+          "doc_count": 48835
+        },
+        {
+          "key": "15aa4812-aad2-4b26-a1d8-d4f8d79e6163",
+          "doc_count": 48468
+        },
+        {
+          "key": "b688c17c-3761-4ccd-a42f-88219f5fcff4",
+          "doc_count": 48321
+        },
+        {
+          "key": "e34cf41b-196c-4199-85d5-4d2ca5954b09",
+          "doc_count": 48249
+        },
+        {
+          "key": "ef77ec72-6537-41ab-a418-17f9a58e6e73",
+          "doc_count": 48030
+        },
+        {
+          "key": "e6eba8cd-fa2c-4ba2-bec0-6841e7633695",
+          "doc_count": 47925
+        },
+        {
+          "key": "f31a5f98-efd3-476a-9627-de3add582acd",
+          "doc_count": 47407
+        },
+        {
+          "key": "a16dc8d8-ff4a-4d62-a684-2937fb292b8d",
+          "doc_count": 46459
+        },
+        {
+          "key": "645bcd10-a74f-4207-a375-0254b954b7ad",
+          "doc_count": 45833
+        },
+        {
+          "key": "7f497d81-4c7e-4e06-b166-a459968b14e3",
+          "doc_count": 45585
+        },
+        {
+          "key": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "doc_count": 45109
+        },
+        {
+          "key": "7a31ab80-1cc0-4456-9dea-61c2e9031a6f",
+          "doc_count": 45032
+        },
+        {
+          "key": "120d557c-c5be-474d-98f0-1ba00ae16b40",
+          "doc_count": 43931
+        },
+        {
+          "key": "2cf2843f-567c-45c1-a328-cc210af76fc1",
+          "doc_count": 42486
+        },
+        {
+          "key": "e794b292-4a94-471e-ab84-6aaef1fea1b3",
+          "doc_count": 41979
+        },
+        {
+          "key": "a69decc7-76ba-496a-a66e-f91049c02cf0",
+          "doc_count": 40857
+        },
+        {
+          "key": "e7ac8c4a-64bd-491b-b764-232de9b4bfe5",
+          "doc_count": 40732
+        },
+        {
+          "key": "8f689b8b-5b65-4638-9555-f2a5d237a624",
+          "doc_count": 40574
+        },
+        {
+          "key": "d0d1c390-e662-4980-97e3-ae0039a06de8",
+          "doc_count": 40469
+        },
+        {
+          "key": "6b5e29d3-b462-44d8-ba38-d68af5088067",
+          "doc_count": 40079
+        },
+        {
+          "key": "46374ee7-7c70-48d8-bf16-2e6c1626565e",
+          "doc_count": 39597
+        },
+        {
+          "key": "0f19f6d6-79a4-434e-ba0b-a4f49f334078",
+          "doc_count": 39112
+        },
+        {
+          "key": "8e58cd34-3cbb-46f7-9c25-527251881a6f",
+          "doc_count": 38676
+        },
+        {
+          "key": "8fc08919-1137-42e4-9fa5-9e64f1e5757b",
+          "doc_count": 36996
+        },
+        {
+          "key": "d2c71720-e156-4943-8182-0a7bbe477a37",
+          "doc_count": 36771
+        },
+        {
+          "key": "32d433aa-9e2b-4ff9-bc55-5c3e30112207",
+          "doc_count": 35816
+        },
+        {
+          "key": "8445ab25-ff89-44b0-90f8-bf0790f50afc",
+          "doc_count": 35403
+        },
+        {
+          "key": "23a47a5f-2ac1-4f81-acd3-21d5b82ed22a",
+          "doc_count": 35280
+        },
+        {
+          "key": "3056112e-97c6-4d0d-b6c2-3c0a9adaca24",
+          "doc_count": 34921
+        },
+        {
+          "key": "e39f6dee-f2cf-4eff-afc9-4600cafe660c",
+          "doc_count": 34553
+        },
+        {
+          "key": "99b04c9f-908e-42bd-92bc-41aa94b72949",
+          "doc_count": 33449
+        },
+        {
+          "key": "aced32f9-e511-48c7-8e9e-b625777bdf7f",
+          "doc_count": 33118
+        },
+        {
+          "key": "e4ff51ba-5007-4c40-9a86-e8c6f4db77b7",
+          "doc_count": 33097
+        },
+        {
+          "key": "0266a3f4-872b-4d21-a6b4-5c9818d8742b",
+          "doc_count": 32818
+        },
+        {
+          "key": "9a06cc34-be24-4ebf-b599-cbb1d4b8ac7b",
+          "doc_count": 31844
+        },
+        {
+          "key": "c5b7dae8-b483-4742-9954-d7f9226daa34",
+          "doc_count": 31809
+        },
+        {
+          "key": "ced8c9bc-e8b5-49e7-860a-289fc913860c",
+          "doc_count": 31549
+        },
+        {
+          "key": "6b565194-9707-42da-8052-9f9cf5f9aa60",
+          "doc_count": 31217
+        },
+        {
+          "key": "e0e37702-32af-405b-b652-ee54b5bb94e2",
+          "doc_count": 30656
+        },
+        {
+          "key": "5e893602-84ca-4c8c-bac1-99111c777582",
+          "doc_count": 30515
+        },
+        {
+          "key": "244ee82a-438c-4e77-a2ce-4e2af9ddbe4d",
+          "doc_count": 30171
+        },
+        {
+          "key": "774a153b-e556-47f6-95d1-bab49e61cc58",
+          "doc_count": 29572
+        },
+        {
+          "key": "654e092c-edbd-456c-8cce-2bcbdff71a04",
+          "doc_count": 29162
+        },
+        {
+          "key": "9cecfba6-6501-401c-9043-e95ba70164f3",
+          "doc_count": 29159
+        },
+        {
+          "key": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "doc_count": 28726
+        },
+        {
+          "key": "678dc436-3370-4992-a361-761dab8c3fda",
+          "doc_count": 28624
+        },
+        {
+          "key": "570dcca6-a84f-43aa-8053-1a2ac60d9ead",
+          "doc_count": 28478
+        },
+        {
+          "key": "e27f0218-47e0-41bc-9086-9d9169096e90",
+          "doc_count": 28062
+        },
+        {
+          "key": "e185415c-15c4-4612-89f3-27cfebbca0d9",
+          "doc_count": 27982
+        },
+        {
+          "key": "0220907a-0463-4ae0-8a0b-77f5e80fff40",
+          "doc_count": 27865
+        },
+        {
+          "key": "d29b9265-07e6-4e73-8f72-fc42d3d83fb1",
+          "doc_count": 27711
+        },
+        {
+          "key": "4db72a36-c08b-4a6b-8c68-ab45ebb0efce",
+          "doc_count": 27680
+        },
+        {
+          "key": "6bb853ab-e8ea-43b1-bd83-47318fc4c345",
+          "doc_count": 27614
+        },
+        {
+          "key": "37213da3-a1c7-4644-917e-8f8440e1c4d4",
+          "doc_count": 27344
+        },
+        {
+          "key": "181352ea-3598-4f32-b919-c8f6097f4c65",
+          "doc_count": 27092
+        },
+        {
+          "key": "a7020dbf-35fc-46e8-a441-c0a6b957193c",
+          "doc_count": 26701
+        },
+        {
+          "key": "7fbf76b1-6bd6-4217-a5bc-1d89e45f6a68",
+          "doc_count": 26605
+        },
+        {
+          "key": "1a44dfa0-6a54-4584-8c57-d98669d7f033",
+          "doc_count": 26323
+        },
+        {
+          "key": "7ad07cff-f782-4ddf-b780-3a757cdb77e0",
+          "doc_count": 26149
+        },
+        {
+          "key": "1bfc0147-2df1-4488-bcf7-d140e24dda51",
+          "doc_count": 25733
+        },
+        {
+          "key": "dfd53a42-8f63-4040-93a5-3f1347ce7686",
+          "doc_count": 25569
+        },
+        {
+          "key": "f1a78c0f-449c-45fa-9472-0b92cc2a58da",
+          "doc_count": 24997
+        },
+        {
+          "key": "1c729855-f3dd-439d-b326-54d62f57b0fd",
+          "doc_count": 24922
+        },
+        {
+          "key": "364a24d9-d4a8-4e0b-8e50-07b90f844548",
+          "doc_count": 24529
+        },
+        {
+          "key": "6b2c3ca9-69ad-4316-a2d1-33399e9f547e",
+          "doc_count": 24481
+        },
+        {
+          "key": "518518b7-9e85-42ea-b419-2d23a3ef546a",
+          "doc_count": 24109
+        },
+        {
+          "key": "ef59f7cc-ed42-45fc-9abc-5edfb2c8caec",
+          "doc_count": 23979
+        },
+        {
+          "key": "fccc3c1d-d9df-4ffd-b7e1-1b9eb11f95b1",
+          "doc_count": 23820
+        },
+        {
+          "key": "531537fc-6349-4a20-ae42-540d61797086",
+          "doc_count": 23767
+        },
+        {
+          "key": "7e4aacd3-0a24-49ab-b019-518b7069b682",
+          "doc_count": 23576
+        },
+        {
+          "key": "04d9b721-259c-4d6b-b48f-2e23edf66c9f",
+          "doc_count": 23409
+        },
+        {
+          "key": "7110b8ba-0ead-4666-8279-e30f53e343d0",
+          "doc_count": 23286
+        },
+        {
+          "key": "c49bc91d-0a50-497b-8b17-d77808745cf9",
+          "doc_count": 23045
+        },
+        {
+          "key": "45544aa4-8762-4bf0-bfc6-890d08dc6ead",
+          "doc_count": 22907
+        },
+        {
+          "key": "2941b767-e90b-41b9-9627-6e589e0c0c85",
+          "doc_count": 22552
+        },
+        {
+          "key": "042dbdba-a449-4291-8777-577a5a4045de",
+          "doc_count": 22203
+        },
+        {
+          "key": "21b563bc-70c2-46d5-bce8-2489db2db3d8",
+          "doc_count": 21645
+        },
+        {
+          "key": "1e054b9b-0193-4ff3-b623-9264cf982d4d",
+          "doc_count": 21052
+        },
+        {
+          "key": "e7016bd5-cb10-45b9-8959-0f5750f7a5db",
+          "doc_count": 20384
+        },
+        {
+          "key": "b000920c-6f7d-49d3-9d0f-2bb630d2e01a",
+          "doc_count": 20310
+        },
+        {
+          "key": "3f508496-c860-4701-93e4-84e940c8395e",
+          "doc_count": 20172
+        },
+        {
+          "key": "98ece30d-bf85-4122-b872-7786031b457f",
+          "doc_count": 19756
+        },
+        {
+          "key": "77b762ba-7cda-4617-97d7-e78df7f6dfab",
+          "doc_count": 19665
+        },
+        {
+          "key": "9e1958fb-1dc4-4375-ae35-67ba7f9c7afe",
+          "doc_count": 19660
+        },
+        {
+          "key": "48f5d475-7381-4d06-88eb-119796b9d189",
+          "doc_count": 19451
+        },
+        {
+          "key": "f630e3ea-697f-404a-8683-b86712c26c43",
+          "doc_count": 19168
+        },
+        {
+          "key": "d100843b-d592-4024-8d15-fb1d8e218acd",
+          "doc_count": 19101
+        },
+        {
+          "key": "4ef6540c-e6cf-4678-bc43-b57435354de0",
+          "doc_count": 19067
+        },
+        {
+          "key": "1b6bb28e-e443-4cd3-910a-c6c43849c2cd",
+          "doc_count": 18944
+        },
+        {
+          "key": "a2a17035-1e6c-46df-9178-a610df825336",
+          "doc_count": 18851
+        },
+        {
+          "key": "1f5a1b81-e361-4d65-ab1c-6fb7e30c9910",
+          "doc_count": 18565
+        },
+        {
+          "key": "8e5fffb5-0b22-472d-8386-de291d17d513",
+          "doc_count": 18376
+        },
+        {
+          "key": "cb65cf5e-07b8-4d53-a91a-7dce9b8ccf80",
+          "doc_count": 18304
+        },
+        {
+          "key": "50cfe20a-9100-4710-89f9-a97bc3aa53d7",
+          "doc_count": 18060
+        },
+        {
+          "key": "92dd8c8e-c048-4f0a-9b5d-2ee627d2f553",
+          "doc_count": 17946
+        },
+        {
+          "key": "65007e62-740c-4302-ba20-260fe68da291",
+          "doc_count": 17883
+        },
+        {
+          "key": "79488fda-8310-42cd-b98e-8c3c2dd7d415",
+          "doc_count": 17834
+        },
+        {
+          "key": "c9dad611-5e60-4456-934e-75b0e0842ddd",
+          "doc_count": 17782
+        },
+        {
+          "key": "437826f3-69f9-43d9-b3c3-c0de0e26cd88",
+          "doc_count": 17715
+        },
+        {
+          "key": "bf9066a2-2c5f-4cf2-821a-1a68b4df5b1b",
+          "doc_count": 17648
+        },
+        {
+          "key": "aac5fd7f-8043-4aa8-811f-e50de70d96f3",
+          "doc_count": 17478
+        },
+        {
+          "key": "f33e9494-7b3c-4ac6-a735-59693b5a9638",
+          "doc_count": 17427
+        },
+        {
+          "key": "821c1855-6817-40ee-8732-7f472d238513",
+          "doc_count": 17079
+        },
+        {
+          "key": "a062eb42-d5c6-4332-8c88-64b4ac1af892",
+          "doc_count": 17036
+        },
+        {
+          "key": "2b45c778-b10c-496b-b8cb-1e414da59ccf",
+          "doc_count": 16711
+        },
+        {
+          "key": "c3134980-bf5c-49b8-a289-790d45f02c86",
+          "doc_count": 16504
+        },
+        {
+          "key": "7ae4d15d-62e2-459b-842a-446f921b9d3f",
+          "doc_count": 16477
+        },
+        {
+          "key": "4fed055b-3c46-4ec4-b76d-84d43df9258b",
+          "doc_count": 16341
+        },
+        {
+          "key": "8295ea14-c4fd-499b-bc68-2907ed36badc",
+          "doc_count": 16217
+        },
+        {
+          "key": "c5eeb223-0515-423a-a51a-151426c8f60d",
+          "doc_count": 16149
+        },
+        {
+          "key": "b30a7dd2-d974-4073-bdd0-cb4ea5402bae",
+          "doc_count": 15961
+        },
+        {
+          "key": "1e798b2d-7f97-49b0-a864-79c968af91d3",
+          "doc_count": 15664
+        },
+        {
+          "key": "ad4e4ea0-2ac9-4030-b4bd-bf4206e79bcc",
+          "doc_count": 15339
+        },
+        {
+          "key": "6ae7221e-2085-46cf-9ad0-353269e95bc8",
+          "doc_count": 15175
+        },
+        {
+          "key": "cd177f63-761b-44f6-866e-ee19d2ac134e",
+          "doc_count": 14855
+        },
+        {
+          "key": "0038ce2e-43bb-4f70-8dd6-dca34efd3fca",
+          "doc_count": 14808
+        },
+        {
+          "key": "50b0bbe4-f075-4427-8dfc-fcc469dd3e78",
+          "doc_count": 14583
+        },
+        {
+          "key": "92e4e092-6dcb-46bc-85a0-dea8310aba45",
+          "doc_count": 14534
+        },
+        {
+          "key": "837d99c6-3045-4ba3-8951-643ddb3d6676",
+          "doc_count": 14434
+        },
+        {
+          "key": "bbf5f8ed-f33f-40ba-9d0d-1c24dfec4193",
+          "doc_count": 13613
+        },
+        {
+          "key": "a4378725-7967-47bc-aada-0220e02e1f96",
+          "doc_count": 13552
+        },
+        {
+          "key": "662b1aa5-9c19-4eb9-9766-1da78a117456",
+          "doc_count": 13461
+        },
+        {
+          "key": "e3c0918d-ec6e-4ecd-a1db-15ec6880dade",
+          "doc_count": 13426
+        },
+        {
+          "key": "5a9ae910-9e4b-488b-af8e-88074fabc3a4",
+          "doc_count": 13374
+        },
+        {
+          "key": "e23109b4-e143-437c-b329-3dff7cb35488",
+          "doc_count": 13082
+        },
+        {
+          "key": "87017793-00dc-4f5d-b95b-09e7d17327cc",
+          "doc_count": 12983
+        },
+        {
+          "key": "341611f4-8b65-4655-b244-9be91a1109cd",
+          "doc_count": 12978
+        },
+        {
+          "key": "c3f05887-ffa9-44c4-b1af-e38fea5557bf",
+          "doc_count": 12961
+        },
+        {
+          "key": "e4b33221-1e2c-405c-ac02-a39d93f9a69b",
+          "doc_count": 12914
+        },
+        {
+          "key": "bd7cfd55-bf55-46fc-878d-e6e11f574ccd",
+          "doc_count": 12632
+        },
+        {
+          "key": "13510466-6232-4313-9e46-ea197b82750c",
+          "doc_count": 12631
+        },
+        {
+          "key": "86b2bfc9-ca99-4250-b93a-f86f3777236d",
+          "doc_count": 12457
+        },
+        {
+          "key": "91c5eec8-0cdc-4be2-9a99-a15ae5ec3edc",
+          "doc_count": 12373
+        },
+        {
+          "key": "063825dc-b8c3-4962-aea4-9994bcc09bc8",
+          "doc_count": 12238
+        },
+        {
+          "key": "139f2c47-4051-4c44-b95a-45fd20b1a8b9",
+          "doc_count": 12151
+        },
+        {
+          "key": "3c367a2d-eec0-4ef1-b3bc-4cbebb320c5a",
+          "doc_count": 11895
+        },
+        {
+          "key": "b5e5c781-765f-4981-af2a-c19c250e2cf0",
+          "doc_count": 11662
+        },
+        {
+          "key": "93e97f6c-0ab6-41a7-9b58-7e230a80ec1e",
+          "doc_count": 11634
+        },
+        {
+          "key": "2532cbd0-2752-4211-b249-4a9811a280f2",
+          "doc_count": 11614
+        },
+        {
+          "key": "04fe30b4-c1e5-4482-addb-67a4c2cd39ef",
+          "doc_count": 11602
+        },
+        {
+          "key": "4d89070b-5dea-4a12-8a09-3f65ba33dba1",
+          "doc_count": 10956
+        },
+        {
+          "key": "1ad40bde-8a2a-46bb-9252-0cdc53df5683",
+          "doc_count": 10874
+        },
+        {
+          "key": "3ac8f738-bc3e-43e4-8358-00a32594954d",
+          "doc_count": 10763
+        },
+        {
+          "key": "5082e6c8-8f5b-4bf6-a930-e3e6de7bf6fb",
+          "doc_count": 10677
+        },
+        {
+          "key": "f89ada44-88df-46f0-bc61-cc46d9c84673",
+          "doc_count": 10668
+        },
+        {
+          "key": "6d09cfc1-a17c-4067-b1a0-557b8e5334ea",
+          "doc_count": 10539
+        },
+        {
+          "key": "ab4b6a2b-a90a-44ce-95a1-2c44c911fcc6",
+          "doc_count": 10504
+        },
+        {
+          "key": "a2a7754b-2346-496d-b681-eb754ef32b9e",
+          "doc_count": 10371
+        },
+        {
+          "key": "12018be6-3795-43a3-a073-a2b9d60c0af3",
+          "doc_count": 10183
+        },
+        {
+          "key": "bfa3c276-a3a9-48cd-8d4a-4ac42f4fe10a",
+          "doc_count": 10134
+        },
+        {
+          "key": "06c35934-1b75-4196-838d-29d509951bf9",
+          "doc_count": 10044
+        },
+        {
+          "key": "81dc7cdb-66be-4683-ae79-068a784378b1",
+          "doc_count": 10033
+        },
+        {
+          "key": "c94a06a5-df24-4546-adba-4f7940661826",
+          "doc_count": 9963
+        },
+        {
+          "key": "7cc1fb18-45c1-499f-8476-682daa14a4a3",
+          "doc_count": 9890
+        },
+        {
+          "key": "79aa7602-a963-44f3-82dd-e141a387adb8",
+          "doc_count": 9861
+        },
+        {
+          "key": "15e04168-22cc-4283-9042-247ab053c7ca",
+          "doc_count": 9804
+        },
+        {
+          "key": "252a0a12-f114-4fb5-aa9a-678c523d6dcd",
+          "doc_count": 9535
+        },
+        {
+          "key": "e701ecce-f9ab-445f-afcb-24f279efbc9c",
+          "doc_count": 9475
+        },
+        {
+          "key": "3c6f1ea5-f2e7-4203-9cfe-74ec2fb1b035",
+          "doc_count": 9426
+        },
+        {
+          "key": "c004cf67-eafc-49f9-99bd-b8198e2234ed",
+          "doc_count": 9370
+        },
+        {
+          "key": "abe3903e-ceba-4864-aa5d-bd985c70fa21",
+          "doc_count": 9205
+        },
+        {
+          "key": "3a5b5c9b-b241-4883-904a-b167a7edb41a",
+          "doc_count": 9155
+        },
+        {
+          "key": "90739622-5232-4048-8121-9af9ec69604f",
+          "doc_count": 9154
+        },
+        {
+          "key": "5889291d-9105-4740-a30f-2d9d2469c264",
+          "doc_count": 9100
+        },
+        {
+          "key": "f0599190-e5b7-42ed-bec8-810905f50c34",
+          "doc_count": 8900
+        },
+        {
+          "key": "ec248223-f277-4c02-b1fa-60056b5a689a",
+          "doc_count": 8865
+        },
+        {
+          "key": "9d2a4189-6048-46e9-bac4-e5ef566334bb",
+          "doc_count": 8857
+        },
+        {
+          "key": "dbb2acdc-a808-4deb-9dc2-542d70368a3f",
+          "doc_count": 8797
+        },
+        {
+          "key": "0272afc1-36ee-4899-8c28-dde9d8a211d9",
+          "doc_count": 8788
+        },
+        {
+          "key": "414a5bf5-061e-4e47-8410-0f76a04f7d1d",
+          "doc_count": 8715
+        },
+        {
+          "key": "5ffc8bc6-e366-4157-b1ba-00859f1048a4",
+          "doc_count": 8701
+        },
+        {
+          "key": "f08c31ea-0e90-4cc1-b471-dfd0584ae7cf",
+          "doc_count": 8470
+        },
+        {
+          "key": "9756b9a4-c070-4359-8a07-2383b09d0d04",
+          "doc_count": 8361
+        },
+        {
+          "key": "bdf65f9c-a730-4083-bd8d-a2def3037637",
+          "doc_count": 8345
+        },
+        {
+          "key": "ef04e127-bb7d-4bf0-82d3-767d43108f81",
+          "doc_count": 8289
+        },
+        {
+          "key": "e7db896a-c95b-4a18-99a4-866fff238ca5",
+          "doc_count": 8046
+        },
+        {
+          "key": "331b6d1b-842e-4c63-aa23-75ef275d8a9f",
+          "doc_count": 8010
+        },
+        {
+          "key": "81d00e23-92aa-45d7-b289-5cf045ddfbf4",
+          "doc_count": 7958
+        },
+        {
+          "key": "cfe5c00e-bec3-4120-a8eb-62c5353f3e80",
+          "doc_count": 7903
+        },
+        {
+          "key": "cf60ed8a-2c79-4b85-a259-15a8e216dae4",
+          "doc_count": 7897
+        },
+        {
+          "key": "7e44229a-e8fa-4570-ada1-0cd7843a66d7",
+          "doc_count": 7747
+        },
+        {
+          "key": "6539877e-82dc-485c-ad3d-038f383d5431",
+          "doc_count": 7721
+        },
+        {
+          "key": "eaa5f19e-ff6f-4d09-8b55-4a6810e77a6c",
+          "doc_count": 7647
+        },
+        {
+          "key": "4960f30c-c1c7-490e-966a-61ad02969e38",
+          "doc_count": 7567
+        },
+        {
+          "key": "540e18dc-09aa-4790-8b47-8d18ae86fabc",
+          "doc_count": 7567
+        },
+        {
+          "key": "364b1f8d-5975-48d9-bba1-c97ab172986c",
+          "doc_count": 7551
+        },
+        {
+          "key": "1ffce054-8e3e-4209-9ff4-c26fa6c24c2f",
+          "doc_count": 7491
+        },
+        {
+          "key": "e77108de-88dd-4931-8085-0ea59d7ca4ee",
+          "doc_count": 7378
+        },
+        {
+          "key": "3501e0a6-1420-45b9-bbf9-77349e79e9d7",
+          "doc_count": 7307
+        },
+        {
+          "key": "c7ae0ade-c23e-4fe6-a3d4-79bd973374c2",
+          "doc_count": 7276
+        },
+        {
+          "key": "5fd5a403-8e94-4865-8c77-ee92cb4a95f2",
+          "doc_count": 7150
+        },
+        {
+          "key": "4f436daa-01d5-4be6-b5c3-fdd255677536",
+          "doc_count": 6994
+        },
+        {
+          "key": "e80fe2bb-547d-4e98-84ce-01176379e3a8",
+          "doc_count": 6843
+        },
+        {
+          "key": "d6c6e57a-4ccb-4707-b87d-c91d01d6aa42",
+          "doc_count": 6814
+        },
+        {
+          "key": "d840624f-42d5-40d9-9daa-2260f85feb54",
+          "doc_count": 6806
+        },
+        {
+          "key": "a83151ae-e1db-4166-9dde-438f6544dca9",
+          "doc_count": 6732
+        },
+        {
+          "key": "ea9de87b-7231-4a05-809f-4b658ea4173d",
+          "doc_count": 6722
+        },
+        {
+          "key": "cd7b335e-6f5c-4259-ba45-5e334a719464",
+          "doc_count": 6667
+        },
+        {
+          "key": "73236de8-c2cc-458c-b0c3-743c7b57db3a",
+          "doc_count": 6634
+        },
+        {
+          "key": "b00cf471-6bbe-4f94-846e-288900398b65",
+          "doc_count": 6626
+        },
+        {
+          "key": "69037495-438d-4dba-bf0f-4878073766f1",
+          "doc_count": 6610
+        },
+        {
+          "key": "b4bcc255-4acf-4966-b9b3-af9dd4e458d1",
+          "doc_count": 6576
+        },
+        {
+          "key": "5ab5f23d-292e-4bea-ba06-12db0f8a8c86",
+          "doc_count": 6530
+        },
+        {
+          "key": "7ed2ce52-26e5-4847-9563-955ae3e97455",
+          "doc_count": 6526
+        },
+        {
+          "key": "c38b867b-05f3-4733-802e-d8d2d3324f84",
+          "doc_count": 6400
+        },
+        {
+          "key": "959c0dc4-fcf3-477e-af63-c00a005dbc0a",
+          "doc_count": 6384
+        },
+        {
+          "key": "b1ed65bb-f27e-4695-a0f5-7ca52fc0c3e6",
+          "doc_count": 6275
+        },
+        {
+          "key": "2c662e9e-cdc6-4bbf-93a5-1566ceca1af3",
+          "doc_count": 6268
+        },
+        {
+          "key": "5486b66d-2082-433d-9223-bd789ebca29c",
+          "doc_count": 6172
+        },
+        {
+          "key": "d5a1b706-c624-43df-afcf-9cea7094e75b",
+          "doc_count": 6164
+        },
+        {
+          "key": "e5cb850f-de98-45ce-9872-95262732809f",
+          "doc_count": 6015
+        },
+        {
+          "key": "8eabbc48-2b30-419d-bd8f-eece9185eca1",
+          "doc_count": 6001
+        },
+        {
+          "key": "55e724a4-336a-4315-99e7-01bf0c94f222",
+          "doc_count": 5924
+        },
+        {
+          "key": "1eca069b-09e0-406d-9625-cb9c52e1e5cc",
+          "doc_count": 5917
+        },
+        {
+          "key": "954ec5e0-4fcd-414d-8ad2-46b4b75cfc74",
+          "doc_count": 5902
+        },
+        {
+          "key": "d5c32031-231f-4213-b0f1-2dc4bbf711a0",
+          "doc_count": 5891
+        },
+        {
+          "key": "22436fe4-5049-4266-9849-335dd3f161aa",
+          "doc_count": 5863
+        },
+        {
+          "key": "c1122f57-9ab9-4552-9393-7d56b0bbe852",
+          "doc_count": 5797
+        },
+        {
+          "key": "8bcb95b2-ab5c-4368-8ead-14588eeb9c98",
+          "doc_count": 5756
+        },
+        {
+          "key": "6f470382-cb0b-4634-a796-2248bfa97fdc",
+          "doc_count": 5696
+        },
+        {
+          "key": "44328ef7-fc7f-4ff6-b51b-ed9049857e11",
+          "doc_count": 5680
+        },
+        {
+          "key": "9368e302-f8e7-4714-aed4-db2faa861e5c",
+          "doc_count": 5642
+        },
+        {
+          "key": "67893f3c-c409-41c6-a8f2-47956739a911",
+          "doc_count": 5541
+        },
+        {
+          "key": "ec135c9b-ff89-4f28-aa18-88b16d932d94",
+          "doc_count": 5441
+        },
+        {
+          "key": "5af1bae4-35c0-4ab7-9d08-08bbe22ca003",
+          "doc_count": 5428
+        },
+        {
+          "key": "347579f4-d44a-4c8e-a578-09c2a8132573",
+          "doc_count": 5391
+        },
+        {
+          "key": "a5fdee09-34c4-48bc-99ff-a503c93a9d7e",
+          "doc_count": 5227
+        },
+        {
+          "key": "66427724-af1d-43f8-bc00-cb744e55ac2c",
+          "doc_count": 5220
+        },
+        {
+          "key": "fd14095c-3658-4e00-8cec-729a89459e92",
+          "doc_count": 5138
+        },
+        {
+          "key": "7cea906d-ae65-420c-a6f7-a9a3ad64fb93",
+          "doc_count": 5121
+        },
+        {
+          "key": "589ee0cf-456c-4d9c-8e7e-3adc3cec0e09",
+          "doc_count": 5111
+        },
+        {
+          "key": "de5203b1-5a44-4010-948c-b7d33f46397a",
+          "doc_count": 5099
+        },
+        {
+          "key": "f5d395b8-c3c9-43df-b4ff-63d65c6a971e",
+          "doc_count": 5037
+        },
+        {
+          "key": "6cab4420-11e4-4b55-85ac-6ecfdda70184",
+          "doc_count": 5023
+        },
+        {
+          "key": "43c69d2a-0fd2-4d34-a1ef-50d0f9c01353",
+          "doc_count": 5020
+        },
+        {
+          "key": "d14d21fe-da24-47e5-81fb-4bfe962ce828",
+          "doc_count": 5003
+        },
+        {
+          "key": "a4babe52-5740-44e4-9ea2-acef4797f127",
+          "doc_count": 4970
+        },
+        {
+          "key": "2f740a87-8049-435d-9d06-1c393c9c11b7",
+          "doc_count": 4851
+        },
+        {
+          "key": "196c4f1c-53f9-480f-a012-dc0522629047",
+          "doc_count": 4660
+        },
+        {
+          "key": "282fe9c2-d6cb-4325-b3b5-b70ab1d22bbb",
+          "doc_count": 4611
+        },
+        {
+          "key": "fe04dab1-5a3d-4c28-a450-012658e982d8",
+          "doc_count": 4570
+        },
+        {
+          "key": "9b34b218-efb2-43b9-9b9e-dac3c470a9f9",
+          "doc_count": 4552
+        },
+        {
+          "key": "b1beb057-bc34-49a9-b784-2a50af226712",
+          "doc_count": 4442
+        },
+        {
+          "key": "25cd5e12-7830-4f46-bf6d-9b6deb706f44",
+          "doc_count": 4339
+        },
+        {
+          "key": "295a8445-346f-4ea2-b0cf-4a3863c72cdb",
+          "doc_count": 4301
+        },
+        {
+          "key": "6e922c92-b37d-4c46-8982-19d945ff8fd1",
+          "doc_count": 4272
+        },
+        {
+          "key": "23b85d9d-4669-40db-901f-aaad686fe0b8",
+          "doc_count": 4241
+        },
+        {
+          "key": "2b03a9d6-3575-43ea-8f43-38cbe0ee72e6",
+          "doc_count": 4231
+        },
+        {
+          "key": "9e046dad-2b23-4f95-8eaf-c0346de2556e",
+          "doc_count": 4224
+        },
+        {
+          "key": "69d150df-eba4-4ab3-9156-71cb0db41830",
+          "doc_count": 4207
+        },
+        {
+          "key": "c5d42fed-eed0-4e14-9625-f8a9c0ff6bb1",
+          "doc_count": 4196
+        },
+        {
+          "key": "4bec11d1-f8c3-43a7-9e70-ee0256fcedaf",
+          "doc_count": 4187
+        },
+        {
+          "key": "4790a6a0-ce11-4cd8-8cad-4b2032a55c1b",
+          "doc_count": 4168
+        },
+        {
+          "key": "fc628e53-5fdf-4436-9782-bf637d812b48",
+          "doc_count": 4153
+        },
+        {
+          "key": "eeb4872b-7fb4-4ecd-8ce5-82e194f04735",
+          "doc_count": 4138
+        },
+        {
+          "key": "7370af7d-07b5-4fc6-9eca-0204b4d6e33e",
+          "doc_count": 4122
+        },
+        {
+          "key": "093030d9-a124-42a8-8cf3-8c6904fefbe7",
+          "doc_count": 4116
+        },
+        {
+          "key": "6f510e69-96b2-4817-bab7-3a36c8250c79",
+          "doc_count": 4074
+        },
+        {
+          "key": "2bbafa00-3162-4e8e-947c-64a13b8d3fef",
+          "doc_count": 4069
+        },
+        {
+          "key": "11170c5e-033a-4410-aed1-3dee2458bc43",
+          "doc_count": 4063
+        },
+        {
+          "key": "0e5201c0-bad2-4e28-9322-5c5dca8862c8",
+          "doc_count": 4010
+        },
+        {
+          "key": "9c963109-9898-4953-a351-d5ee36d6115b",
+          "doc_count": 4010
+        },
+        {
+          "key": "6ac89a16-4604-4a78-9047-dcc57e5c0130",
+          "doc_count": 3961
+        },
+        {
+          "key": "d6f12b28-bb9f-44f9-9000-08f644658bf8",
+          "doc_count": 3955
+        },
+        {
+          "key": "833306f7-91b6-4ff7-bc16-0e406334d991",
+          "doc_count": 3949
+        },
+        {
+          "key": "677f57a9-9a0d-4e69-8622-96aa1e6392c2",
+          "doc_count": 3921
+        },
+        {
+          "key": "9fab87bf-c5a7-4296-acdc-f22859cfe620",
+          "doc_count": 3898
+        },
+        {
+          "key": "d1b25dcd-472e-4902-b53c-3b164269e049",
+          "doc_count": 3879
+        },
+        {
+          "key": "9d9b81f1-3a9a-4515-b741-a145293f1fef",
+          "doc_count": 3849
+        },
+        {
+          "key": "2d4658e3-0d1a-43fc-97ff-b4813dd1f86e",
+          "doc_count": 3831
+        },
+        {
+          "key": "b8972f6b-c67f-45c0-b348-954866e04a0f",
+          "doc_count": 3777
+        },
+        {
+          "key": "560ba8f5-0dab-46f6-985d-7b37397344cd",
+          "doc_count": 3755
+        },
+        {
+          "key": "49153f74-2969-4a6a-a145-309fcb970308",
+          "doc_count": 3748
+        },
+        {
+          "key": "64b54f96-91f0-4442-b6de-173aa1a5c31b",
+          "doc_count": 3740
+        },
+        {
+          "key": "196bb137-2f82-40d5-b294-e730af29749f",
+          "doc_count": 3738
+        },
+        {
+          "key": "a50e98bd-13e9-41fe-a5cc-aee4f240628b",
+          "doc_count": 3674
+        },
+        {
+          "key": "09a76937-b01a-4f4a-aefd-825876453015",
+          "doc_count": 3673
+        },
+        {
+          "key": "66e00116-15fa-4149-a94a-eb91b98b622c",
+          "doc_count": 3632
+        },
+        {
+          "key": "1f8c7572-5cda-44be-9a78-0658217fc279",
+          "doc_count": 3622
+        },
+        {
+          "key": "a2bc3d61-3c37-4aca-b47d-c3413f7e3b87",
+          "doc_count": 3591
+        },
+        {
+          "key": "4c9d08ce-71c1-47b8-a572-2d40e5984c49",
+          "doc_count": 3564
+        },
+        {
+          "key": "34cad268-8226-4280-b637-dde38c82a29e",
+          "doc_count": 3514
+        },
+        {
+          "key": "b880344e-22b2-4540-a56a-1de5f5601a20",
+          "doc_count": 3480
+        },
+        {
+          "key": "ff111763-e72d-4f24-8914-b5b2dd94908c",
+          "doc_count": 3478
+        },
+        {
+          "key": "55b17f44-8c6b-4dc5-a31d-d9955b425790",
+          "doc_count": 3458
+        },
+        {
+          "key": "0e0e9bbc-1dea-4de4-95ae-aecc90844bbf",
+          "doc_count": 3338
+        },
+        {
+          "key": "9a09745d-4449-46a2-b8b3-60f3c0d25e83",
+          "doc_count": 3334
+        },
+        {
+          "key": "b40e13f7-a79a-4265-93d9-3b4878dfc988",
+          "doc_count": 3303
+        },
+        {
+          "key": "4900d7ce-9442-4305-9889-c9cbbb953eaa",
+          "doc_count": 3296
+        },
+        {
+          "key": "7026b70a-7245-42bd-8162-81ae9a6cfbcb",
+          "doc_count": 3262
+        },
+        {
+          "key": "bf897c17-06cc-48c1-a7cc-f41b45166880",
+          "doc_count": 3244
+        },
+        {
+          "key": "8728ef71-fdcc-4027-8139-38b2c0628fba",
+          "doc_count": 3205
+        },
+        {
+          "key": "df516dc6-6ef0-426d-94e3-8a2bbb0439a5",
+          "doc_count": 3174
+        },
+        {
+          "key": "e85a9948-9c9e-451d-9485-b2b4cb7b73d5",
+          "doc_count": 3161
+        },
+        {
+          "key": "ef637c01-c551-4d47-8a48-4442b8ad5ecd",
+          "doc_count": 3152
+        },
+        {
+          "key": "79be41bc-8142-485a-9d57-d6195f9a7c81",
+          "doc_count": 3137
+        },
+        {
+          "key": "fcbcb214-cd62-4453-af56-b4b49161a261",
+          "doc_count": 3137
+        },
+        {
+          "key": "fc40fabd-0a70-48fa-b142-79990cd259a5",
+          "doc_count": 3107
+        },
+        {
+          "key": "d1983d53-434a-436e-a698-3a2745eb61dc",
+          "doc_count": 3090
+        },
+        {
+          "key": "0bfd2d69-2a35-4291-9e73-bd311463bd15",
+          "doc_count": 3076
+        },
+        {
+          "key": "6d4b658a-90b4-4639-8b06-b7f07637f6aa",
+          "doc_count": 3062
+        },
+        {
+          "key": "b4d4e884-a2ef-4967-b4cb-2072fc465eaf",
+          "doc_count": 3043
+        },
+        {
+          "key": "b20588fd-61f4-4765-8025-30c81a5f4250",
+          "doc_count": 2975
+        },
+        {
+          "key": "47ac1531-5213-4848-a32d-5bb396ab9348",
+          "doc_count": 2966
+        },
+        {
+          "key": "d81c6ad6-fb8f-4c31-bba3-f2b65f780893",
+          "doc_count": 2962
+        },
+        {
+          "key": "2e3a8e5c-eef9-462d-a690-3a91fe111e13",
+          "doc_count": 2959
+        },
+        {
+          "key": "9fa0a48c-7dd2-4372-a768-9aea3cbd35bb",
+          "doc_count": 2919
+        },
+        {
+          "key": "5277e72c-9e53-4c98-85f1-ee413bc473cd",
+          "doc_count": 2909
+        },
+        {
+          "key": "9f3bbc7b-c682-4f66-88b3-48eef3a38f38",
+          "doc_count": 2865
+        },
+        {
+          "key": "39289378-eed8-442c-ba0b-fce8b1679d8f",
+          "doc_count": 2856
+        },
+        {
+          "key": "333ac26a-30bc-4e0c-a6ef-c57a40f6bd99",
+          "doc_count": 2830
+        },
+        {
+          "key": "8783e947-93cf-4b60-b387-d10642b0eee0",
+          "doc_count": 2829
+        },
+        {
+          "key": "19daf0a7-5e37-41e6-97f8-4494553c358c",
+          "doc_count": 2822
+        },
+        {
+          "key": "5e8863ea-56ec-40f3-8075-d42b35d12e72",
+          "doc_count": 2789
+        },
+        {
+          "key": "59734d15-8edb-41a4-b3f2-f9bd3407460b",
+          "doc_count": 2778
+        },
+        {
+          "key": "d08a71aa-fe87-4bf5-ac68-8e7497bf585c",
+          "doc_count": 2745
+        },
+        {
+          "key": "40d35f62-cf89-488a-bad3-66e66d38c10c",
+          "doc_count": 2733
+        },
+        {
+          "key": "ef30a918-b583-41f1-9ac4-4a37591b515a",
+          "doc_count": 2692
+        },
+        {
+          "key": "cc11b4e3-823d-4490-95b2-afe6a1f3a9d2",
+          "doc_count": 2679
+        },
+        {
+          "key": "7c927849-94ed-4034-90e9-af34ac0cb47c",
+          "doc_count": 2664
+        },
+        {
+          "key": "2eb8ff2f-4826-4fc3-be68-22d805bcae88",
+          "doc_count": 2658
+        },
+        {
+          "key": "33bac15d-b1d0-42a1-8801-86149887eeef",
+          "doc_count": 2639
+        },
+        {
+          "key": "1aa66130-6668-4c4b-8383-a51b8e8389ec",
+          "doc_count": 2506
+        },
+        {
+          "key": "96588aed-3b7a-4179-b92b-2159427f4fcb",
+          "doc_count": 2479
+        },
+        {
+          "key": "5ddcbd44-1802-46b0-bae5-11126409c03d",
+          "doc_count": 2432
+        },
+        {
+          "key": "b5234343-b0f1-472a-9db7-dfa78affd402",
+          "doc_count": 2396
+        },
+        {
+          "key": "7232e59b-b0e1-49cd-9632-b8ae1f49f828",
+          "doc_count": 2390
+        },
+        {
+          "key": "0dabd609-2505-4492-8b7a-3f8301d8d5e1",
+          "doc_count": 2381
+        },
+        {
+          "key": "e38af226-7109-4f99-a6f1-9fd3bec5638d",
+          "doc_count": 2364
+        },
+        {
+          "key": "0072bf11-a354-4998-8730-c0cb4cfc9517",
+          "doc_count": 2351
+        },
+        {
+          "key": "d315c4a3-0bee-49d1-8d03-726358937cde",
+          "doc_count": 2308
+        },
+        {
+          "key": "9354db6c-4019-4351-a822-cb87b1b73a44",
+          "doc_count": 2247
+        },
+        {
+          "key": "e73fedf0-90ee-4c6d-88dd-49399878fc54",
+          "doc_count": 2227
+        },
+        {
+          "key": "3a0d8092-c577-4775-a586-1542574edc53",
+          "doc_count": 2188
+        },
+        {
+          "key": "18c215c3-c02f-47e9-bb66-196c33c8f672",
+          "doc_count": 2056
+        },
+        {
+          "key": "b985f284-eac5-4efe-8a7c-c726cdf7cf33",
+          "doc_count": 2055
+        },
+        {
+          "key": "82541f90-fe8e-4d66-84d8-4fe515dc5533",
+          "doc_count": 2035
+        },
+        {
+          "key": "3ad82604-c4b3-4fd0-b03e-d8f874062146",
+          "doc_count": 2009
+        },
+        {
+          "key": "db4bb0df-8539-4617-ab5f-eb118aa3126b",
+          "doc_count": 2002
+        },
+        {
+          "key": "994b60a2-88f1-49ec-a6da-27d56dfa6f16",
+          "doc_count": 1958
+        },
+        {
+          "key": "fb97dfb4-72be-4dc1-9f5a-2faea75341b4",
+          "doc_count": 1883
+        },
+        {
+          "key": "30ab9c2a-0b54-4c04-84ca-bc7abdd90b52",
+          "doc_count": 1876
+        },
+        {
+          "key": "f9a33279-d6ba-41c7-a511-ef6adfcb6e20",
+          "doc_count": 1831
+        },
+        {
+          "key": "a0ec3ce6-fc8a-48b7-9105-cecf27602e37",
+          "doc_count": 1812
+        },
+        {
+          "key": "5d7869be-8526-43d8-af53-f16a15ebadb5",
+          "doc_count": 1808
+        },
+        {
+          "key": "401fec56-515d-4fa8-87d1-507e742f4f6f",
+          "doc_count": 1802
+        },
+        {
+          "key": "045aa661-f985-4203-80ff-98daafdfe377",
+          "doc_count": 1792
+        },
+        {
+          "key": "09b18522-5643-478f-86e9-d2e34440d43e",
+          "doc_count": 1782
+        },
+        {
+          "key": "8e4ff036-d38e-455f-a0fe-4ac50823f4fb",
+          "doc_count": 1742
+        },
+        {
+          "key": "2e65e24b-b7e2-40a4-a40c-09edafc1e3f4",
+          "doc_count": 1687
+        },
+        {
+          "key": "241d64f1-480a-48ae-8ec2-cd12af4a16e9",
+          "doc_count": 1685
+        },
+        {
+          "key": "7e43ea77-d2e5-4bdc-a4f7-a4792866f53f",
+          "doc_count": 1664
+        },
+        {
+          "key": "ff0d1543-247c-4039-a8ff-cf4fc224c449",
+          "doc_count": 1663
+        },
+        {
+          "key": "0e2f3962-e905-48f2-a1c6-19d16e2bd5ba",
+          "doc_count": 1630
+        },
+        {
+          "key": "7340c0df-8829-4197-9dc7-0328b8e7f5dd",
+          "doc_count": 1590
+        },
+        {
+          "key": "1e86442f-35a5-4e7b-9a38-4599e4d3b510",
+          "doc_count": 1582
+        },
+        {
+          "key": "f3327705-8d69-4d9c-88b7-584a08c74653",
+          "doc_count": 1579
+        },
+        {
+          "key": "e506c5e0-99b6-4e97-b7b4-4536cb80209b",
+          "doc_count": 1536
+        },
+        {
+          "key": "5aac25d2-bcfb-4084-a700-584311ea539d",
+          "doc_count": 1480
+        },
+        {
+          "key": "ba77d411-4179-4dbd-b6c1-39b8a71ae795",
+          "doc_count": 1469
+        },
+        {
+          "key": "2c2cc29c-3572-4568-a129-c8cbec34ccbe",
+          "doc_count": 1445
+        },
+        {
+          "key": "3d2b5be0-7c1d-4693-9226-94bc0061123b",
+          "doc_count": 1417
+        },
+        {
+          "key": "56879e73-bf9d-4bd9-a7a4-4f2f940d0f62",
+          "doc_count": 1408
+        },
+        {
+          "key": "f5c38252-89f1-4753-af3a-da8818fe3a86",
+          "doc_count": 1325
+        },
+        {
+          "key": "99e84c7d-dd3c-40d9-9526-54f4342cda95",
+          "doc_count": 1287
+        },
+        {
+          "key": "feb74628-8724-466f-8c8c-b3d3b72f2417",
+          "doc_count": 1274
+        },
+        {
+          "key": "3bbf3659-4b21-40b7-b74f-f17a60097154",
+          "doc_count": 1267
+        },
+        {
+          "key": "a4b888a2-94bf-4680-b912-84964a236c82",
+          "doc_count": 1209
+        },
+        {
+          "key": "9a861ebe-f8d7-4eb1-a2c8-3006f07cfec2",
+          "doc_count": 1205
+        },
+        {
+          "key": "ea9d9c05-11b3-4514-898e-66bd8560ec5b",
+          "doc_count": 1202
+        },
+        {
+          "key": "0a410c4a-cd4f-4bd8-b6ba-a0c2baa37622",
+          "doc_count": 1185
+        },
+        {
+          "key": "442246b3-6610-45e6-b2bf-c11ee15917b8",
+          "doc_count": 1184
+        },
+        {
+          "key": "1da2a87d-4fc7-4233-b127-59cb8d1ca5ee",
+          "doc_count": 1167
+        },
+        {
+          "key": "50b4c365-5472-4fe8-8825-b1fa0ac57fb3",
+          "doc_count": 1132
+        },
+        {
+          "key": "3ff3bf5c-7aba-40c3-80b2-1b00ea1abdd5",
+          "doc_count": 1123
+        },
+        {
+          "key": "2d853a6d-50ec-4931-8e91-48fc2491fdee",
+          "doc_count": 1122
+        },
+        {
+          "key": "b12b08da-3d05-4406-a051-0139a33ecf35",
+          "doc_count": 1118
+        },
+        {
+          "key": "76015dea-c909-4e6d-a8e1-3bf35763571e",
+          "doc_count": 1100
+        },
+        {
+          "key": "15a1cc29-b66c-4633-ad9c-c2c094b19902",
+          "doc_count": 1090
+        },
+        {
+          "key": "1e6c8187-1521-4501-b205-ac8f513d5e04",
+          "doc_count": 1068
+        },
+        {
+          "key": "4aecf17c-154a-42fb-a3c0-f5e621c791e6",
+          "doc_count": 1054
+        },
+        {
+          "key": "50ca2a08-0e76-4f56-9976-d344dd201a9b",
+          "doc_count": 1053
+        },
+        {
+          "key": "8cd3a748-7f59-40e9-9cf3-3951e1e6430d",
+          "doc_count": 1053
+        },
+        {
+          "key": "bfb53140-79c1-4625-81aa-3f37de7c0c2f",
+          "doc_count": 1026
+        },
+        {
+          "key": "e8a10a16-86af-42b2-be40-9d6a1b21859a",
+          "doc_count": 986
+        },
+        {
+          "key": "af60ac71-fbfb-4648-95fb-0eb5fe24765b",
+          "doc_count": 984
+        },
+        {
+          "key": "93341fe7-38f8-4ef2-8dfc-ae550aa522dc",
+          "doc_count": 976
+        },
+        {
+          "key": "b3976394-a174-4ceb-8d64-3a435d66bde6",
+          "doc_count": 972
+        },
+        {
+          "key": "d601bd5e-4f4c-4637-9196-4bd821dbd2e2",
+          "doc_count": 928
+        },
+        {
+          "key": "f4666aa7-93f0-41f7-83c2-497af7a06887",
+          "doc_count": 885
+        },
+        {
+          "key": "75c7a013-8dab-4f9c-ae6d-3a7cc24b67ce",
+          "doc_count": 882
+        },
+        {
+          "key": "886f3b02-e2f2-4c49-9ace-df25bf5d091a",
+          "doc_count": 856
+        },
+        {
+          "key": "c882214e-8ba4-482b-9998-070b5547dc54",
+          "doc_count": 853
+        },
+        {
+          "key": "4efa66cf-8adb-414b-b78c-8e651d20f84d",
+          "doc_count": 852
+        },
+        {
+          "key": "49db9725-7bdc-4c38-8548-c32994e811c1",
+          "doc_count": 838
+        },
+        {
+          "key": "c3a7b339-122e-4fe9-8851-371b1fdf584e",
+          "doc_count": 803
+        },
+        {
+          "key": "41350373-fc6f-4dd9-b908-27805fff9155",
+          "doc_count": 800
+        },
+        {
+          "key": "f266a75c-3529-4868-8669-9f98822e033f",
+          "doc_count": 795
+        },
+        {
+          "key": "2b89de41-42bd-46c6-ab61-d386f855f7fb",
+          "doc_count": 790
+        },
+        {
+          "key": "b764863c-de93-4d7c-b0cf-1bb57166141d",
+          "doc_count": 765
+        },
+        {
+          "key": "2936c837-ad9f-40d8-bea0-58b2a635c637",
+          "doc_count": 747
+        },
+        {
+          "key": "781b461a-2788-4fa6-b3df-bbed9447f5a3",
+          "doc_count": 741
+        },
+        {
+          "key": "b027383d-6705-4d06-8514-db6ef16efdb5",
+          "doc_count": 736
+        },
+        {
+          "key": "3c919328-94fd-4657-b81d-21f4707253ed",
+          "doc_count": 697
+        },
+        {
+          "key": "0c9378fa-3ccb-4342-be2e-5b5080691dd1",
+          "doc_count": 691
+        },
+        {
+          "key": "c359c2e5-cd20-4057-9179-35a7a5b5da72",
+          "doc_count": 648
+        },
+        {
+          "key": "ad5c4ec7-ed56-4d3e-881a-963af217d334",
+          "doc_count": 627
+        },
+        {
+          "key": "c96ca51c-908e-41cc-ae10-ac1fb72ca3d9",
+          "doc_count": 624
+        },
+        {
+          "key": "fb4cc282-eba5-4156-b7c7-df41e0581b68",
+          "doc_count": 619
+        },
+        {
+          "key": "932e8ecc-fb16-4ce1-9863-e0e586e3ab34",
+          "doc_count": 610
+        },
+        {
+          "key": "6659b6dd-d487-4b72-b0c8-ae65942a6f15",
+          "doc_count": 594
+        },
+        {
+          "key": "4cdf5c2f-1a44-4fd5-bdd8-de08c8a660e2",
+          "doc_count": 566
+        },
+        {
+          "key": "e7bc6545-f14f-4fc4-9902-1aa38040f184",
+          "doc_count": 561
+        },
+        {
+          "key": "aa977d4a-0dd6-4441-87d4-5efb60435a0b",
+          "doc_count": 544
+        },
+        {
+          "key": "539721d9-f5f8-489b-a816-abc28b2748e8",
+          "doc_count": 523
+        },
+        {
+          "key": "abb0a03c-4dcb-4f6f-a31d-55268f63d44c",
+          "doc_count": 515
+        },
+        {
+          "key": "2ee56f8c-db1d-43aa-bfb7-3fb2a19601df",
+          "doc_count": 500
+        },
+        {
+          "key": "1c8ec291-8067-4b48-848b-410c2c768420",
+          "doc_count": 470
+        },
+        {
+          "key": "f4f833ea-0abf-4059-948e-132c64dda1be",
+          "doc_count": 456
+        },
+        {
+          "key": "41e1a09b-bd55-4d20-a480-5d8187f7afca",
+          "doc_count": 450
+        },
+        {
+          "key": "e2a12ef3-cf03-4ce4-8aff-802ccf2aec1d",
+          "doc_count": 440
+        },
+        {
+          "key": "b7a79601-c07b-46d5-bd09-d4472b0d9431",
+          "doc_count": 427
+        },
+        {
+          "key": "f3a5ec1a-49dd-4a52-8bd8-67cacae7a7ac",
+          "doc_count": 426
+        },
+        {
+          "key": "4efa0623-a625-4949-aea4-7cb60a99b6f8",
+          "doc_count": 411
+        },
+        {
+          "key": "47e638be-2983-4d22-b05d-260dd5881e9c",
+          "doc_count": 409
+        },
+        {
+          "key": "8dd13cdf-1425-497d-a4ff-bb5dadfe21a8",
+          "doc_count": 403
+        },
+        {
+          "key": "6aca6f67-a2e9-440d-a503-9501db6e6f36",
+          "doc_count": 397
+        },
+        {
+          "key": "9aa11cc8-6c2d-4202-b30b-c8454338bbd2",
+          "doc_count": 394
+        },
+        {
+          "key": "1ae056ac-8834-43a8-ad44-d1148b6e075f",
+          "doc_count": 358
+        },
+        {
+          "key": "0df55e93-0fce-4ba6-a344-1d9918b60816",
+          "doc_count": 346
+        },
+        {
+          "key": "00df4fe2-0025-45ec-814a-36777155e077",
+          "doc_count": 328
+        },
+        {
+          "key": "f271128e-2e79-430b-81a4-a92ec7c969b8",
+          "doc_count": 326
+        },
+        {
+          "key": "4f5fc75f-f983-4ef8-9723-ba375615d926",
+          "doc_count": 324
+        },
+        {
+          "key": "314f66a9-2b8f-4085-b10c-0f083ce2f1eb",
+          "doc_count": 307
+        },
+        {
+          "key": "d3412433-4df9-4828-89e0-73956898f749",
+          "doc_count": 305
+        },
+        {
+          "key": "07c47dd3-a0a9-434a-b144-71c32996f278",
+          "doc_count": 304
+        },
+        {
+          "key": "3451a762-d117-430e-968c-dd747ed53887",
+          "doc_count": 298
+        },
+        {
+          "key": "85ae9fb4-de87-41ce-abb3-44fda2fb24a8",
+          "doc_count": 292
+        },
+        {
+          "key": "d9d38b3f-5173-4051-98a6-2efad16fc8da",
+          "doc_count": 285
+        },
+        {
+          "key": "a7463c8a-27f0-485e-b794-fb78d94beda7",
+          "doc_count": 277
+        },
+        {
+          "key": "697b5707-b86f-43c5-a114-93a3fc602719",
+          "doc_count": 276
+        },
+        {
+          "key": "fd36e434-8c4d-4d97-a15d-e4d55f312d73",
+          "doc_count": 270
+        },
+        {
+          "key": "e27dc54d-8114-4927-b400-694caab9872e",
+          "doc_count": 261
+        },
+        {
+          "key": "71e55d91-4c0c-4a13-9421-c732348b0a47",
+          "doc_count": 253
+        },
+        {
+          "key": "a5d9992f-ebbb-457c-b56a-b6cd0429e2d6",
+          "doc_count": 245
+        },
+        {
+          "key": "b3d53973-5bac-432a-90d3-7956baa09c5d",
+          "doc_count": 237
+        },
+        {
+          "key": "57b1a2a3-78ab-4e69-a77e-a8fd4394ee5a",
+          "doc_count": 221
+        },
+        {
+          "key": "011880b9-7697-4626-946f-258a68f754cb",
+          "doc_count": 201
+        },
+        {
+          "key": "7fcdca8e-7469-480c-8516-cce4e24c37c9",
+          "doc_count": 193
+        },
+        {
+          "key": "433d3c37-8dde-42e4-a344-2cb6605c5da2",
+          "doc_count": 190
+        },
+        {
+          "key": "03eac319-23c7-429e-9fa4-480640007d62",
+          "doc_count": 184
+        },
+        {
+          "key": "997c4dda-0465-40c0-af8d-67f8f90dea3b",
+          "doc_count": 182
+        },
+        {
+          "key": "e2c129bc-e45b-43d1-ab52-86e52093080b",
+          "doc_count": 175
+        },
+        {
+          "key": "f3d1fbbb-93d5-432e-8808-ebc08c42ef6d",
+          "doc_count": 172
+        },
+        {
+          "key": "9b62118d-9b90-46b1-854d-06a5a9a22a90",
+          "doc_count": 171
+        },
+        {
+          "key": "9764480a-6e4a-4800-9bb7-b6fb73bccc50",
+          "doc_count": 169
+        },
+        {
+          "key": "1d14acd1-20ef-4a55-8206-f04c8a75ea3e",
+          "doc_count": 168
+        },
+        {
+          "key": "b761d317-a36e-4a05-a5f4-bd3e3963daf6",
+          "doc_count": 164
+        },
+        {
+          "key": "4c46db9d-74d7-4e45-9ed2-0da40ec6b44f",
+          "doc_count": 161
+        },
+        {
+          "key": "87fee729-2a4e-4d23-ad8a-5e03e1ab7c1a",
+          "doc_count": 161
+        },
+        {
+          "key": "e6b4d68a-59b5-4b74-a5ce-daadd930d3ca",
+          "doc_count": 159
+        },
+        {
+          "key": "c6e89321-fc23-4cba-ad79-be3e52edfb6d",
+          "doc_count": 144
+        },
+        {
+          "key": "c19c539d-2f8c-4a99-b956-15921ec345ed",
+          "doc_count": 138
+        },
+        {
+          "key": "b3f10d7b-6763-4f79-9789-f6abc68b9720",
+          "doc_count": 137
+        },
+        {
+          "key": "6acaebd6-e8d2-454a-8f50-e7a6734b8c79",
+          "doc_count": 136
+        },
+        {
+          "key": "4bf197cb-6fbc-4b22-82d0-849fffb5906e",
+          "doc_count": 134
+        },
+        {
+          "key": "8a54c5fa-2900-4859-a2d6-1b7faedafac4",
+          "doc_count": 130
+        },
+        {
+          "key": "ec8f29eb-6d25-4a48-841c-49d6217761a4",
+          "doc_count": 129
+        },
+        {
+          "key": "fbac84f2-8db7-4af5-96b1-9d8885370c10",
+          "doc_count": 127
+        },
+        {
+          "key": "f8944362-0f02-4ccb-bbaf-3149b2de8e22",
+          "doc_count": 118
+        },
+        {
+          "key": "21ea1ef6-4a2a-4ff2-a18b-5c0f297fc1cf",
+          "doc_count": 108
+        },
+        {
+          "key": "b3d3a357-9fa6-453c-9f02-d86a1bbc762a",
+          "doc_count": 106
+        },
+        {
+          "key": "95773ebb-2f5f-43f0-a652-bfd8d5f4707a",
+          "doc_count": 105
+        },
+        {
+          "key": "bcbae485-1286-4452-bbc9-bcb38c6c3573",
+          "doc_count": 94
+        },
+        {
+          "key": "974f7564-a7fb-409a-bb67-35b7cafec327",
+          "doc_count": 84
+        },
+        {
+          "key": "94dd2cee-ed7d-4f98-894f-efafeac92b5b",
+          "doc_count": 82
+        },
+        {
+          "key": "4fecde59-9f59-44eb-ab6f-4a50b4ed85cf",
+          "doc_count": 76
+        },
+        {
+          "key": "2e746628-f895-4367-ae31-62e81e0b6b98",
+          "doc_count": 70
+        },
+        {
+          "key": "5302ea7f-1c6f-4fc9-8c20-97dd38c0c783",
+          "doc_count": 48
+        },
+        {
+          "key": "86b1f54d-ac01-4c5e-8ed8-09da2689c7a9",
+          "doc_count": 47
+        },
+        {
+          "key": "17cea35c-721f-4d9b-b67f-d29250064d25",
+          "doc_count": 43
+        },
+        {
+          "key": "473400bf-fe83-4bd6-9f69-c4608f4cdf4f",
+          "doc_count": 41
+        },
+        {
+          "key": "bdaa6842-3055-465e-82f6-da577e987cde",
+          "doc_count": 40
+        },
+        {
+          "key": "9e66257f-21a9-491a-ac23-06b7b62ceeb7",
+          "doc_count": 37
+        },
+        {
+          "key": "513dd822-f211-42c3-9af2-ee3c798cd1b8",
+          "doc_count": 36
+        },
+        {
+          "key": "6f6bf083-d27a-417d-9205-e5a70c2b7a0d",
+          "doc_count": 36
+        },
+        {
+          "key": "3617a6a3-d384-48de-948d-2d1e1c54e090",
+          "doc_count": 29
+        },
+        {
+          "key": "2c00d087-1df6-4744-807d-056be36eed0d",
+          "doc_count": 28
+        },
+        {
+          "key": "adae5c6c-72f3-4cd8-a00b-3ea71d516abc",
+          "doc_count": 27
+        },
+        {
+          "key": "1fc07b28-43f5-49d1-badf-63005e1c3e9a",
+          "doc_count": 26
+        },
+        {
+          "key": "2c84db50-bab1-40a6-a9ef-405f3ffcec7e",
+          "doc_count": 26
+        },
+        {
+          "key": "ab820732-0844-4323-ba14-c58c24f3fc7e",
+          "doc_count": 26
+        },
+        {
+          "key": "fb7db48e-1599-420e-8f10-1f20fe1c6aa3",
+          "doc_count": 24
+        },
+        {
+          "key": "656d1c9a-cbb7-4dde-ac24-62323af5b831",
+          "doc_count": 22
+        },
+        {
+          "key": "7400877a-13b8-423d-9074-5371a8234157",
+          "doc_count": 21
+        },
+        {
+          "key": "76aab8f5-69d4-4ce9-b0c9-837b64a2dd06",
+          "doc_count": 20
+        },
+        {
+          "key": "80daac2f-e496-4c65-b196-6be7a9c4c98e",
+          "doc_count": 20
+        },
+        {
+          "key": "061dfaff-0c45-459e-ac56-738fe4cbe213",
+          "doc_count": 19
+        },
+        {
+          "key": "88271bd3-1985-4fa7-9e33-f82cc24dfad3",
+          "doc_count": 18
+        },
+        {
+          "key": "a8add96d-651c-488e-8ca3-ed3f85c7a117",
+          "doc_count": 18
+        },
+        {
+          "key": "62c35d43-f15c-451d-a8be-1b9c6928b8bd",
+          "doc_count": 17
+        },
+        {
+          "key": "f93c403b-d0f0-4be1-8a4b-ed9aa3b513e3",
+          "doc_count": 17
+        },
+        {
+          "key": "72059315-e131-42ba-b7c6-489415e297b9",
+          "doc_count": 16
+        },
+        {
+          "key": "879d475f-4b76-4d18-8cf6-a7e5a6d44926",
+          "doc_count": 15
+        },
+        {
+          "key": "b1c7a275-21f6-4b66-895d-d497359b34a1",
+          "doc_count": 11
+        },
+        {
+          "key": "e1c7bc41-50a4-4723-b8b3-f970844ffb65",
+          "doc_count": 11
+        },
+        {
+          "key": "8f62e9b0-96e5-4d64-8008-b2b8692050db",
+          "doc_count": 10
+        },
+        {
+          "key": "a8cafd75-ca3b-42c6-8b8e-52aafa15753b",
+          "doc_count": 10
+        },
+        {
+          "key": "0c15e83e-79ee-4ee3-86e3-e5f98a51dc11",
+          "doc_count": 9
+        },
+        {
+          "key": "372d25cd-e4c6-4c58-8d3f-abe16887c805",
+          "doc_count": 9
+        },
+        {
+          "key": "5bd3bf29-b78d-4bf3-bbd7-bbfb4eaf36a1",
+          "doc_count": 9
+        },
+        {
+          "key": "a8d88237-2f62-4ad5-b1f7-ab13ace304df",
+          "doc_count": 9
+        },
+        {
+          "key": "5f681b65-9a7e-4b79-8a17-fc95cc26b837",
+          "doc_count": 6
+        },
+        {
+          "key": "6226705f-4867-464d-9fab-4e81ecee731f",
+          "doc_count": 6
+        },
+        {
+          "key": "73b2abe8-93ea-4343-bc37-35693035dea0",
+          "doc_count": 5
+        },
+        {
+          "key": "84006c59-fead-4b84-b3b5-cedf28f67ea9",
+          "doc_count": 5
+        },
+        {
+          "key": "bf1a26f8-6e89-4b95-b512-16430cccb6df",
+          "doc_count": 4
+        },
+        {
+          "key": "a3b54f92-360f-49a9-ae3b-9f5361549ef9",
+          "doc_count": 3
+        },
+        {
+          "key": "e5f377de-c662-4eec-a4d4-b41b18441f3a",
+          "doc_count": 3
+        },
+        {
+          "key": "3c6099e4-3a0c-44c8-942a-f44860aea12b",
+          "doc_count": 2
+        },
+        {
+          "key": "41800344-33b3-4201-b9d2-cabbbf564fbc",
+          "doc_count": 2
+        },
+        {
+          "key": "48e1b8c1-91aa-4b87-8ca0-de1f81232eaf",
+          "doc_count": 2
+        },
+        {
+          "key": "53feaa83-e3b6-4ad3-8597-293b153e7548",
+          "doc_count": 2
+        },
+        {
+          "key": "a73b61c5-812c-453b-b12b-5c65929e947a",
+          "doc_count": 2
+        },
+        {
+          "key": "abf5b4f3-ed39-4bb9-acd6-9ee50acac0ad",
+          "doc_count": 2
+        },
+        {
+          "key": "c2dcb184-6c90-4aa3-9ebb-33b2d53837b9",
+          "doc_count": 2
+        },
+        {
+          "key": "c7883ffb-d381-4748-9694-e5abdaa46dbc",
+          "doc_count": 2
+        },
+        {
+          "key": "d07e7b8a-2222-477f-a7f3-f098bbfdaf54",
+          "doc_count": 2
+        },
+        {
+          "key": "de67ccab-7d04-43b9-8083-81e45f628505",
+          "doc_count": 2
+        },
+        {
+          "key": "0395f3c4-0277-43b6-a36d-e07720588790",
+          "doc_count": 1
+        },
+        {
+          "key": "0da18fe6-2e2a-43fc-9d2a-ffb2cefc05c0",
+          "doc_count": 1
+        },
+        {
+          "key": "53064db5-a272-46f9-85d2-d1b78e9a3293",
+          "doc_count": 1
+        },
+        {
+          "key": "54ae6783-dbb5-403a-b0e6-11a3b07d491a",
+          "doc_count": 1
+        },
+        {
+          "key": "8a9e3b42-e6e8-4485-b304-3cbf6d709a6c",
+          "doc_count": 1
+        },
+        {
+          "key": "a9bb4417-af3e-46e7-a2e0-167d61b49d10",
+          "doc_count": 1
+        }
+      ]
+    },
+    "max_dm": {
+      "value": 1674657431736,
+      "value_as_string": "2023-01-25T14:37:11.736Z"
+    }
+  }
+}

--- a/__tests__/mock/search-a3089e2b8e67ae11ee601b781e9cc17f.json
+++ b/__tests__/mock/search-a3089e2b8e67ae11ee601b781e9cc17f.json
@@ -1,0 +1,3694 @@
+{
+  "timed_out": false,
+  "_shards": {
+    "total": 48,
+    "successful": 48,
+    "failed": 0
+  },
+  "hits": {
+    "total": 50776115,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "000992e7-6519-4fae-ab02-d990234e3752",
+        "_score": null,
+        "_routing": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_parent": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=78088&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "003b2287-1f6c-4897-bd59-2e58f6022739",
+        "_score": null,
+        "_routing": "4bd36c58-e935-4c2b-82f5-21a83b359557",
+        "_parent": "4bd36c58-e935-4c2b-82f5-21a83b359557",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=103926&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "007977cb-7a8d-49bd-8450-45800bec15af",
+        "_score": null,
+        "_routing": "599f5853-b35c-43eb-90d3-5143ebbf9d21",
+        "_parent": "599f5853-b35c-43eb-90d3-5143ebbf9d21",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=134681&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0089b314-b365-4244-9f93-8cec2f29be98",
+        "_score": null,
+        "_routing": "9a059a20-1927-4ea0-be70-7b7c5d3a430d",
+        "_parent": "9a059a20-1927-4ea0-be70-7b7c5d3a430d",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=111648&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00b06c30-4949-415b-9a5f-342fe99abca2",
+        "_score": null,
+        "_routing": "95d7ee27-3a69-4f29-b7f9-4e0c6123264a",
+        "_parent": "95d7ee27-3a69-4f29-b7f9-4e0c6123264a",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=99828&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00bda874-9f9d-48d4-b582-c5bcac4a08b5",
+        "_score": null,
+        "_routing": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_parent": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=78097&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00c7c963-860b-4b70-a55e-571bfef030fd",
+        "_score": null,
+        "_routing": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_parent": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=100377&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00edde43-e608-4e84-862c-f9cb9af9b21a",
+        "_score": null,
+        "_routing": "7c5f4753-8a79-42df-b87f-5501f1f1676b",
+        "_parent": "7c5f4753-8a79-42df-b87f-5501f1f1676b",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=661111&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00f8d929-db1c-4478-bef2-ef0babf1d576",
+        "_score": null,
+        "_routing": "53d4865e-8083-4884-8393-08277937e408",
+        "_parent": "53d4865e-8083-4884-8393-08277937e408",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=742849&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0119c9f7-8706-4114-8a26-6d25ccf3964b",
+        "_score": null,
+        "_routing": "3a00b94a-ab08-411b-b781-0df20f0a9379",
+        "_parent": "3a00b94a-ab08-411b-b781-0df20f0a9379",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=755859&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "011a1397-b055-4090-b6fd-9bd644eb02bf",
+        "_score": null,
+        "_routing": "9a059a20-1927-4ea0-be70-7b7c5d3a430d",
+        "_parent": "9a059a20-1927-4ea0-be70-7b7c5d3a430d",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=111650&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "014d1271-6165-44d0-b4f0-f493358c0acb",
+        "_score": null,
+        "_routing": "dab39256-4cb9-4c5e-b3fd-db398fa8848b",
+        "_parent": "dab39256-4cb9-4c5e-b3fd-db398fa8848b",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=656896&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0151eb78-720f-4af2-b2c0-395a1000b7d1",
+        "_score": null,
+        "_routing": "1ed2b128-b2f6-4784-984b-69ec5aae9c24",
+        "_parent": "1ed2b128-b2f6-4784-984b-69ec5aae9c24",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=730672&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "019841c5-ec17-4a80-b92d-eeb0680682aa",
+        "_score": null,
+        "_routing": "888f773c-2655-4806-abdd-370f12716543",
+        "_parent": "888f773c-2655-4806-abdd-370f12716543",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=736111&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "01a34b4c-74fd-4a33-8bbf-79d3a25622f8",
+        "_score": null,
+        "_routing": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_parent": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=100337&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "01c35b3c-f014-4344-abf4-9cc03511ec5e",
+        "_score": null,
+        "_routing": "2ab6d7a9-4730-43f4-96ea-b7e943fe9640",
+        "_parent": "2ab6d7a9-4730-43f4-96ea-b7e943fe9640",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=750870&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "01cf1085-c956-4597-a958-5adf29298ebf",
+        "_score": null,
+        "_routing": "95d7ee27-3a69-4f29-b7f9-4e0c6123264a",
+        "_parent": "95d7ee27-3a69-4f29-b7f9-4e0c6123264a",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=99816&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "01f4f3e3-632f-41bb-acbd-db138d35e03b",
+        "_score": null,
+        "_routing": "eb4640cf-4771-4dfe-89db-36372badd257",
+        "_parent": "eb4640cf-4771-4dfe-89db-36372badd257",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=66899&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "02104779-3467-4775-8540-fad66ae1eabd",
+        "_score": null,
+        "_routing": "9d0077e2-574d-461c-8b67-d6e01221e81b",
+        "_parent": "9d0077e2-574d-461c-8b67-d6e01221e81b",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=717895&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0251dfab-5668-4e01-bc77-88703b3dee95",
+        "_score": null,
+        "_routing": "fb6942c0-4577-4009-8c90-460b8d6650cc",
+        "_parent": "fb6942c0-4577-4009-8c90-460b8d6650cc",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=101902&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "02546cb5-5284-497f-9aaa-66917f309fcf",
+        "_score": null,
+        "_routing": "836320a3-b003-490d-8712-3ca2375f8f21",
+        "_parent": "836320a3-b003-490d-8712-3ca2375f8f21",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=770730&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "02607712-5923-4eff-91db-512db1fe6a84",
+        "_score": null,
+        "_routing": "460a8a37-121d-434d-ab97-1a79b30dafa8",
+        "_parent": "460a8a37-121d-434d-ab97-1a79b30dafa8",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=561071&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0284bdfc-ec3b-4248-8b2d-99d348b81f1a",
+        "_score": null,
+        "_routing": "421db2c2-f39f-44e2-bb03-316efa33f66c",
+        "_parent": "421db2c2-f39f-44e2-bb03-316efa33f66c",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=801121&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "028e3db3-a575-4261-a8b4-78c963300ac0",
+        "_score": null,
+        "_routing": "c4bbcb7a-5942-4148-98cf-4d802476b082",
+        "_parent": "c4bbcb7a-5942-4148-98cf-4d802476b082",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=721279&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "028e4c83-dbb0-4e17-b2e0-9b7788fe6d50",
+        "_score": null,
+        "_routing": "edcc76a9-ccd0-477b-97e3-3ef3b5156e06",
+        "_parent": "edcc76a9-ccd0-477b-97e3-3ef3b5156e06",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=780186&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "028f8982-e28d-4f38-af58-6211f4ea8316",
+        "_score": null,
+        "_routing": "a3a90786-7774-4654-819b-79c991a5b485",
+        "_parent": "a3a90786-7774-4654-819b-79c991a5b485",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=735661&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "02985101-ec9a-433e-823a-8258b04193cf",
+        "_score": null,
+        "_routing": "14f651aa-2ed6-4d4d-9566-39a5edc5b4e9",
+        "_parent": "14f651aa-2ed6-4d4d-9566-39a5edc5b4e9",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=750069&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "02fbb412-8f3e-40e2-afa2-c3a340c10cd8",
+        "_score": null,
+        "_routing": "58a5591f-5979-4023-abf9-b1fd8211e76b",
+        "_parent": "58a5591f-5979-4023-abf9-b1fd8211e76b",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=369127&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "03301337-9f1e-430b-af3a-f322cdc1ac8d",
+        "_score": null,
+        "_routing": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_parent": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=100386&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "03510df7-b380-46b1-8709-314d676550eb",
+        "_score": null,
+        "_routing": "83255e81-1685-4a79-840b-0ef82235ab8c",
+        "_parent": "83255e81-1685-4a79-840b-0ef82235ab8c",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=79838&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "036dfeb3-b1fc-4253-9350-4596a3663d5f",
+        "_score": null,
+        "_routing": "be5a87f5-76b0-41d8-8ce5-8c626b1e28ea",
+        "_parent": "be5a87f5-76b0-41d8-8ce5-8c626b1e28ea",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=727360&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "038054f3-e87a-4e66-8501-bb4daf29ac90",
+        "_score": null,
+        "_routing": "e02cd9f0-ac0a-4a0a-9bf0-f97237e48397",
+        "_parent": "e02cd9f0-ac0a-4a0a-9bf0-f97237e48397",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=463859&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "03a3fbfe-1cbb-49f4-b4ce-c4560dc0a172",
+        "_score": null,
+        "_routing": "cc3ca348-444f-4787-8043-7dda29898b55",
+        "_parent": "cc3ca348-444f-4787-8043-7dda29898b55",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=762144&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "03ad0e7a-2511-497f-88dd-1fde388b25a5",
+        "_score": null,
+        "_routing": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_parent": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=100382&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "03d39c02-9c79-4171-8d75-913246f746c1",
+        "_score": null,
+        "_routing": "fb6942c0-4577-4009-8c90-460b8d6650cc",
+        "_parent": "fb6942c0-4577-4009-8c90-460b8d6650cc",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=101892&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "03f0ffe5-caf3-4e6a-b68a-0f908ccd3097",
+        "_score": null,
+        "_routing": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_parent": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=78116&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0465e85c-4917-4f2e-977f-12b34ce5a129",
+        "_score": null,
+        "_routing": "7b3187a7-ce18-4bbb-973f-8a75c182e277",
+        "_parent": "7b3187a7-ce18-4bbb-973f-8a75c182e277",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=770682&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "04f2d4b4-9ce1-4ed9-8ccd-a4a9dae8f171",
+        "_score": null,
+        "_routing": "12035a01-47eb-4e72-b3f3-ed6fc465eea0",
+        "_parent": "12035a01-47eb-4e72-b3f3-ed6fc465eea0",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=773058&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "050f03d4-c0aa-45e0-9dda-5b916cd2f7f6",
+        "_score": null,
+        "_routing": "4bd36c58-e935-4c2b-82f5-21a83b359557",
+        "_parent": "4bd36c58-e935-4c2b-82f5-21a83b359557",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=103929&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0534d962-8909-4157-a991-b439cad77e86",
+        "_score": null,
+        "_routing": "a5b19037-3b2f-4e02-bbc3-f31b17ddcd2b",
+        "_parent": "a5b19037-3b2f-4e02-bbc3-f31b17ddcd2b",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=780102&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "053c36a3-edd7-49a5-bcfc-8df1f8911a1c",
+        "_score": null,
+        "_routing": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_parent": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=100376&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0566dc2a-e1b0-408f-ab15-8eaca19addef",
+        "_score": null,
+        "_routing": "1a2ae543-db57-4d52-91e7-7879917cbf85",
+        "_parent": "1a2ae543-db57-4d52-91e7-7879917cbf85",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=110386&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "056e8574-f500-4612-8f36-d88c3c30cfe7",
+        "_score": null,
+        "_routing": "5ea146c5-318e-4854-bc3e-c214d22b9dc4",
+        "_parent": "5ea146c5-318e-4854-bc3e-c214d22b9dc4",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=668410&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "057683ab-1d35-4784-ab59-63edcfdef852",
+        "_score": null,
+        "_routing": "dbfd579d-4170-42ae-ab17-a1f850b07dd1",
+        "_parent": "dbfd579d-4170-42ae-ab17-a1f850b07dd1",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=711258&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "05f2a0a7-ec10-4ce1-a1fa-78eddb7273c3",
+        "_score": null,
+        "_routing": "d0dbaa27-0eb1-4173-b4fd-a5d047d0c62c",
+        "_parent": "d0dbaa27-0eb1-4173-b4fd-a5d047d0c62c",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=668911&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "079635a6-4d3b-4973-8044-11c40f499ddd",
+        "_score": null,
+        "_routing": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_parent": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=100341&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "07b24646-1ef8-4d40-98f9-b1e0eb595335",
+        "_score": null,
+        "_routing": "e90ff1f8-f7c2-464b-b680-ccf3b0f2f032",
+        "_parent": "e90ff1f8-f7c2-464b-b680-ccf3b0f2f032",
+        "_source": {
+          "data": {
+            "ac:accessURI": "http://www.morphbank.net?id=743527&imgType=jpeg"
+          }
+        },
+        "sort": [
+          0.90909094
+        ]
+      }
+    ]
+  },
+  "aggregations": {
+    "rs": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+          "doc_count": 5576909
+        },
+        {
+          "key": "a6eee223-cf3b-4079-8bb2-b77dad8cae9d",
+          "doc_count": 5135183
+        },
+        {
+          "key": "fabcdc12-9d29-4bd2-912b-176e71818144",
+          "doc_count": 4596608
+        },
+        {
+          "key": "3c9420c9-c4a8-47dc-88b7-b5638ca5e716",
+          "doc_count": 3801254
+        },
+        {
+          "key": "36d35b23-113e-4633-90ec-19d265a3b5f6",
+          "doc_count": 3537264
+        },
+        {
+          "key": "7450a9e3-ef95-4f9e-8260-09b498d2c5e6",
+          "doc_count": 1372219
+        },
+        {
+          "key": "5386d272-06c6-4027-b5d5-d588c2afe5e5",
+          "doc_count": 928757
+        },
+        {
+          "key": "e6ccc2bd-9451-4802-8a51-8640d9f09793",
+          "doc_count": 819632
+        },
+        {
+          "key": "0583609b-202f-40d0-8021-4c019635d4c9",
+          "doc_count": 707693
+        },
+        {
+          "key": "953b0329-c3e4-4816-a038-7afbd2bb2547",
+          "doc_count": 698464
+        },
+        {
+          "key": "710a8a54-783c-41aa-ad9a-05544cdb4c55",
+          "doc_count": 609014
+        },
+        {
+          "key": "205fa34c-2fcb-4492-b992-972b18560f6f",
+          "doc_count": 608981
+        },
+        {
+          "key": "65536dcd-7bb2-44e5-af3f-4a13f08e53d0",
+          "doc_count": 543365
+        },
+        {
+          "key": "285a4be0-5cfe-4d4f-9c8b-b0f0f3571079",
+          "doc_count": 489273
+        },
+        {
+          "key": "271a9ce9-c6d3-4b63-a722-cb0adc48863f",
+          "doc_count": 468247
+        },
+        {
+          "key": "b6ec6203-09db-4d6e-8cba-ee4bebd2934c",
+          "doc_count": 417978
+        },
+        {
+          "key": "4e3043a6-d48a-4a35-b5fb-f67d50cbc158",
+          "doc_count": 408346
+        },
+        {
+          "key": "e60301d9-9b40-483f-92de-065769b9d3dd",
+          "doc_count": 380640
+        },
+        {
+          "key": "a4e6033a-d1eb-46d3-869d-7c0328f09aa7",
+          "doc_count": 343844
+        },
+        {
+          "key": "9e5aede6-bee5-4a3d-a255-513771b20035",
+          "doc_count": 316956
+        },
+        {
+          "key": "4523e216-ee13-4b15-a3f7-a6fd56431604",
+          "doc_count": 306235
+        },
+        {
+          "key": "137ed4cd-5172-45a5-acdb-8e1de9a64e32",
+          "doc_count": 299965
+        },
+        {
+          "key": "2d7910d9-7f63-4bde-918a-9e0265f1c245",
+          "doc_count": 294161
+        },
+        {
+          "key": "9151bc4c-8505-4b22-a16b-9dbf337535fa",
+          "doc_count": 294161
+        },
+        {
+          "key": "53091d18-f173-4fc0-b9d9-20a1494e2466",
+          "doc_count": 291399
+        },
+        {
+          "key": "beab5209-9628-4d4d-851e-2bc9bb1a0105",
+          "doc_count": 276792
+        },
+        {
+          "key": "3027c437-cdb3-4072-9410-5a46ec3b1fd5",
+          "doc_count": 275401
+        },
+        {
+          "key": "a2b36fdf-50bc-44ef-a6a4-ca6dc1dc148a",
+          "doc_count": 253201
+        },
+        {
+          "key": "72d4c3c7-3413-4588-a803-e1a63e0d7c6c",
+          "doc_count": 252250
+        },
+        {
+          "key": "ded380b5-1ba2-4089-8e0c-0aa1b4140785",
+          "doc_count": 245491
+        },
+        {
+          "key": "d53132e6-7997-4850-8607-4fec5a3f9c3f",
+          "doc_count": 241932
+        },
+        {
+          "key": "207b6c64-7b58-4d6a-816d-bc759c27eafc",
+          "doc_count": 241497
+        },
+        {
+          "key": "f1cf8457-237e-487a-9d13-5de7d81b9de4",
+          "doc_count": 238178
+        },
+        {
+          "key": "da67ebd9-52de-444d-b114-e23c03111ac6",
+          "doc_count": 220286
+        },
+        {
+          "key": "e2def7e2-1455-4856-9823-6d3738417d24",
+          "doc_count": 214256
+        },
+        {
+          "key": "f062cb7d-c03e-4762-b1c4-49118fee1a56",
+          "doc_count": 195002
+        },
+        {
+          "key": "db6c3db9-1e6d-4def-af29-33aa0339bfa9",
+          "doc_count": 192851
+        },
+        {
+          "key": "70abba3e-5f2a-4276-87f3-261706e24453",
+          "doc_count": 192778
+        },
+        {
+          "key": "40250f4d-7aa6-4fcc-ac38-2868fa4846bd",
+          "doc_count": 187242
+        },
+        {
+          "key": "e881a3e2-f7ba-43c8-ae9a-11fcbfd741bb",
+          "doc_count": 185371
+        },
+        {
+          "key": "0fd6e726-6828-4f62-ba8d-6ec316fe0b52",
+          "doc_count": 180782
+        },
+        {
+          "key": "01017cef-5065-48b2-9db8-3e428971d702",
+          "doc_count": 172853
+        },
+        {
+          "key": "58402fe3-37c1-4d15-9e07-0ff1c4c9fb11",
+          "doc_count": 171183
+        },
+        {
+          "key": "703b5bdc-4581-47e3-b4b6-e6f32d0eec54",
+          "doc_count": 170392
+        },
+        {
+          "key": "d4ea4495-c4b2-4d05-b524-163423f17cd7",
+          "doc_count": 168645
+        },
+        {
+          "key": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "doc_count": 166689
+        },
+        {
+          "key": "6c6f34ed-58a4-4ba2-b9c7-34524f79a349",
+          "doc_count": 163095
+        },
+        {
+          "key": "0dab1fc7-ca99-456b-9985-76edbac003e0",
+          "doc_count": 161405
+        },
+        {
+          "key": "59efaf7d-60b5-4295-abb3-27ba42eb5231",
+          "doc_count": 157291
+        },
+        {
+          "key": "1527b668-b797-42be-94d3-0058e1393e94",
+          "doc_count": 147919
+        },
+        {
+          "key": "8057906f-17c9-4e25-b173-4e7fb938078b",
+          "doc_count": 141503
+        },
+        {
+          "key": "48b4b812-c52e-4f47-9327-e761f6fc2e28",
+          "doc_count": 138133
+        },
+        {
+          "key": "6258d160-a7aa-4937-bce3-3538eebd374f",
+          "doc_count": 137717
+        },
+        {
+          "key": "cdb6ec43-935e-4da2-8798-71e40ca6d12a",
+          "doc_count": 134508
+        },
+        {
+          "key": "2c00c297-9ebd-498a-b701-d3ebde4b49f3",
+          "doc_count": 133295
+        },
+        {
+          "key": "96662fa9-ff60-495b-912a-284f3b98ed72",
+          "doc_count": 126289
+        },
+        {
+          "key": "cf42855e-a54a-4488-a79e-beac086ba1d4",
+          "doc_count": 123875
+        },
+        {
+          "key": "df22987f-d20d-41db-b8eb-8b5f5fca6df0",
+          "doc_count": 121441
+        },
+        {
+          "key": "beecd160-a96c-46fc-bdce-7dcb7024d473",
+          "doc_count": 120720
+        },
+        {
+          "key": "b531ea59-025d-4c29-9d23-99ae75bcd55f",
+          "doc_count": 118459
+        },
+        {
+          "key": "d2217bca-3a93-4407-bb56-087afa000cbc",
+          "doc_count": 107269
+        },
+        {
+          "key": "aca26f37-3ec8-4e9e-b927-50b4944a0096",
+          "doc_count": 102740
+        },
+        {
+          "key": "ba042ffa-8175-4a47-8eb1-08b4d6319ccf",
+          "doc_count": 102728
+        },
+        {
+          "key": "35c43eda-1f4a-4713-bb69-e3fbe1bf792f",
+          "doc_count": 102464
+        },
+        {
+          "key": "31c140bc-e6f1-4acc-beaf-b825cf288ad9",
+          "doc_count": 100206
+        },
+        {
+          "key": "215eeaf0-0a88-409e-a75d-aec98b7c41eb",
+          "doc_count": 100041
+        },
+        {
+          "key": "6cc31636-c3e5-4887-bbee-2e56621771c4",
+          "doc_count": 96684
+        },
+        {
+          "key": "f84d528a-7d08-467e-b532-ace707316f1d",
+          "doc_count": 95826
+        },
+        {
+          "key": "71bf994a-3af5-484d-983b-b146aa1512d1",
+          "doc_count": 93283
+        },
+        {
+          "key": "0bc60df1-a162-4173-9a73-c51e09031843",
+          "doc_count": 92054
+        },
+        {
+          "key": "ccd17772-d220-4088-8fa3-df3729f14df4",
+          "doc_count": 91822
+        },
+        {
+          "key": "995cc7f1-69c3-4317-ab77-28fd48f1e535",
+          "doc_count": 91120
+        },
+        {
+          "key": "02fceae6-c71c-4db9-8b2f-e235ced6624a",
+          "doc_count": 90591
+        },
+        {
+          "key": "f00b6a32-5337-406b-a850-17f5d78470ad",
+          "doc_count": 90018
+        },
+        {
+          "key": "61a1c0ce-8327-4e2a-9766-449751a49b7a",
+          "doc_count": 89789
+        },
+        {
+          "key": "781fd581-7b93-471e-a025-413e4bcd8491",
+          "doc_count": 89195
+        },
+        {
+          "key": "c481fbc6-4bd7-4c50-8537-ba1993d4eb88",
+          "doc_count": 87485
+        },
+        {
+          "key": "d78d13a7-3852-4244-ba34-86ef5765fa99",
+          "doc_count": 86774
+        },
+        {
+          "key": "26f7cbde-fbcb-4500-80a9-a99daa0ead9d",
+          "doc_count": 85734
+        },
+        {
+          "key": "7644703a-ce24-4f7b-b800-66ddf8812f86",
+          "doc_count": 85277
+        },
+        {
+          "key": "46c11153-2154-495d-89d2-7cdef6425cdb",
+          "doc_count": 85172
+        },
+        {
+          "key": "ee9d38ef-c1db-44de-b8f2-62acb7049370",
+          "doc_count": 82837
+        },
+        {
+          "key": "8b0c1f4b-9de7-4521-98c2-983e0bfd33c7",
+          "doc_count": 81586
+        },
+        {
+          "key": "c569e530-7322-40b8-9b66-1e0ed96fefcb",
+          "doc_count": 81456
+        },
+        {
+          "key": "cf641fbf-fa31-481a-993b-9204f2ee1884",
+          "doc_count": 80738
+        },
+        {
+          "key": "b667cef4-96fe-42e8-a9fa-6298aa80bb14",
+          "doc_count": 80713
+        },
+        {
+          "key": "83ad8494-136b-485a-87d4-8ce01dd6a8de",
+          "doc_count": 79509
+        },
+        {
+          "key": "b9ab58cf-785e-44a7-a873-1966e14a6715",
+          "doc_count": 79181
+        },
+        {
+          "key": "d7540872-1c53-48ac-a617-2d0739eadcbd",
+          "doc_count": 79113
+        },
+        {
+          "key": "ddef79ec-043c-4027-9876-c4a298feff6d",
+          "doc_count": 78656
+        },
+        {
+          "key": "b2b294ed-1742-4479-b0c8-a8891fccd7eb",
+          "doc_count": 77886
+        },
+        {
+          "key": "5e29dbcc-ce45-4f05-9bb0-212baffa8932",
+          "doc_count": 77700
+        },
+        {
+          "key": "264c48ec-8636-451f-a7e0-74131bc6f84c",
+          "doc_count": 77595
+        },
+        {
+          "key": "ba54ba45-caac-4708-a389-ac94642976f8",
+          "doc_count": 77466
+        },
+        {
+          "key": "20360fae-574a-4d63-b9f6-47b1cc07fd22",
+          "doc_count": 76898
+        },
+        {
+          "key": "ff89320d-e232-4edd-9cdd-4b6acc672ad3",
+          "doc_count": 76125
+        },
+        {
+          "key": "ec6cef7d-d8aa-43b4-b352-908f172a378e",
+          "doc_count": 75488
+        },
+        {
+          "key": "5835f642-2560-4e3e-9c25-741a12cc3fe8",
+          "doc_count": 75384
+        },
+        {
+          "key": "8dc14464-57b3-423e-8cb0-950ab8f36b6f",
+          "doc_count": 74455
+        },
+        {
+          "key": "7c1a1d78-aeaa-4501-87e1-83eceb8ca8ea",
+          "doc_count": 74122
+        },
+        {
+          "key": "dd232f5c-7f53-48ec-9bb7-7205702c3dc8",
+          "doc_count": 72999
+        },
+        {
+          "key": "844875a9-9927-48a5-90b4-76c5f227f145",
+          "doc_count": 70991
+        },
+        {
+          "key": "e5f57bb0-07ec-4405-90b6-dc89647a1cb5",
+          "doc_count": 70947
+        },
+        {
+          "key": "5a660a44-afdd-45ac-8c48-1a6c570ce0b5",
+          "doc_count": 70928
+        },
+        {
+          "key": "026a4216-957a-4efb-acf1-506499ec474e",
+          "doc_count": 70918
+        },
+        {
+          "key": "76fd34da-4892-4821-858d-98fe9e28ba8b",
+          "doc_count": 68987
+        },
+        {
+          "key": "e48bb88f-9594-461e-8230-522a3a5572fe",
+          "doc_count": 68353
+        },
+        {
+          "key": "4830ffb8-669a-4717-bec8-2f2374f52120",
+          "doc_count": 68346
+        },
+        {
+          "key": "1bb33d2d-0714-4fc9-968e-b66bab1cf3d3",
+          "doc_count": 66199
+        },
+        {
+          "key": "7809d96b-7edf-4ef7-9f12-59967e9a01a6",
+          "doc_count": 65733
+        },
+        {
+          "key": "767c78b4-1c16-4cac-ad04-66333ac5a7f2",
+          "doc_count": 65505
+        },
+        {
+          "key": "8ec76c75-a673-4682-bfde-00a18bc12794",
+          "doc_count": 65365
+        },
+        {
+          "key": "d82fa49b-915e-4aa8-acc6-51df3d431884",
+          "doc_count": 64222
+        },
+        {
+          "key": "5ab348ab-439a-4697-925c-d6abe0c09b92",
+          "doc_count": 63025
+        },
+        {
+          "key": "b26fa674-6300-4ea0-a8e3-fc0ce32b5226",
+          "doc_count": 62139
+        },
+        {
+          "key": "fc7b78d7-82d4-4648-8185-87a0ba209c20",
+          "doc_count": 60909
+        },
+        {
+          "key": "9ef17d55-0498-44cf-9da4-dde3e3acb570",
+          "doc_count": 60669
+        },
+        {
+          "key": "ea12da76-1b2e-4944-8709-1de3af1c65e2",
+          "doc_count": 58835
+        },
+        {
+          "key": "e5b0c46a-5eb6-4b94-9d4c-fb1000f534b0",
+          "doc_count": 58665
+        },
+        {
+          "key": "09a3fcf2-55a1-488f-aa42-f103bdce0536",
+          "doc_count": 58250
+        },
+        {
+          "key": "5626f61a-822e-4692-b432-51f53d053e4d",
+          "doc_count": 58071
+        },
+        {
+          "key": "e1b03497-7632-4ba4-a9e0-dd230d06638c",
+          "doc_count": 56827
+        },
+        {
+          "key": "ec4acc26-ff1b-4131-a1df-a950fe31bb0e",
+          "doc_count": 56622
+        },
+        {
+          "key": "cb33cf97-2a7b-4b45-9b73-5aca568332a6",
+          "doc_count": 55502
+        },
+        {
+          "key": "f0174bc9-0cca-450e-a941-655d80040139",
+          "doc_count": 54865
+        },
+        {
+          "key": "8f3b62fb-56ec-49e8-9f8f-bb257348291f",
+          "doc_count": 54453
+        },
+        {
+          "key": "9ff03c57-ba5a-4127-9439-4bf3e838c4df",
+          "doc_count": 54392
+        },
+        {
+          "key": "471835cc-feb6-4d05-a8d1-62ce71399326",
+          "doc_count": 54131
+        },
+        {
+          "key": "9b725e43-93c9-423b-adf8-a11d08a83d13",
+          "doc_count": 53487
+        },
+        {
+          "key": "1f2b44b8-8556-4d6e-8247-4611689551cf",
+          "doc_count": 53268
+        },
+        {
+          "key": "1701a75c-5a57-48c3-84c2-234a53f4c3e2",
+          "doc_count": 52027
+        },
+        {
+          "key": "b88033dd-5dbb-4377-b374-2210f32ece16",
+          "doc_count": 50850
+        },
+        {
+          "key": "fdf7bb59-aad2-4f10-879f-6c0e7d3baa64",
+          "doc_count": 50838
+        },
+        {
+          "key": "e36691ec-c4f8-4bec-b331-b48ffa82ff49",
+          "doc_count": 50713
+        },
+        {
+          "key": "62254613-2696-4834-8c58-5c465f70df56",
+          "doc_count": 50672
+        },
+        {
+          "key": "72b6dbee-bc4d-4e35-a32c-8df0422771fb",
+          "doc_count": 50672
+        },
+        {
+          "key": "005ac06a-3d9a-46ad-ac3c-062aaa5b7059",
+          "doc_count": 50655
+        },
+        {
+          "key": "667a12e7-c6d8-4de0-933f-ce2f07cb7a92",
+          "doc_count": 50445
+        },
+        {
+          "key": "14f8f83f-7a0c-458c-b6d5-6da7dc8eaa0a",
+          "doc_count": 49996
+        },
+        {
+          "key": "b5f4526b-f4fb-4d90-8ce0-975e0cda8ff6",
+          "doc_count": 49612
+        },
+        {
+          "key": "910eadc8-8131-428c-b28a-91d0e2890f1d",
+          "doc_count": 49530
+        },
+        {
+          "key": "40987883-03cf-494a-a5cf-7c77c7aadb79",
+          "doc_count": 49396
+        },
+        {
+          "key": "2ec3b31e-c86b-4ce9-b265-77c8c3f9643c",
+          "doc_count": 49335
+        },
+        {
+          "key": "3998ec8d-4aae-46db-9370-179c19b69356",
+          "doc_count": 48835
+        },
+        {
+          "key": "15aa4812-aad2-4b26-a1d8-d4f8d79e6163",
+          "doc_count": 48468
+        },
+        {
+          "key": "b688c17c-3761-4ccd-a42f-88219f5fcff4",
+          "doc_count": 48321
+        },
+        {
+          "key": "e34cf41b-196c-4199-85d5-4d2ca5954b09",
+          "doc_count": 48249
+        },
+        {
+          "key": "ef77ec72-6537-41ab-a418-17f9a58e6e73",
+          "doc_count": 48030
+        },
+        {
+          "key": "e6eba8cd-fa2c-4ba2-bec0-6841e7633695",
+          "doc_count": 47925
+        },
+        {
+          "key": "f31a5f98-efd3-476a-9627-de3add582acd",
+          "doc_count": 47407
+        },
+        {
+          "key": "a16dc8d8-ff4a-4d62-a684-2937fb292b8d",
+          "doc_count": 46459
+        },
+        {
+          "key": "645bcd10-a74f-4207-a375-0254b954b7ad",
+          "doc_count": 45833
+        },
+        {
+          "key": "7f497d81-4c7e-4e06-b166-a459968b14e3",
+          "doc_count": 45585
+        },
+        {
+          "key": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "doc_count": 45123
+        },
+        {
+          "key": "7a31ab80-1cc0-4456-9dea-61c2e9031a6f",
+          "doc_count": 45032
+        },
+        {
+          "key": "120d557c-c5be-474d-98f0-1ba00ae16b40",
+          "doc_count": 43931
+        },
+        {
+          "key": "be31dfd1-c721-4697-8ee0-f7043c070810",
+          "doc_count": 43179
+        },
+        {
+          "key": "2cf2843f-567c-45c1-a328-cc210af76fc1",
+          "doc_count": 42486
+        },
+        {
+          "key": "e794b292-4a94-471e-ab84-6aaef1fea1b3",
+          "doc_count": 41979
+        },
+        {
+          "key": "a69decc7-76ba-496a-a66e-f91049c02cf0",
+          "doc_count": 40857
+        },
+        {
+          "key": "e7ac8c4a-64bd-491b-b764-232de9b4bfe5",
+          "doc_count": 40732
+        },
+        {
+          "key": "8f689b8b-5b65-4638-9555-f2a5d237a624",
+          "doc_count": 40574
+        },
+        {
+          "key": "d0d1c390-e662-4980-97e3-ae0039a06de8",
+          "doc_count": 40469
+        },
+        {
+          "key": "6b5e29d3-b462-44d8-ba38-d68af5088067",
+          "doc_count": 40079
+        },
+        {
+          "key": "46374ee7-7c70-48d8-bf16-2e6c1626565e",
+          "doc_count": 39597
+        },
+        {
+          "key": "0f19f6d6-79a4-434e-ba0b-a4f49f334078",
+          "doc_count": 39118
+        },
+        {
+          "key": "8e58cd34-3cbb-46f7-9c25-527251881a6f",
+          "doc_count": 38676
+        },
+        {
+          "key": "c55ac6d0-180d-41be-829a-e82898c5ca54",
+          "doc_count": 37628
+        },
+        {
+          "key": "8fc08919-1137-42e4-9fa5-9e64f1e5757b",
+          "doc_count": 36996
+        },
+        {
+          "key": "d2c71720-e156-4943-8182-0a7bbe477a37",
+          "doc_count": 36771
+        },
+        {
+          "key": "32d433aa-9e2b-4ff9-bc55-5c3e30112207",
+          "doc_count": 35816
+        },
+        {
+          "key": "9e66257f-21a9-491a-ac23-06b7b62ceeb7",
+          "doc_count": 35406
+        },
+        {
+          "key": "8445ab25-ff89-44b0-90f8-bf0790f50afc",
+          "doc_count": 35403
+        },
+        {
+          "key": "23a47a5f-2ac1-4f81-acd3-21d5b82ed22a",
+          "doc_count": 35280
+        },
+        {
+          "key": "589ad4bd-a0aa-4949-bb92-0533ba7edaf2",
+          "doc_count": 35108
+        },
+        {
+          "key": "3056112e-97c6-4d0d-b6c2-3c0a9adaca24",
+          "doc_count": 34921
+        },
+        {
+          "key": "e39f6dee-f2cf-4eff-afc9-4600cafe660c",
+          "doc_count": 34553
+        },
+        {
+          "key": "99b04c9f-908e-42bd-92bc-41aa94b72949",
+          "doc_count": 33449
+        },
+        {
+          "key": "aced32f9-e511-48c7-8e9e-b625777bdf7f",
+          "doc_count": 33118
+        },
+        {
+          "key": "e4ff51ba-5007-4c40-9a86-e8c6f4db77b7",
+          "doc_count": 33097
+        },
+        {
+          "key": "0266a3f4-872b-4d21-a6b4-5c9818d8742b",
+          "doc_count": 32818
+        },
+        {
+          "key": "9a06cc34-be24-4ebf-b599-cbb1d4b8ac7b",
+          "doc_count": 31844
+        },
+        {
+          "key": "c5b7dae8-b483-4742-9954-d7f9226daa34",
+          "doc_count": 31809
+        },
+        {
+          "key": "ced8c9bc-e8b5-49e7-860a-289fc913860c",
+          "doc_count": 31549
+        },
+        {
+          "key": "6b565194-9707-42da-8052-9f9cf5f9aa60",
+          "doc_count": 31217
+        },
+        {
+          "key": "e0e37702-32af-405b-b652-ee54b5bb94e2",
+          "doc_count": 30656
+        },
+        {
+          "key": "5e893602-84ca-4c8c-bac1-99111c777582",
+          "doc_count": 30515
+        },
+        {
+          "key": "244ee82a-438c-4e77-a2ce-4e2af9ddbe4d",
+          "doc_count": 30171
+        },
+        {
+          "key": "774a153b-e556-47f6-95d1-bab49e61cc58",
+          "doc_count": 29572
+        },
+        {
+          "key": "654e092c-edbd-456c-8cce-2bcbdff71a04",
+          "doc_count": 29162
+        },
+        {
+          "key": "9cecfba6-6501-401c-9043-e95ba70164f3",
+          "doc_count": 29159
+        },
+        {
+          "key": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "doc_count": 28729
+        },
+        {
+          "key": "678dc436-3370-4992-a361-761dab8c3fda",
+          "doc_count": 28624
+        },
+        {
+          "key": "9b27c2f1-8b0a-4482-8424-8a9bb3bf0cf9",
+          "doc_count": 28520
+        },
+        {
+          "key": "570dcca6-a84f-43aa-8053-1a2ac60d9ead",
+          "doc_count": 28478
+        },
+        {
+          "key": "4f8c3594-d7b2-4985-8dd9-1ae77f9187d4",
+          "doc_count": 28155
+        },
+        {
+          "key": "e27f0218-47e0-41bc-9086-9d9169096e90",
+          "doc_count": 28062
+        },
+        {
+          "key": "e185415c-15c4-4612-89f3-27cfebbca0d9",
+          "doc_count": 27982
+        },
+        {
+          "key": "0220907a-0463-4ae0-8a0b-77f5e80fff40",
+          "doc_count": 27865
+        },
+        {
+          "key": "d29b9265-07e6-4e73-8f72-fc42d3d83fb1",
+          "doc_count": 27711
+        },
+        {
+          "key": "4db72a36-c08b-4a6b-8c68-ab45ebb0efce",
+          "doc_count": 27680
+        },
+        {
+          "key": "6bb853ab-e8ea-43b1-bd83-47318fc4c345",
+          "doc_count": 27614
+        },
+        {
+          "key": "37213da3-a1c7-4644-917e-8f8440e1c4d4",
+          "doc_count": 27344
+        },
+        {
+          "key": "181352ea-3598-4f32-b919-c8f6097f4c65",
+          "doc_count": 27092
+        },
+        {
+          "key": "a7020dbf-35fc-46e8-a441-c0a6b957193c",
+          "doc_count": 26701
+        },
+        {
+          "key": "7fbf76b1-6bd6-4217-a5bc-1d89e45f6a68",
+          "doc_count": 26605
+        },
+        {
+          "key": "e1e0f2cc-a50c-40d4-9031-c2d90a826247",
+          "doc_count": 26601
+        },
+        {
+          "key": "51b958bb-9d5f-48d7-9a97-e372c0c747c3",
+          "doc_count": 26514
+        },
+        {
+          "key": "1a44dfa0-6a54-4584-8c57-d98669d7f033",
+          "doc_count": 26323
+        },
+        {
+          "key": "025a810b-28f6-427d-b342-16fdf5f74f4b",
+          "doc_count": 26260
+        },
+        {
+          "key": "7ad07cff-f782-4ddf-b780-3a757cdb77e0",
+          "doc_count": 26149
+        },
+        {
+          "key": "d598446c-2b25-4d5d-a983-99be53001203",
+          "doc_count": 26125
+        },
+        {
+          "key": "1bfc0147-2df1-4488-bcf7-d140e24dda51",
+          "doc_count": 25733
+        },
+        {
+          "key": "dfd53a42-8f63-4040-93a5-3f1347ce7686",
+          "doc_count": 25569
+        },
+        {
+          "key": "f1a78c0f-449c-45fa-9472-0b92cc2a58da",
+          "doc_count": 24997
+        },
+        {
+          "key": "1c729855-f3dd-439d-b326-54d62f57b0fd",
+          "doc_count": 24922
+        },
+        {
+          "key": "364a24d9-d4a8-4e0b-8e50-07b90f844548",
+          "doc_count": 24529
+        },
+        {
+          "key": "6b2c3ca9-69ad-4316-a2d1-33399e9f547e",
+          "doc_count": 24481
+        },
+        {
+          "key": "518518b7-9e85-42ea-b419-2d23a3ef546a",
+          "doc_count": 24109
+        },
+        {
+          "key": "ef59f7cc-ed42-45fc-9abc-5edfb2c8caec",
+          "doc_count": 23979
+        },
+        {
+          "key": "fccc3c1d-d9df-4ffd-b7e1-1b9eb11f95b1",
+          "doc_count": 23820
+        },
+        {
+          "key": "531537fc-6349-4a20-ae42-540d61797086",
+          "doc_count": 23767
+        },
+        {
+          "key": "7e4aacd3-0a24-49ab-b019-518b7069b682",
+          "doc_count": 23576
+        },
+        {
+          "key": "04d9b721-259c-4d6b-b48f-2e23edf66c9f",
+          "doc_count": 23409
+        },
+        {
+          "key": "7110b8ba-0ead-4666-8279-e30f53e343d0",
+          "doc_count": 23286
+        },
+        {
+          "key": "c49bc91d-0a50-497b-8b17-d77808745cf9",
+          "doc_count": 23045
+        },
+        {
+          "key": "45544aa4-8762-4bf0-bfc6-890d08dc6ead",
+          "doc_count": 22907
+        },
+        {
+          "key": "2941b767-e90b-41b9-9627-6e589e0c0c85",
+          "doc_count": 22552
+        },
+        {
+          "key": "042dbdba-a449-4291-8777-577a5a4045de",
+          "doc_count": 22203
+        },
+        {
+          "key": "21b563bc-70c2-46d5-bce8-2489db2db3d8",
+          "doc_count": 21645
+        },
+        {
+          "key": "1e054b9b-0193-4ff3-b623-9264cf982d4d",
+          "doc_count": 21052
+        },
+        {
+          "key": "5aef068f-efd3-4851-a623-f542e97350cd",
+          "doc_count": 20465
+        },
+        {
+          "key": "e7016bd5-cb10-45b9-8959-0f5750f7a5db",
+          "doc_count": 20384
+        },
+        {
+          "key": "b000920c-6f7d-49d3-9d0f-2bb630d2e01a",
+          "doc_count": 20310
+        },
+        {
+          "key": "3f508496-c860-4701-93e4-84e940c8395e",
+          "doc_count": 20172
+        },
+        {
+          "key": "98ece30d-bf85-4122-b872-7786031b457f",
+          "doc_count": 19756
+        },
+        {
+          "key": "77b762ba-7cda-4617-97d7-e78df7f6dfab",
+          "doc_count": 19665
+        },
+        {
+          "key": "9e1958fb-1dc4-4375-ae35-67ba7f9c7afe",
+          "doc_count": 19660
+        },
+        {
+          "key": "48f5d475-7381-4d06-88eb-119796b9d189",
+          "doc_count": 19451
+        },
+        {
+          "key": "f630e3ea-697f-404a-8683-b86712c26c43",
+          "doc_count": 19168
+        },
+        {
+          "key": "e9b69a0a-497d-4201-b114-51519a4dfef9",
+          "doc_count": 19118
+        },
+        {
+          "key": "d100843b-d592-4024-8d15-fb1d8e218acd",
+          "doc_count": 19101
+        },
+        {
+          "key": "4ef6540c-e6cf-4678-bc43-b57435354de0",
+          "doc_count": 19067
+        },
+        {
+          "key": "1b6bb28e-e443-4cd3-910a-c6c43849c2cd",
+          "doc_count": 18944
+        },
+        {
+          "key": "a2a17035-1e6c-46df-9178-a610df825336",
+          "doc_count": 18851
+        },
+        {
+          "key": "1f5a1b81-e361-4d65-ab1c-6fb7e30c9910",
+          "doc_count": 18565
+        },
+        {
+          "key": "8e5fffb5-0b22-472d-8386-de291d17d513",
+          "doc_count": 18376
+        },
+        {
+          "key": "cb65cf5e-07b8-4d53-a91a-7dce9b8ccf80",
+          "doc_count": 18304
+        },
+        {
+          "key": "50cfe20a-9100-4710-89f9-a97bc3aa53d7",
+          "doc_count": 18060
+        },
+        {
+          "key": "92dd8c8e-c048-4f0a-9b5d-2ee627d2f553",
+          "doc_count": 17946
+        },
+        {
+          "key": "65007e62-740c-4302-ba20-260fe68da291",
+          "doc_count": 17883
+        },
+        {
+          "key": "79488fda-8310-42cd-b98e-8c3c2dd7d415",
+          "doc_count": 17834
+        },
+        {
+          "key": "c9dad611-5e60-4456-934e-75b0e0842ddd",
+          "doc_count": 17782
+        },
+        {
+          "key": "437826f3-69f9-43d9-b3c3-c0de0e26cd88",
+          "doc_count": 17715
+        },
+        {
+          "key": "bf9066a2-2c5f-4cf2-821a-1a68b4df5b1b",
+          "doc_count": 17648
+        },
+        {
+          "key": "aac5fd7f-8043-4aa8-811f-e50de70d96f3",
+          "doc_count": 17478
+        },
+        {
+          "key": "f33e9494-7b3c-4ac6-a735-59693b5a9638",
+          "doc_count": 17427
+        },
+        {
+          "key": "821c1855-6817-40ee-8732-7f472d238513",
+          "doc_count": 17079
+        },
+        {
+          "key": "a062eb42-d5c6-4332-8c88-64b4ac1af892",
+          "doc_count": 17036
+        },
+        {
+          "key": "2b45c778-b10c-496b-b8cb-1e414da59ccf",
+          "doc_count": 16711
+        },
+        {
+          "key": "c3134980-bf5c-49b8-a289-790d45f02c86",
+          "doc_count": 16504
+        },
+        {
+          "key": "7ae4d15d-62e2-459b-842a-446f921b9d3f",
+          "doc_count": 16477
+        },
+        {
+          "key": "4fed055b-3c46-4ec4-b76d-84d43df9258b",
+          "doc_count": 16341
+        },
+        {
+          "key": "8295ea14-c4fd-499b-bc68-2907ed36badc",
+          "doc_count": 16217
+        },
+        {
+          "key": "c5eeb223-0515-423a-a51a-151426c8f60d",
+          "doc_count": 16149
+        },
+        {
+          "key": "b30a7dd2-d974-4073-bdd0-cb4ea5402bae",
+          "doc_count": 15961
+        },
+        {
+          "key": "1e798b2d-7f97-49b0-a864-79c968af91d3",
+          "doc_count": 15664
+        },
+        {
+          "key": "53af19e1-9cb3-4834-8974-62adc640491c",
+          "doc_count": 15560
+        },
+        {
+          "key": "ad4e4ea0-2ac9-4030-b4bd-bf4206e79bcc",
+          "doc_count": 15339
+        },
+        {
+          "key": "6ae7221e-2085-46cf-9ad0-353269e95bc8",
+          "doc_count": 15175
+        },
+        {
+          "key": "cd177f63-761b-44f6-866e-ee19d2ac134e",
+          "doc_count": 14855
+        },
+        {
+          "key": "0038ce2e-43bb-4f70-8dd6-dca34efd3fca",
+          "doc_count": 14808
+        },
+        {
+          "key": "50b0bbe4-f075-4427-8dfc-fcc469dd3e78",
+          "doc_count": 14583
+        },
+        {
+          "key": "92e4e092-6dcb-46bc-85a0-dea8310aba45",
+          "doc_count": 14534
+        },
+        {
+          "key": "837d99c6-3045-4ba3-8951-643ddb3d6676",
+          "doc_count": 14434
+        },
+        {
+          "key": "bbf5f8ed-f33f-40ba-9d0d-1c24dfec4193",
+          "doc_count": 13613
+        },
+        {
+          "key": "a4378725-7967-47bc-aada-0220e02e1f96",
+          "doc_count": 13552
+        },
+        {
+          "key": "c9bff84f-8de4-43e6-b195-f515f187a68a",
+          "doc_count": 13487
+        },
+        {
+          "key": "662b1aa5-9c19-4eb9-9766-1da78a117456",
+          "doc_count": 13461
+        },
+        {
+          "key": "e3c0918d-ec6e-4ecd-a1db-15ec6880dade",
+          "doc_count": 13426
+        },
+        {
+          "key": "5a9ae910-9e4b-488b-af8e-88074fabc3a4",
+          "doc_count": 13374
+        },
+        {
+          "key": "e23109b4-e143-437c-b329-3dff7cb35488",
+          "doc_count": 13082
+        },
+        {
+          "key": "87017793-00dc-4f5d-b95b-09e7d17327cc",
+          "doc_count": 12983
+        },
+        {
+          "key": "341611f4-8b65-4655-b244-9be91a1109cd",
+          "doc_count": 12978
+        },
+        {
+          "key": "c3f05887-ffa9-44c4-b1af-e38fea5557bf",
+          "doc_count": 12961
+        },
+        {
+          "key": "e4b33221-1e2c-405c-ac02-a39d93f9a69b",
+          "doc_count": 12914
+        },
+        {
+          "key": "bd7cfd55-bf55-46fc-878d-e6e11f574ccd",
+          "doc_count": 12632
+        },
+        {
+          "key": "13510466-6232-4313-9e46-ea197b82750c",
+          "doc_count": 12631
+        },
+        {
+          "key": "86b2bfc9-ca99-4250-b93a-f86f3777236d",
+          "doc_count": 12457
+        },
+        {
+          "key": "91c5eec8-0cdc-4be2-9a99-a15ae5ec3edc",
+          "doc_count": 12373
+        },
+        {
+          "key": "063825dc-b8c3-4962-aea4-9994bcc09bc8",
+          "doc_count": 12238
+        },
+        {
+          "key": "139f2c47-4051-4c44-b95a-45fd20b1a8b9",
+          "doc_count": 12151
+        },
+        {
+          "key": "3c367a2d-eec0-4ef1-b3bc-4cbebb320c5a",
+          "doc_count": 11895
+        },
+        {
+          "key": "b5e5c781-765f-4981-af2a-c19c250e2cf0",
+          "doc_count": 11662
+        },
+        {
+          "key": "93e97f6c-0ab6-41a7-9b58-7e230a80ec1e",
+          "doc_count": 11634
+        },
+        {
+          "key": "2532cbd0-2752-4211-b249-4a9811a280f2",
+          "doc_count": 11614
+        },
+        {
+          "key": "04fe30b4-c1e5-4482-addb-67a4c2cd39ef",
+          "doc_count": 11602
+        },
+        {
+          "key": "cd46dc32-5e36-414b-a8d7-dea9df1f9106",
+          "doc_count": 11272
+        },
+        {
+          "key": "4d89070b-5dea-4a12-8a09-3f65ba33dba1",
+          "doc_count": 10956
+        },
+        {
+          "key": "1ad40bde-8a2a-46bb-9252-0cdc53df5683",
+          "doc_count": 10874
+        },
+        {
+          "key": "3ac8f738-bc3e-43e4-8358-00a32594954d",
+          "doc_count": 10763
+        },
+        {
+          "key": "5082e6c8-8f5b-4bf6-a930-e3e6de7bf6fb",
+          "doc_count": 10677
+        },
+        {
+          "key": "f89ada44-88df-46f0-bc61-cc46d9c84673",
+          "doc_count": 10668
+        },
+        {
+          "key": "3e86e072-2597-4849-87d5-565afe40f988",
+          "doc_count": 10594
+        },
+        {
+          "key": "6d09cfc1-a17c-4067-b1a0-557b8e5334ea",
+          "doc_count": 10542
+        },
+        {
+          "key": "ab4b6a2b-a90a-44ce-95a1-2c44c911fcc6",
+          "doc_count": 10504
+        },
+        {
+          "key": "a2a7754b-2346-496d-b681-eb754ef32b9e",
+          "doc_count": 10384
+        },
+        {
+          "key": "12018be6-3795-43a3-a073-a2b9d60c0af3",
+          "doc_count": 10183
+        },
+        {
+          "key": "bfa3c276-a3a9-48cd-8d4a-4ac42f4fe10a",
+          "doc_count": 10134
+        },
+        {
+          "key": "06c35934-1b75-4196-838d-29d509951bf9",
+          "doc_count": 10044
+        },
+        {
+          "key": "81dc7cdb-66be-4683-ae79-068a784378b1",
+          "doc_count": 10033
+        },
+        {
+          "key": "c94a06a5-df24-4546-adba-4f7940661826",
+          "doc_count": 9963
+        },
+        {
+          "key": "7cc1fb18-45c1-499f-8476-682daa14a4a3",
+          "doc_count": 9890
+        },
+        {
+          "key": "79aa7602-a963-44f3-82dd-e141a387adb8",
+          "doc_count": 9861
+        },
+        {
+          "key": "15e04168-22cc-4283-9042-247ab053c7ca",
+          "doc_count": 9804
+        },
+        {
+          "key": "dddf9315-7819-4289-b587-6be72e4894d2",
+          "doc_count": 9761
+        },
+        {
+          "key": "252a0a12-f114-4fb5-aa9a-678c523d6dcd",
+          "doc_count": 9535
+        },
+        {
+          "key": "e701ecce-f9ab-445f-afcb-24f279efbc9c",
+          "doc_count": 9475
+        },
+        {
+          "key": "3c6f1ea5-f2e7-4203-9cfe-74ec2fb1b035",
+          "doc_count": 9426
+        },
+        {
+          "key": "c004cf67-eafc-49f9-99bd-b8198e2234ed",
+          "doc_count": 9370
+        },
+        {
+          "key": "abe3903e-ceba-4864-aa5d-bd985c70fa21",
+          "doc_count": 9205
+        },
+        {
+          "key": "3a5b5c9b-b241-4883-904a-b167a7edb41a",
+          "doc_count": 9155
+        },
+        {
+          "key": "90739622-5232-4048-8121-9af9ec69604f",
+          "doc_count": 9154
+        },
+        {
+          "key": "5889291d-9105-4740-a30f-2d9d2469c264",
+          "doc_count": 9100
+        },
+        {
+          "key": "f0599190-e5b7-42ed-bec8-810905f50c34",
+          "doc_count": 8900
+        },
+        {
+          "key": "ec248223-f277-4c02-b1fa-60056b5a689a",
+          "doc_count": 8865
+        },
+        {
+          "key": "9d2a4189-6048-46e9-bac4-e5ef566334bb",
+          "doc_count": 8857
+        },
+        {
+          "key": "dbb2acdc-a808-4deb-9dc2-542d70368a3f",
+          "doc_count": 8797
+        },
+        {
+          "key": "0272afc1-36ee-4899-8c28-dde9d8a211d9",
+          "doc_count": 8788
+        },
+        {
+          "key": "414a5bf5-061e-4e47-8410-0f76a04f7d1d",
+          "doc_count": 8715
+        },
+        {
+          "key": "5ffc8bc6-e366-4157-b1ba-00859f1048a4",
+          "doc_count": 8701
+        },
+        {
+          "key": "f08c31ea-0e90-4cc1-b471-dfd0584ae7cf",
+          "doc_count": 8470
+        },
+        {
+          "key": "9756b9a4-c070-4359-8a07-2383b09d0d04",
+          "doc_count": 8361
+        },
+        {
+          "key": "bdf65f9c-a730-4083-bd8d-a2def3037637",
+          "doc_count": 8345
+        },
+        {
+          "key": "ef04e127-bb7d-4bf0-82d3-767d43108f81",
+          "doc_count": 8289
+        },
+        {
+          "key": "e7db896a-c95b-4a18-99a4-866fff238ca5",
+          "doc_count": 8046
+        },
+        {
+          "key": "331b6d1b-842e-4c63-aa23-75ef275d8a9f",
+          "doc_count": 8010
+        },
+        {
+          "key": "81d00e23-92aa-45d7-b289-5cf045ddfbf4",
+          "doc_count": 7958
+        },
+        {
+          "key": "cfe5c00e-bec3-4120-a8eb-62c5353f3e80",
+          "doc_count": 7903
+        },
+        {
+          "key": "cf60ed8a-2c79-4b85-a259-15a8e216dae4",
+          "doc_count": 7897
+        },
+        {
+          "key": "665f34ed-bfa3-4b25-a838-3b97f4dce586",
+          "doc_count": 7829
+        },
+        {
+          "key": "7e44229a-e8fa-4570-ada1-0cd7843a66d7",
+          "doc_count": 7747
+        },
+        {
+          "key": "6539877e-82dc-485c-ad3d-038f383d5431",
+          "doc_count": 7721
+        },
+        {
+          "key": "eaa5f19e-ff6f-4d09-8b55-4a6810e77a6c",
+          "doc_count": 7647
+        },
+        {
+          "key": "4960f30c-c1c7-490e-966a-61ad02969e38",
+          "doc_count": 7577
+        },
+        {
+          "key": "540e18dc-09aa-4790-8b47-8d18ae86fabc",
+          "doc_count": 7567
+        },
+        {
+          "key": "364b1f8d-5975-48d9-bba1-c97ab172986c",
+          "doc_count": 7551
+        },
+        {
+          "key": "1ffce054-8e3e-4209-9ff4-c26fa6c24c2f",
+          "doc_count": 7491
+        },
+        {
+          "key": "e77108de-88dd-4931-8085-0ea59d7ca4ee",
+          "doc_count": 7378
+        },
+        {
+          "key": "3501e0a6-1420-45b9-bbf9-77349e79e9d7",
+          "doc_count": 7307
+        },
+        {
+          "key": "c7ae0ade-c23e-4fe6-a3d4-79bd973374c2",
+          "doc_count": 7276
+        },
+        {
+          "key": "75e3aff5-b3d0-45c3-835c-5ffde192c63f",
+          "doc_count": 7170
+        },
+        {
+          "key": "5fd5a403-8e94-4865-8c77-ee92cb4a95f2",
+          "doc_count": 7150
+        },
+        {
+          "key": "4f436daa-01d5-4be6-b5c3-fdd255677536",
+          "doc_count": 6994
+        },
+        {
+          "key": "e80fe2bb-547d-4e98-84ce-01176379e3a8",
+          "doc_count": 6843
+        },
+        {
+          "key": "482990c6-da88-4d99-8cf4-ccd27ee82f44",
+          "doc_count": 6836
+        },
+        {
+          "key": "d6c6e57a-4ccb-4707-b87d-c91d01d6aa42",
+          "doc_count": 6814
+        },
+        {
+          "key": "d840624f-42d5-40d9-9daa-2260f85feb54",
+          "doc_count": 6806
+        },
+        {
+          "key": "a83151ae-e1db-4166-9dde-438f6544dca9",
+          "doc_count": 6732
+        },
+        {
+          "key": "ea9de87b-7231-4a05-809f-4b658ea4173d",
+          "doc_count": 6722
+        },
+        {
+          "key": "cd7b335e-6f5c-4259-ba45-5e334a719464",
+          "doc_count": 6667
+        },
+        {
+          "key": "73236de8-c2cc-458c-b0c3-743c7b57db3a",
+          "doc_count": 6634
+        },
+        {
+          "key": "b00cf471-6bbe-4f94-846e-288900398b65",
+          "doc_count": 6626
+        },
+        {
+          "key": "69037495-438d-4dba-bf0f-4878073766f1",
+          "doc_count": 6610
+        },
+        {
+          "key": "b4bcc255-4acf-4966-b9b3-af9dd4e458d1",
+          "doc_count": 6576
+        },
+        {
+          "key": "5ab5f23d-292e-4bea-ba06-12db0f8a8c86",
+          "doc_count": 6530
+        },
+        {
+          "key": "7ed2ce52-26e5-4847-9563-955ae3e97455",
+          "doc_count": 6526
+        },
+        {
+          "key": "c38b867b-05f3-4733-802e-d8d2d3324f84",
+          "doc_count": 6400
+        },
+        {
+          "key": "959c0dc4-fcf3-477e-af63-c00a005dbc0a",
+          "doc_count": 6384
+        },
+        {
+          "key": "beb74dc2-22ea-49e4-b1e3-bedb8e06e8f2",
+          "doc_count": 6365
+        },
+        {
+          "key": "b1ed65bb-f27e-4695-a0f5-7ca52fc0c3e6",
+          "doc_count": 6275
+        },
+        {
+          "key": "2c662e9e-cdc6-4bbf-93a5-1566ceca1af3",
+          "doc_count": 6268
+        },
+        {
+          "key": "5486b66d-2082-433d-9223-bd789ebca29c",
+          "doc_count": 6172
+        },
+        {
+          "key": "d5a1b706-c624-43df-afcf-9cea7094e75b",
+          "doc_count": 6164
+        },
+        {
+          "key": "e5cb850f-de98-45ce-9872-95262732809f",
+          "doc_count": 6015
+        },
+        {
+          "key": "8eabbc48-2b30-419d-bd8f-eece9185eca1",
+          "doc_count": 6001
+        },
+        {
+          "key": "55e724a4-336a-4315-99e7-01bf0c94f222",
+          "doc_count": 5924
+        },
+        {
+          "key": "1eca069b-09e0-406d-9625-cb9c52e1e5cc",
+          "doc_count": 5917
+        },
+        {
+          "key": "954ec5e0-4fcd-414d-8ad2-46b4b75cfc74",
+          "doc_count": 5902
+        },
+        {
+          "key": "d5c32031-231f-4213-b0f1-2dc4bbf711a0",
+          "doc_count": 5891
+        },
+        {
+          "key": "22436fe4-5049-4266-9849-335dd3f161aa",
+          "doc_count": 5863
+        },
+        {
+          "key": "c1122f57-9ab9-4552-9393-7d56b0bbe852",
+          "doc_count": 5797
+        },
+        {
+          "key": "8bcb95b2-ab5c-4368-8ead-14588eeb9c98",
+          "doc_count": 5756
+        },
+        {
+          "key": "6f470382-cb0b-4634-a796-2248bfa97fdc",
+          "doc_count": 5696
+        },
+        {
+          "key": "44328ef7-fc7f-4ff6-b51b-ed9049857e11",
+          "doc_count": 5680
+        },
+        {
+          "key": "9368e302-f8e7-4714-aed4-db2faa861e5c",
+          "doc_count": 5642
+        },
+        {
+          "key": "67893f3c-c409-41c6-a8f2-47956739a911",
+          "doc_count": 5541
+        },
+        {
+          "key": "ec135c9b-ff89-4f28-aa18-88b16d932d94",
+          "doc_count": 5441
+        },
+        {
+          "key": "5af1bae4-35c0-4ab7-9d08-08bbe22ca003",
+          "doc_count": 5428
+        },
+        {
+          "key": "347579f4-d44a-4c8e-a578-09c2a8132573",
+          "doc_count": 5391
+        },
+        {
+          "key": "a5fdee09-34c4-48bc-99ff-a503c93a9d7e",
+          "doc_count": 5227
+        },
+        {
+          "key": "66427724-af1d-43f8-bc00-cb744e55ac2c",
+          "doc_count": 5222
+        },
+        {
+          "key": "fd14095c-3658-4e00-8cec-729a89459e92",
+          "doc_count": 5138
+        },
+        {
+          "key": "7cea906d-ae65-420c-a6f7-a9a3ad64fb93",
+          "doc_count": 5121
+        },
+        {
+          "key": "589ee0cf-456c-4d9c-8e7e-3adc3cec0e09",
+          "doc_count": 5111
+        },
+        {
+          "key": "de5203b1-5a44-4010-948c-b7d33f46397a",
+          "doc_count": 5099
+        },
+        {
+          "key": "f5d395b8-c3c9-43df-b4ff-63d65c6a971e",
+          "doc_count": 5037
+        },
+        {
+          "key": "6cab4420-11e4-4b55-85ac-6ecfdda70184",
+          "doc_count": 5023
+        },
+        {
+          "key": "43c69d2a-0fd2-4d34-a1ef-50d0f9c01353",
+          "doc_count": 5020
+        },
+        {
+          "key": "d14d21fe-da24-47e5-81fb-4bfe962ce828",
+          "doc_count": 5003
+        },
+        {
+          "key": "a4babe52-5740-44e4-9ea2-acef4797f127",
+          "doc_count": 4970
+        },
+        {
+          "key": "2f740a87-8049-435d-9d06-1c393c9c11b7",
+          "doc_count": 4851
+        },
+        {
+          "key": "196c4f1c-53f9-480f-a012-dc0522629047",
+          "doc_count": 4660
+        },
+        {
+          "key": "282fe9c2-d6cb-4325-b3b5-b70ab1d22bbb",
+          "doc_count": 4611
+        },
+        {
+          "key": "fe04dab1-5a3d-4c28-a450-012658e982d8",
+          "doc_count": 4570
+        },
+        {
+          "key": "9b34b218-efb2-43b9-9b9e-dac3c470a9f9",
+          "doc_count": 4552
+        },
+        {
+          "key": "b1beb057-bc34-49a9-b784-2a50af226712",
+          "doc_count": 4442
+        },
+        {
+          "key": "25cd5e12-7830-4f46-bf6d-9b6deb706f44",
+          "doc_count": 4339
+        },
+        {
+          "key": "295a8445-346f-4ea2-b0cf-4a3863c72cdb",
+          "doc_count": 4301
+        },
+        {
+          "key": "6e922c92-b37d-4c46-8982-19d945ff8fd1",
+          "doc_count": 4272
+        },
+        {
+          "key": "23b85d9d-4669-40db-901f-aaad686fe0b8",
+          "doc_count": 4241
+        },
+        {
+          "key": "2b03a9d6-3575-43ea-8f43-38cbe0ee72e6",
+          "doc_count": 4231
+        },
+        {
+          "key": "9e046dad-2b23-4f95-8eaf-c0346de2556e",
+          "doc_count": 4226
+        },
+        {
+          "key": "69d150df-eba4-4ab3-9156-71cb0db41830",
+          "doc_count": 4207
+        },
+        {
+          "key": "c5d42fed-eed0-4e14-9625-f8a9c0ff6bb1",
+          "doc_count": 4196
+        },
+        {
+          "key": "497d74c2-d07f-4325-ac9c-8e80bcb53f61",
+          "doc_count": 4187
+        },
+        {
+          "key": "4bec11d1-f8c3-43a7-9e70-ee0256fcedaf",
+          "doc_count": 4187
+        },
+        {
+          "key": "4790a6a0-ce11-4cd8-8cad-4b2032a55c1b",
+          "doc_count": 4168
+        },
+        {
+          "key": "fc628e53-5fdf-4436-9782-bf637d812b48",
+          "doc_count": 4153
+        },
+        {
+          "key": "eeb4872b-7fb4-4ecd-8ce5-82e194f04735",
+          "doc_count": 4138
+        },
+        {
+          "key": "7370af7d-07b5-4fc6-9eca-0204b4d6e33e",
+          "doc_count": 4122
+        },
+        {
+          "key": "093030d9-a124-42a8-8cf3-8c6904fefbe7",
+          "doc_count": 4116
+        },
+        {
+          "key": "6f510e69-96b2-4817-bab7-3a36c8250c79",
+          "doc_count": 4074
+        },
+        {
+          "key": "2bbafa00-3162-4e8e-947c-64a13b8d3fef",
+          "doc_count": 4069
+        },
+        {
+          "key": "11170c5e-033a-4410-aed1-3dee2458bc43",
+          "doc_count": 4063
+        },
+        {
+          "key": "0e5201c0-bad2-4e28-9322-5c5dca8862c8",
+          "doc_count": 4010
+        },
+        {
+          "key": "9c963109-9898-4953-a351-d5ee36d6115b",
+          "doc_count": 4010
+        },
+        {
+          "key": "6ac89a16-4604-4a78-9047-dcc57e5c0130",
+          "doc_count": 3961
+        },
+        {
+          "key": "d6f12b28-bb9f-44f9-9000-08f644658bf8",
+          "doc_count": 3955
+        },
+        {
+          "key": "833306f7-91b6-4ff7-bc16-0e406334d991",
+          "doc_count": 3949
+        },
+        {
+          "key": "677f57a9-9a0d-4e69-8622-96aa1e6392c2",
+          "doc_count": 3921
+        },
+        {
+          "key": "9fab87bf-c5a7-4296-acdc-f22859cfe620",
+          "doc_count": 3898
+        },
+        {
+          "key": "d1b25dcd-472e-4902-b53c-3b164269e049",
+          "doc_count": 3879
+        },
+        {
+          "key": "9d9b81f1-3a9a-4515-b741-a145293f1fef",
+          "doc_count": 3849
+        },
+        {
+          "key": "2d4658e3-0d1a-43fc-97ff-b4813dd1f86e",
+          "doc_count": 3831
+        },
+        {
+          "key": "b8972f6b-c67f-45c0-b348-954866e04a0f",
+          "doc_count": 3777
+        },
+        {
+          "key": "560ba8f5-0dab-46f6-985d-7b37397344cd",
+          "doc_count": 3755
+        },
+        {
+          "key": "49153f74-2969-4a6a-a145-309fcb970308",
+          "doc_count": 3748
+        },
+        {
+          "key": "64b54f96-91f0-4442-b6de-173aa1a5c31b",
+          "doc_count": 3740
+        },
+        {
+          "key": "196bb137-2f82-40d5-b294-e730af29749f",
+          "doc_count": 3738
+        },
+        {
+          "key": "09a76937-b01a-4f4a-aefd-825876453015",
+          "doc_count": 3678
+        },
+        {
+          "key": "a50e98bd-13e9-41fe-a5cc-aee4f240628b",
+          "doc_count": 3674
+        },
+        {
+          "key": "66e00116-15fa-4149-a94a-eb91b98b622c",
+          "doc_count": 3632
+        },
+        {
+          "key": "1f8c7572-5cda-44be-9a78-0658217fc279",
+          "doc_count": 3622
+        },
+        {
+          "key": "6b6c13d9-7789-4da0-99d7-6786322e2612",
+          "doc_count": 3597
+        },
+        {
+          "key": "a2bc3d61-3c37-4aca-b47d-c3413f7e3b87",
+          "doc_count": 3591
+        },
+        {
+          "key": "4c9d08ce-71c1-47b8-a572-2d40e5984c49",
+          "doc_count": 3564
+        },
+        {
+          "key": "34cad268-8226-4280-b637-dde38c82a29e",
+          "doc_count": 3514
+        },
+        {
+          "key": "b880344e-22b2-4540-a56a-1de5f5601a20",
+          "doc_count": 3480
+        },
+        {
+          "key": "ff111763-e72d-4f24-8914-b5b2dd94908c",
+          "doc_count": 3478
+        },
+        {
+          "key": "55b17f44-8c6b-4dc5-a31d-d9955b425790",
+          "doc_count": 3458
+        },
+        {
+          "key": "0e0e9bbc-1dea-4de4-95ae-aecc90844bbf",
+          "doc_count": 3338
+        },
+        {
+          "key": "9a09745d-4449-46a2-b8b3-60f3c0d25e83",
+          "doc_count": 3334
+        },
+        {
+          "key": "b40e13f7-a79a-4265-93d9-3b4878dfc988",
+          "doc_count": 3303
+        },
+        {
+          "key": "4900d7ce-9442-4305-9889-c9cbbb953eaa",
+          "doc_count": 3296
+        },
+        {
+          "key": "2292f5d5-d39f-4944-be72-fa5dd62f581c",
+          "doc_count": 3287
+        },
+        {
+          "key": "7026b70a-7245-42bd-8162-81ae9a6cfbcb",
+          "doc_count": 3262
+        },
+        {
+          "key": "bf897c17-06cc-48c1-a7cc-f41b45166880",
+          "doc_count": 3244
+        },
+        {
+          "key": "8728ef71-fdcc-4027-8139-38b2c0628fba",
+          "doc_count": 3205
+        },
+        {
+          "key": "df516dc6-6ef0-426d-94e3-8a2bbb0439a5",
+          "doc_count": 3174
+        },
+        {
+          "key": "e85a9948-9c9e-451d-9485-b2b4cb7b73d5",
+          "doc_count": 3161
+        },
+        {
+          "key": "ef637c01-c551-4d47-8a48-4442b8ad5ecd",
+          "doc_count": 3152
+        },
+        {
+          "key": "79be41bc-8142-485a-9d57-d6195f9a7c81",
+          "doc_count": 3137
+        },
+        {
+          "key": "fcbcb214-cd62-4453-af56-b4b49161a261",
+          "doc_count": 3137
+        },
+        {
+          "key": "fc40fabd-0a70-48fa-b142-79990cd259a5",
+          "doc_count": 3107
+        },
+        {
+          "key": "d1983d53-434a-436e-a698-3a2745eb61dc",
+          "doc_count": 3090
+        },
+        {
+          "key": "0bfd2d69-2a35-4291-9e73-bd311463bd15",
+          "doc_count": 3076
+        },
+        {
+          "key": "6d4b658a-90b4-4639-8b06-b7f07637f6aa",
+          "doc_count": 3062
+        },
+        {
+          "key": "b4d4e884-a2ef-4967-b4cb-2072fc465eaf",
+          "doc_count": 3043
+        },
+        {
+          "key": "b20588fd-61f4-4765-8025-30c81a5f4250",
+          "doc_count": 2975
+        },
+        {
+          "key": "47ac1531-5213-4848-a32d-5bb396ab9348",
+          "doc_count": 2966
+        },
+        {
+          "key": "d81c6ad6-fb8f-4c31-bba3-f2b65f780893",
+          "doc_count": 2962
+        },
+        {
+          "key": "2e3a8e5c-eef9-462d-a690-3a91fe111e13",
+          "doc_count": 2959
+        },
+        {
+          "key": "9fa0a48c-7dd2-4372-a768-9aea3cbd35bb",
+          "doc_count": 2919
+        },
+        {
+          "key": "5277e72c-9e53-4c98-85f1-ee413bc473cd",
+          "doc_count": 2909
+        },
+        {
+          "key": "9f3bbc7b-c682-4f66-88b3-48eef3a38f38",
+          "doc_count": 2865
+        },
+        {
+          "key": "39289378-eed8-442c-ba0b-fce8b1679d8f",
+          "doc_count": 2856
+        },
+        {
+          "key": "333ac26a-30bc-4e0c-a6ef-c57a40f6bd99",
+          "doc_count": 2830
+        },
+        {
+          "key": "8783e947-93cf-4b60-b387-d10642b0eee0",
+          "doc_count": 2829
+        },
+        {
+          "key": "19daf0a7-5e37-41e6-97f8-4494553c358c",
+          "doc_count": 2822
+        },
+        {
+          "key": "5e8863ea-56ec-40f3-8075-d42b35d12e72",
+          "doc_count": 2789
+        },
+        {
+          "key": "59734d15-8edb-41a4-b3f2-f9bd3407460b",
+          "doc_count": 2778
+        },
+        {
+          "key": "d08a71aa-fe87-4bf5-ac68-8e7497bf585c",
+          "doc_count": 2745
+        },
+        {
+          "key": "40d35f62-cf89-488a-bad3-66e66d38c10c",
+          "doc_count": 2733
+        },
+        {
+          "key": "ef30a918-b583-41f1-9ac4-4a37591b515a",
+          "doc_count": 2692
+        },
+        {
+          "key": "cc11b4e3-823d-4490-95b2-afe6a1f3a9d2",
+          "doc_count": 2679
+        },
+        {
+          "key": "7c927849-94ed-4034-90e9-af34ac0cb47c",
+          "doc_count": 2664
+        },
+        {
+          "key": "2eb8ff2f-4826-4fc3-be68-22d805bcae88",
+          "doc_count": 2658
+        },
+        {
+          "key": "33bac15d-b1d0-42a1-8801-86149887eeef",
+          "doc_count": 2639
+        },
+        {
+          "key": "1aa66130-6668-4c4b-8383-a51b8e8389ec",
+          "doc_count": 2506
+        },
+        {
+          "key": "96588aed-3b7a-4179-b92b-2159427f4fcb",
+          "doc_count": 2479
+        },
+        {
+          "key": "5ddcbd44-1802-46b0-bae5-11126409c03d",
+          "doc_count": 2432
+        },
+        {
+          "key": "b5234343-b0f1-472a-9db7-dfa78affd402",
+          "doc_count": 2396
+        },
+        {
+          "key": "7232e59b-b0e1-49cd-9632-b8ae1f49f828",
+          "doc_count": 2390
+        },
+        {
+          "key": "0dabd609-2505-4492-8b7a-3f8301d8d5e1",
+          "doc_count": 2381
+        },
+        {
+          "key": "e38af226-7109-4f99-a6f1-9fd3bec5638d",
+          "doc_count": 2364
+        },
+        {
+          "key": "0072bf11-a354-4998-8730-c0cb4cfc9517",
+          "doc_count": 2351
+        },
+        {
+          "key": "d315c4a3-0bee-49d1-8d03-726358937cde",
+          "doc_count": 2308
+        },
+        {
+          "key": "9354db6c-4019-4351-a822-cb87b1b73a44",
+          "doc_count": 2247
+        },
+        {
+          "key": "e73fedf0-90ee-4c6d-88dd-49399878fc54",
+          "doc_count": 2227
+        },
+        {
+          "key": "3a0d8092-c577-4775-a586-1542574edc53",
+          "doc_count": 2188
+        },
+        {
+          "key": "18c215c3-c02f-47e9-bb66-196c33c8f672",
+          "doc_count": 2056
+        },
+        {
+          "key": "b985f284-eac5-4efe-8a7c-c726cdf7cf33",
+          "doc_count": 2055
+        },
+        {
+          "key": "82541f90-fe8e-4d66-84d8-4fe515dc5533",
+          "doc_count": 2035
+        },
+        {
+          "key": "3ad82604-c4b3-4fd0-b03e-d8f874062146",
+          "doc_count": 2009
+        },
+        {
+          "key": "db4bb0df-8539-4617-ab5f-eb118aa3126b",
+          "doc_count": 2002
+        },
+        {
+          "key": "8157bc94-5fba-4bf6-98bd-9ba653b595e8",
+          "doc_count": 1963
+        },
+        {
+          "key": "994b60a2-88f1-49ec-a6da-27d56dfa6f16",
+          "doc_count": 1958
+        },
+        {
+          "key": "fb97dfb4-72be-4dc1-9f5a-2faea75341b4",
+          "doc_count": 1883
+        },
+        {
+          "key": "30ab9c2a-0b54-4c04-84ca-bc7abdd90b52",
+          "doc_count": 1876
+        },
+        {
+          "key": "f9a33279-d6ba-41c7-a511-ef6adfcb6e20",
+          "doc_count": 1831
+        },
+        {
+          "key": "a0ec3ce6-fc8a-48b7-9105-cecf27602e37",
+          "doc_count": 1812
+        },
+        {
+          "key": "5d7869be-8526-43d8-af53-f16a15ebadb5",
+          "doc_count": 1808
+        },
+        {
+          "key": "401fec56-515d-4fa8-87d1-507e742f4f6f",
+          "doc_count": 1802
+        },
+        {
+          "key": "045aa661-f985-4203-80ff-98daafdfe377",
+          "doc_count": 1792
+        },
+        {
+          "key": "09b18522-5643-478f-86e9-d2e34440d43e",
+          "doc_count": 1782
+        },
+        {
+          "key": "8e4ff036-d38e-455f-a0fe-4ac50823f4fb",
+          "doc_count": 1742
+        },
+        {
+          "key": "2e65e24b-b7e2-40a4-a40c-09edafc1e3f4",
+          "doc_count": 1687
+        },
+        {
+          "key": "241d64f1-480a-48ae-8ec2-cd12af4a16e9",
+          "doc_count": 1685
+        },
+        {
+          "key": "7e43ea77-d2e5-4bdc-a4f7-a4792866f53f",
+          "doc_count": 1664
+        },
+        {
+          "key": "ff0d1543-247c-4039-a8ff-cf4fc224c449",
+          "doc_count": 1663
+        },
+        {
+          "key": "87c45c90-ba1d-409e-a9d7-9baf5a5cbb1c",
+          "doc_count": 1631
+        },
+        {
+          "key": "0e2f3962-e905-48f2-a1c6-19d16e2bd5ba",
+          "doc_count": 1630
+        },
+        {
+          "key": "7340c0df-8829-4197-9dc7-0328b8e7f5dd",
+          "doc_count": 1590
+        },
+        {
+          "key": "1e86442f-35a5-4e7b-9a38-4599e4d3b510",
+          "doc_count": 1582
+        },
+        {
+          "key": "f3327705-8d69-4d9c-88b7-584a08c74653",
+          "doc_count": 1579
+        },
+        {
+          "key": "e506c5e0-99b6-4e97-b7b4-4536cb80209b",
+          "doc_count": 1536
+        },
+        {
+          "key": "a545560f-a02a-4b8a-af4c-ed09f1f05df7",
+          "doc_count": 1485
+        },
+        {
+          "key": "5aac25d2-bcfb-4084-a700-584311ea539d",
+          "doc_count": 1480
+        },
+        {
+          "key": "ba77d411-4179-4dbd-b6c1-39b8a71ae795",
+          "doc_count": 1469
+        },
+        {
+          "key": "2c2cc29c-3572-4568-a129-c8cbec34ccbe",
+          "doc_count": 1458
+        },
+        {
+          "key": "3d2b5be0-7c1d-4693-9226-94bc0061123b",
+          "doc_count": 1417
+        },
+        {
+          "key": "56879e73-bf9d-4bd9-a7a4-4f2f940d0f62",
+          "doc_count": 1408
+        },
+        {
+          "key": "82c60e09-2939-4896-9ce9-5c63fe19cac9",
+          "doc_count": 1381
+        },
+        {
+          "key": "f5c38252-89f1-4753-af3a-da8818fe3a86",
+          "doc_count": 1325
+        },
+        {
+          "key": "99e84c7d-dd3c-40d9-9526-54f4342cda95",
+          "doc_count": 1287
+        },
+        {
+          "key": "feb74628-8724-466f-8c8c-b3d3b72f2417",
+          "doc_count": 1274
+        },
+        {
+          "key": "3bbf3659-4b21-40b7-b74f-f17a60097154",
+          "doc_count": 1267
+        },
+        {
+          "key": "08bfaeb8-abb4-4b33-b0e7-ed1242377bbd",
+          "doc_count": 1241
+        },
+        {
+          "key": "a4b888a2-94bf-4680-b912-84964a236c82",
+          "doc_count": 1209
+        },
+        {
+          "key": "9a861ebe-f8d7-4eb1-a2c8-3006f07cfec2",
+          "doc_count": 1205
+        },
+        {
+          "key": "ea9d9c05-11b3-4514-898e-66bd8560ec5b",
+          "doc_count": 1202
+        },
+        {
+          "key": "0a410c4a-cd4f-4bd8-b6ba-a0c2baa37622",
+          "doc_count": 1185
+        },
+        {
+          "key": "442246b3-6610-45e6-b2bf-c11ee15917b8",
+          "doc_count": 1184
+        },
+        {
+          "key": "1da2a87d-4fc7-4233-b127-59cb8d1ca5ee",
+          "doc_count": 1167
+        },
+        {
+          "key": "50b4c365-5472-4fe8-8825-b1fa0ac57fb3",
+          "doc_count": 1132
+        },
+        {
+          "key": "3ff3bf5c-7aba-40c3-80b2-1b00ea1abdd5",
+          "doc_count": 1123
+        },
+        {
+          "key": "2d853a6d-50ec-4931-8e91-48fc2491fdee",
+          "doc_count": 1122
+        },
+        {
+          "key": "b12b08da-3d05-4406-a051-0139a33ecf35",
+          "doc_count": 1118
+        },
+        {
+          "key": "76015dea-c909-4e6d-a8e1-3bf35763571e",
+          "doc_count": 1100
+        },
+        {
+          "key": "15a1cc29-b66c-4633-ad9c-c2c094b19902",
+          "doc_count": 1090
+        },
+        {
+          "key": "dd783e7e-36d8-4fcd-b7fe-9a481d785560",
+          "doc_count": 1086
+        },
+        {
+          "key": "1e6c8187-1521-4501-b205-ac8f513d5e04",
+          "doc_count": 1068
+        },
+        {
+          "key": "4aecf17c-154a-42fb-a3c0-f5e621c791e6",
+          "doc_count": 1054
+        },
+        {
+          "key": "50ca2a08-0e76-4f56-9976-d344dd201a9b",
+          "doc_count": 1053
+        },
+        {
+          "key": "8cd3a748-7f59-40e9-9cf3-3951e1e6430d",
+          "doc_count": 1053
+        },
+        {
+          "key": "bfb53140-79c1-4625-81aa-3f37de7c0c2f",
+          "doc_count": 1026
+        },
+        {
+          "key": "e8a10a16-86af-42b2-be40-9d6a1b21859a",
+          "doc_count": 986
+        },
+        {
+          "key": "af60ac71-fbfb-4648-95fb-0eb5fe24765b",
+          "doc_count": 984
+        },
+        {
+          "key": "93341fe7-38f8-4ef2-8dfc-ae550aa522dc",
+          "doc_count": 976
+        },
+        {
+          "key": "b3976394-a174-4ceb-8d64-3a435d66bde6",
+          "doc_count": 972
+        },
+        {
+          "key": "96a6898e-1fb6-4c49-a1f2-afb96058dbf8",
+          "doc_count": 967
+        },
+        {
+          "key": "d601bd5e-4f4c-4637-9196-4bd821dbd2e2",
+          "doc_count": 928
+        },
+        {
+          "key": "f4666aa7-93f0-41f7-83c2-497af7a06887",
+          "doc_count": 885
+        },
+        {
+          "key": "75c7a013-8dab-4f9c-ae6d-3a7cc24b67ce",
+          "doc_count": 882
+        },
+        {
+          "key": "da46ceaf-6084-48da-9e53-4d1ae2a51ddf",
+          "doc_count": 865
+        },
+        {
+          "key": "886f3b02-e2f2-4c49-9ace-df25bf5d091a",
+          "doc_count": 856
+        },
+        {
+          "key": "c882214e-8ba4-482b-9998-070b5547dc54",
+          "doc_count": 853
+        },
+        {
+          "key": "4efa66cf-8adb-414b-b78c-8e651d20f84d",
+          "doc_count": 852
+        },
+        {
+          "key": "49db9725-7bdc-4c38-8548-c32994e811c1",
+          "doc_count": 838
+        },
+        {
+          "key": "c3a7b339-122e-4fe9-8851-371b1fdf584e",
+          "doc_count": 803
+        },
+        {
+          "key": "41350373-fc6f-4dd9-b908-27805fff9155",
+          "doc_count": 800
+        },
+        {
+          "key": "f266a75c-3529-4868-8669-9f98822e033f",
+          "doc_count": 795
+        },
+        {
+          "key": "2b89de41-42bd-46c6-ab61-d386f855f7fb",
+          "doc_count": 790
+        },
+        {
+          "key": "b764863c-de93-4d7c-b0cf-1bb57166141d",
+          "doc_count": 765
+        },
+        {
+          "key": "2936c837-ad9f-40d8-bea0-58b2a635c637",
+          "doc_count": 747
+        },
+        {
+          "key": "781b461a-2788-4fa6-b3df-bbed9447f5a3",
+          "doc_count": 741
+        },
+        {
+          "key": "b027383d-6705-4d06-8514-db6ef16efdb5",
+          "doc_count": 736
+        },
+        {
+          "key": "3c919328-94fd-4657-b81d-21f4707253ed",
+          "doc_count": 697
+        },
+        {
+          "key": "0c9378fa-3ccb-4342-be2e-5b5080691dd1",
+          "doc_count": 691
+        },
+        {
+          "key": "a5fe6f13-2121-41dd-a036-dae15546ad91",
+          "doc_count": 661
+        },
+        {
+          "key": "c359c2e5-cd20-4057-9179-35a7a5b5da72",
+          "doc_count": 648
+        },
+        {
+          "key": "ad5c4ec7-ed56-4d3e-881a-963af217d334",
+          "doc_count": 627
+        },
+        {
+          "key": "c96ca51c-908e-41cc-ae10-ac1fb72ca3d9",
+          "doc_count": 624
+        },
+        {
+          "key": "fb4cc282-eba5-4156-b7c7-df41e0581b68",
+          "doc_count": 619
+        },
+        {
+          "key": "932e8ecc-fb16-4ce1-9863-e0e586e3ab34",
+          "doc_count": 610
+        },
+        {
+          "key": "6659b6dd-d487-4b72-b0c8-ae65942a6f15",
+          "doc_count": 594
+        },
+        {
+          "key": "2e03b83d-d2b9-4a8e-90b5-42b5b1301a92",
+          "doc_count": 587
+        },
+        {
+          "key": "4cdf5c2f-1a44-4fd5-bdd8-de08c8a660e2",
+          "doc_count": 566
+        },
+        {
+          "key": "e7bc6545-f14f-4fc4-9902-1aa38040f184",
+          "doc_count": 561
+        },
+        {
+          "key": "8456dc3d-99e2-407c-ab55-4746d382496b",
+          "doc_count": 552
+        },
+        {
+          "key": "aa977d4a-0dd6-4441-87d4-5efb60435a0b",
+          "doc_count": 544
+        },
+        {
+          "key": "539721d9-f5f8-489b-a816-abc28b2748e8",
+          "doc_count": 523
+        },
+        {
+          "key": "abb0a03c-4dcb-4f6f-a31d-55268f63d44c",
+          "doc_count": 515
+        },
+        {
+          "key": "27b2b46f-4cae-4ffa-870d-b17e51d627f2",
+          "doc_count": 504
+        },
+        {
+          "key": "2ee56f8c-db1d-43aa-bfb7-3fb2a19601df",
+          "doc_count": 500
+        },
+        {
+          "key": "1c8ec291-8067-4b48-848b-410c2c768420",
+          "doc_count": 470
+        },
+        {
+          "key": "f4f833ea-0abf-4059-948e-132c64dda1be",
+          "doc_count": 456
+        },
+        {
+          "key": "41e1a09b-bd55-4d20-a480-5d8187f7afca",
+          "doc_count": 450
+        },
+        {
+          "key": "e2a12ef3-cf03-4ce4-8aff-802ccf2aec1d",
+          "doc_count": 440
+        },
+        {
+          "key": "b7a79601-c07b-46d5-bd09-d4472b0d9431",
+          "doc_count": 427
+        },
+        {
+          "key": "f3a5ec1a-49dd-4a52-8bd8-67cacae7a7ac",
+          "doc_count": 426
+        },
+        {
+          "key": "4efa0623-a625-4949-aea4-7cb60a99b6f8",
+          "doc_count": 411
+        },
+        {
+          "key": "47e638be-2983-4d22-b05d-260dd5881e9c",
+          "doc_count": 409
+        },
+        {
+          "key": "8dd13cdf-1425-497d-a4ff-bb5dadfe21a8",
+          "doc_count": 403
+        },
+        {
+          "key": "6aca6f67-a2e9-440d-a503-9501db6e6f36",
+          "doc_count": 397
+        },
+        {
+          "key": "9aa11cc8-6c2d-4202-b30b-c8454338bbd2",
+          "doc_count": 394
+        },
+        {
+          "key": "1ae056ac-8834-43a8-ad44-d1148b6e075f",
+          "doc_count": 358
+        },
+        {
+          "key": "0df55e93-0fce-4ba6-a344-1d9918b60816",
+          "doc_count": 346
+        },
+        {
+          "key": "00df4fe2-0025-45ec-814a-36777155e077",
+          "doc_count": 328
+        },
+        {
+          "key": "f271128e-2e79-430b-81a4-a92ec7c969b8",
+          "doc_count": 326
+        },
+        {
+          "key": "4f5fc75f-f983-4ef8-9723-ba375615d926",
+          "doc_count": 324
+        },
+        {
+          "key": "314f66a9-2b8f-4085-b10c-0f083ce2f1eb",
+          "doc_count": 307
+        },
+        {
+          "key": "d3412433-4df9-4828-89e0-73956898f749",
+          "doc_count": 305
+        },
+        {
+          "key": "07c47dd3-a0a9-434a-b144-71c32996f278",
+          "doc_count": 304
+        },
+        {
+          "key": "3451a762-d117-430e-968c-dd747ed53887",
+          "doc_count": 298
+        },
+        {
+          "key": "85ae9fb4-de87-41ce-abb3-44fda2fb24a8",
+          "doc_count": 292
+        },
+        {
+          "key": "d0769c31-e4f1-42b1-a21f-cd6bf2257edb",
+          "doc_count": 291
+        },
+        {
+          "key": "d9d38b3f-5173-4051-98a6-2efad16fc8da",
+          "doc_count": 285
+        },
+        {
+          "key": "a7463c8a-27f0-485e-b794-fb78d94beda7",
+          "doc_count": 277
+        },
+        {
+          "key": "697b5707-b86f-43c5-a114-93a3fc602719",
+          "doc_count": 276
+        },
+        {
+          "key": "fd36e434-8c4d-4d97-a15d-e4d55f312d73",
+          "doc_count": 270
+        },
+        {
+          "key": "e27dc54d-8114-4927-b400-694caab9872e",
+          "doc_count": 261
+        },
+        {
+          "key": "71e55d91-4c0c-4a13-9421-c732348b0a47",
+          "doc_count": 253
+        },
+        {
+          "key": "639ae683-0a66-4a59-9c09-36304bf11424",
+          "doc_count": 245
+        },
+        {
+          "key": "a5d9992f-ebbb-457c-b56a-b6cd0429e2d6",
+          "doc_count": 245
+        },
+        {
+          "key": "b3d53973-5bac-432a-90d3-7956baa09c5d",
+          "doc_count": 237
+        },
+        {
+          "key": "57b1a2a3-78ab-4e69-a77e-a8fd4394ee5a",
+          "doc_count": 221
+        },
+        {
+          "key": "011880b9-7697-4626-946f-258a68f754cb",
+          "doc_count": 201
+        },
+        {
+          "key": "7fcdca8e-7469-480c-8516-cce4e24c37c9",
+          "doc_count": 193
+        },
+        {
+          "key": "433d3c37-8dde-42e4-a344-2cb6605c5da2",
+          "doc_count": 190
+        },
+        {
+          "key": "25e4ea2d-74ef-4251-b461-6ceb3c812bf1",
+          "doc_count": 187
+        },
+        {
+          "key": "03eac319-23c7-429e-9fa4-480640007d62",
+          "doc_count": 184
+        },
+        {
+          "key": "997c4dda-0465-40c0-af8d-67f8f90dea3b",
+          "doc_count": 182
+        },
+        {
+          "key": "e2c129bc-e45b-43d1-ab52-86e52093080b",
+          "doc_count": 175
+        },
+        {
+          "key": "67dfbfc8-bfc8-4a69-a63c-0918539e4dee",
+          "doc_count": 173
+        },
+        {
+          "key": "f3d1fbbb-93d5-432e-8808-ebc08c42ef6d",
+          "doc_count": 172
+        },
+        {
+          "key": "9b62118d-9b90-46b1-854d-06a5a9a22a90",
+          "doc_count": 171
+        },
+        {
+          "key": "9764480a-6e4a-4800-9bb7-b6fb73bccc50",
+          "doc_count": 169
+        },
+        {
+          "key": "1d14acd1-20ef-4a55-8206-f04c8a75ea3e",
+          "doc_count": 168
+        },
+        {
+          "key": "b761d317-a36e-4a05-a5f4-bd3e3963daf6",
+          "doc_count": 164
+        },
+        {
+          "key": "4c46db9d-74d7-4e45-9ed2-0da40ec6b44f",
+          "doc_count": 161
+        },
+        {
+          "key": "87fee729-2a4e-4d23-ad8a-5e03e1ab7c1a",
+          "doc_count": 161
+        },
+        {
+          "key": "e6b4d68a-59b5-4b74-a5ce-daadd930d3ca",
+          "doc_count": 159
+        },
+        {
+          "key": "c6e89321-fc23-4cba-ad79-be3e52edfb6d",
+          "doc_count": 144
+        },
+        {
+          "key": "c19c539d-2f8c-4a99-b956-15921ec345ed",
+          "doc_count": 138
+        },
+        {
+          "key": "b3f10d7b-6763-4f79-9789-f6abc68b9720",
+          "doc_count": 137
+        },
+        {
+          "key": "6acaebd6-e8d2-454a-8f50-e7a6734b8c79",
+          "doc_count": 136
+        },
+        {
+          "key": "4bf197cb-6fbc-4b22-82d0-849fffb5906e",
+          "doc_count": 134
+        },
+        {
+          "key": "07389fe4-c6dc-4e6c-87d2-345e2d183050",
+          "doc_count": 131
+        },
+        {
+          "key": "8a54c5fa-2900-4859-a2d6-1b7faedafac4",
+          "doc_count": 130
+        },
+        {
+          "key": "ec8f29eb-6d25-4a48-841c-49d6217761a4",
+          "doc_count": 129
+        },
+        {
+          "key": "fbac84f2-8db7-4af5-96b1-9d8885370c10",
+          "doc_count": 127
+        },
+        {
+          "key": "f8944362-0f02-4ccb-bbaf-3149b2de8e22",
+          "doc_count": 118
+        },
+        {
+          "key": "21ea1ef6-4a2a-4ff2-a18b-5c0f297fc1cf",
+          "doc_count": 108
+        },
+        {
+          "key": "b3d3a357-9fa6-453c-9f02-d86a1bbc762a",
+          "doc_count": 106
+        },
+        {
+          "key": "95773ebb-2f5f-43f0-a652-bfd8d5f4707a",
+          "doc_count": 105
+        },
+        {
+          "key": "bcbae485-1286-4452-bbc9-bcb38c6c3573",
+          "doc_count": 94
+        },
+        {
+          "key": "974f7564-a7fb-409a-bb67-35b7cafec327",
+          "doc_count": 84
+        },
+        {
+          "key": "ba4b4a05-f01f-4b16-b36a-83bf997a8722",
+          "doc_count": 84
+        },
+        {
+          "key": "94dd2cee-ed7d-4f98-894f-efafeac92b5b",
+          "doc_count": 82
+        },
+        {
+          "key": "4fecde59-9f59-44eb-ab6f-4a50b4ed85cf",
+          "doc_count": 76
+        },
+        {
+          "key": "2e746628-f895-4367-ae31-62e81e0b6b98",
+          "doc_count": 70
+        },
+        {
+          "key": "2148b4f7-a770-4bca-b276-da70ae948690",
+          "doc_count": 69
+        },
+        {
+          "key": "5302ea7f-1c6f-4fc9-8c20-97dd38c0c783",
+          "doc_count": 48
+        },
+        {
+          "key": "86b1f54d-ac01-4c5e-8ed8-09da2689c7a9",
+          "doc_count": 47
+        },
+        {
+          "key": "0e0d4dba-9c5d-4dbf-9ac8-09114c56ec03",
+          "doc_count": 44
+        },
+        {
+          "key": "17cea35c-721f-4d9b-b67f-d29250064d25",
+          "doc_count": 43
+        },
+        {
+          "key": "bc41afff-4d56-421e-bc87-45e18b4fe64a",
+          "doc_count": 43
+        },
+        {
+          "key": "473400bf-fe83-4bd6-9f69-c4608f4cdf4f",
+          "doc_count": 41
+        },
+        {
+          "key": "bdaa6842-3055-465e-82f6-da577e987cde",
+          "doc_count": 40
+        },
+        {
+          "key": "513dd822-f211-42c3-9af2-ee3c798cd1b8",
+          "doc_count": 36
+        },
+        {
+          "key": "6f6bf083-d27a-417d-9205-e5a70c2b7a0d",
+          "doc_count": 36
+        },
+        {
+          "key": "3617a6a3-d384-48de-948d-2d1e1c54e090",
+          "doc_count": 29
+        },
+        {
+          "key": "2c00d087-1df6-4744-807d-056be36eed0d",
+          "doc_count": 28
+        },
+        {
+          "key": "adae5c6c-72f3-4cd8-a00b-3ea71d516abc",
+          "doc_count": 27
+        },
+        {
+          "key": "1fc07b28-43f5-49d1-badf-63005e1c3e9a",
+          "doc_count": 26
+        },
+        {
+          "key": "2c84db50-bab1-40a6-a9ef-405f3ffcec7e",
+          "doc_count": 26
+        },
+        {
+          "key": "ab820732-0844-4323-ba14-c58c24f3fc7e",
+          "doc_count": 26
+        },
+        {
+          "key": "fb7db48e-1599-420e-8f10-1f20fe1c6aa3",
+          "doc_count": 24
+        },
+        {
+          "key": "656d1c9a-cbb7-4dde-ac24-62323af5b831",
+          "doc_count": 22
+        },
+        {
+          "key": "7400877a-13b8-423d-9074-5371a8234157",
+          "doc_count": 21
+        },
+        {
+          "key": "a4c4e0ee-38dd-47fd-9b06-ce4cc011e111",
+          "doc_count": 21
+        },
+        {
+          "key": "76aab8f5-69d4-4ce9-b0c9-837b64a2dd06",
+          "doc_count": 20
+        },
+        {
+          "key": "80daac2f-e496-4c65-b196-6be7a9c4c98e",
+          "doc_count": 20
+        },
+        {
+          "key": "cb4882a8-19d3-41a1-9373-c1a868b5ac9b",
+          "doc_count": 20
+        },
+        {
+          "key": "061dfaff-0c45-459e-ac56-738fe4cbe213",
+          "doc_count": 19
+        },
+        {
+          "key": "88271bd3-1985-4fa7-9e33-f82cc24dfad3",
+          "doc_count": 18
+        },
+        {
+          "key": "a8add96d-651c-488e-8ca3-ed3f85c7a117",
+          "doc_count": 18
+        },
+        {
+          "key": "4d9103e7-fe58-4dc5-9fa8-e739949fd3f3",
+          "doc_count": 17
+        },
+        {
+          "key": "62c35d43-f15c-451d-a8be-1b9c6928b8bd",
+          "doc_count": 17
+        },
+        {
+          "key": "f93c403b-d0f0-4be1-8a4b-ed9aa3b513e3",
+          "doc_count": 17
+        },
+        {
+          "key": "72059315-e131-42ba-b7c6-489415e297b9",
+          "doc_count": 16
+        },
+        {
+          "key": "879d475f-4b76-4d18-8cf6-a7e5a6d44926",
+          "doc_count": 15
+        },
+        {
+          "key": "90d6f994-d652-49d0-b6e6-924c65c4c079",
+          "doc_count": 12
+        },
+        {
+          "key": "b1c7a275-21f6-4b66-895d-d497359b34a1",
+          "doc_count": 11
+        },
+        {
+          "key": "c16e25c8-1e93-4571-881f-b757d3e48700",
+          "doc_count": 11
+        },
+        {
+          "key": "e1c7bc41-50a4-4723-b8b3-f970844ffb65",
+          "doc_count": 11
+        },
+        {
+          "key": "8f62e9b0-96e5-4d64-8008-b2b8692050db",
+          "doc_count": 10
+        },
+        {
+          "key": "a8cafd75-ca3b-42c6-8b8e-52aafa15753b",
+          "doc_count": 10
+        },
+        {
+          "key": "0c15e83e-79ee-4ee3-86e3-e5f98a51dc11",
+          "doc_count": 9
+        },
+        {
+          "key": "372d25cd-e4c6-4c58-8d3f-abe16887c805",
+          "doc_count": 9
+        },
+        {
+          "key": "5bd3bf29-b78d-4bf3-bbd7-bbfb4eaf36a1",
+          "doc_count": 9
+        },
+        {
+          "key": "a8d88237-2f62-4ad5-b1f7-ab13ace304df",
+          "doc_count": 9
+        },
+        {
+          "key": "5f681b65-9a7e-4b79-8a17-fc95cc26b837",
+          "doc_count": 6
+        },
+        {
+          "key": "6226705f-4867-464d-9fab-4e81ecee731f",
+          "doc_count": 6
+        },
+        {
+          "key": "73b2abe8-93ea-4343-bc37-35693035dea0",
+          "doc_count": 5
+        },
+        {
+          "key": "84006c59-fead-4b84-b3b5-cedf28f67ea9",
+          "doc_count": 5
+        },
+        {
+          "key": "bf1a26f8-6e89-4b95-b512-16430cccb6df",
+          "doc_count": 4
+        },
+        {
+          "key": "a3b54f92-360f-49a9-ae3b-9f5361549ef9",
+          "doc_count": 3
+        },
+        {
+          "key": "e5f377de-c662-4eec-a4d4-b41b18441f3a",
+          "doc_count": 3
+        },
+        {
+          "key": "3c6099e4-3a0c-44c8-942a-f44860aea12b",
+          "doc_count": 2
+        },
+        {
+          "key": "41800344-33b3-4201-b9d2-cabbbf564fbc",
+          "doc_count": 2
+        },
+        {
+          "key": "48e1b8c1-91aa-4b87-8ca0-de1f81232eaf",
+          "doc_count": 2
+        },
+        {
+          "key": "53feaa83-e3b6-4ad3-8597-293b153e7548",
+          "doc_count": 2
+        },
+        {
+          "key": "a73b61c5-812c-453b-b12b-5c65929e947a",
+          "doc_count": 2
+        },
+        {
+          "key": "abf5b4f3-ed39-4bb9-acd6-9ee50acac0ad",
+          "doc_count": 2
+        },
+        {
+          "key": "c2dcb184-6c90-4aa3-9ebb-33b2d53837b9",
+          "doc_count": 2
+        },
+        {
+          "key": "c7883ffb-d381-4748-9694-e5abdaa46dbc",
+          "doc_count": 2
+        },
+        {
+          "key": "d07e7b8a-2222-477f-a7f3-f098bbfdaf54",
+          "doc_count": 2
+        },
+        {
+          "key": "de67ccab-7d04-43b9-8083-81e45f628505",
+          "doc_count": 2
+        },
+        {
+          "key": "0395f3c4-0277-43b6-a36d-e07720588790",
+          "doc_count": 1
+        },
+        {
+          "key": "0da18fe6-2e2a-43fc-9d2a-ffb2cefc05c0",
+          "doc_count": 1
+        },
+        {
+          "key": "237d30ca-7675-4840-b4fd-96771fabf518",
+          "doc_count": 1
+        },
+        {
+          "key": "53064db5-a272-46f9-85d2-d1b78e9a3293",
+          "doc_count": 1
+        },
+        {
+          "key": "54ae6783-dbb5-403a-b0e6-11a3b07d491a",
+          "doc_count": 1
+        },
+        {
+          "key": "74ba1d92-d9a5-486e-8e52-bb44d51e1788",
+          "doc_count": 1
+        },
+        {
+          "key": "8a9e3b42-e6e8-4485-b304-3cbf6d709a6c",
+          "doc_count": 1
+        },
+        {
+          "key": "a9bb4417-af3e-46e7-a2e0-167d61b49d10",
+          "doc_count": 1
+        }
+      ]
+    },
+    "max_dm": {
+      "value": 1674657431736,
+      "value_as_string": "2023-01-25T14:37:11.736Z"
+    }
+  }
+}

--- a/__tests__/mock/search-abd76409580ff86956e1a3c9d04aab6d.json
+++ b/__tests__/mock/search-abd76409580ff86956e1a3c9d04aab6d.json
@@ -1,0 +1,3600 @@
+{
+  "timed_out": false,
+  "_shards": {
+    "total": 48,
+    "successful": 48,
+    "failed": 0
+  },
+  "hits": {
+    "total": 50776115,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "000992e7-6519-4fae-ab02-d990234e3752",
+        "_score": null,
+        "_routing": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_parent": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_source": {
+          "uuid": "000992e7-6519-4fae-ab02-d990234e3752"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "003b2287-1f6c-4897-bd59-2e58f6022739",
+        "_score": null,
+        "_routing": "4bd36c58-e935-4c2b-82f5-21a83b359557",
+        "_parent": "4bd36c58-e935-4c2b-82f5-21a83b359557",
+        "_source": {
+          "uuid": "003b2287-1f6c-4897-bd59-2e58f6022739"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "007977cb-7a8d-49bd-8450-45800bec15af",
+        "_score": null,
+        "_routing": "599f5853-b35c-43eb-90d3-5143ebbf9d21",
+        "_parent": "599f5853-b35c-43eb-90d3-5143ebbf9d21",
+        "_source": {
+          "uuid": "007977cb-7a8d-49bd-8450-45800bec15af"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0089b314-b365-4244-9f93-8cec2f29be98",
+        "_score": null,
+        "_routing": "9a059a20-1927-4ea0-be70-7b7c5d3a430d",
+        "_parent": "9a059a20-1927-4ea0-be70-7b7c5d3a430d",
+        "_source": {
+          "uuid": "0089b314-b365-4244-9f93-8cec2f29be98"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00b06c30-4949-415b-9a5f-342fe99abca2",
+        "_score": null,
+        "_routing": "95d7ee27-3a69-4f29-b7f9-4e0c6123264a",
+        "_parent": "95d7ee27-3a69-4f29-b7f9-4e0c6123264a",
+        "_source": {
+          "uuid": "00b06c30-4949-415b-9a5f-342fe99abca2"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00bda874-9f9d-48d4-b582-c5bcac4a08b5",
+        "_score": null,
+        "_routing": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_parent": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_source": {
+          "uuid": "00bda874-9f9d-48d4-b582-c5bcac4a08b5"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00c7c963-860b-4b70-a55e-571bfef030fd",
+        "_score": null,
+        "_routing": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_parent": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_source": {
+          "uuid": "00c7c963-860b-4b70-a55e-571bfef030fd"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00edde43-e608-4e84-862c-f9cb9af9b21a",
+        "_score": null,
+        "_routing": "7c5f4753-8a79-42df-b87f-5501f1f1676b",
+        "_parent": "7c5f4753-8a79-42df-b87f-5501f1f1676b",
+        "_source": {
+          "uuid": "00edde43-e608-4e84-862c-f9cb9af9b21a"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "00f8d929-db1c-4478-bef2-ef0babf1d576",
+        "_score": null,
+        "_routing": "53d4865e-8083-4884-8393-08277937e408",
+        "_parent": "53d4865e-8083-4884-8393-08277937e408",
+        "_source": {
+          "uuid": "00f8d929-db1c-4478-bef2-ef0babf1d576"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0119c9f7-8706-4114-8a26-6d25ccf3964b",
+        "_score": null,
+        "_routing": "3a00b94a-ab08-411b-b781-0df20f0a9379",
+        "_parent": "3a00b94a-ab08-411b-b781-0df20f0a9379",
+        "_source": {
+          "uuid": "0119c9f7-8706-4114-8a26-6d25ccf3964b"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "011a1397-b055-4090-b6fd-9bd644eb02bf",
+        "_score": null,
+        "_routing": "9a059a20-1927-4ea0-be70-7b7c5d3a430d",
+        "_parent": "9a059a20-1927-4ea0-be70-7b7c5d3a430d",
+        "_source": {
+          "uuid": "011a1397-b055-4090-b6fd-9bd644eb02bf"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "014d1271-6165-44d0-b4f0-f493358c0acb",
+        "_score": null,
+        "_routing": "dab39256-4cb9-4c5e-b3fd-db398fa8848b",
+        "_parent": "dab39256-4cb9-4c5e-b3fd-db398fa8848b",
+        "_source": {
+          "uuid": "014d1271-6165-44d0-b4f0-f493358c0acb"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0151eb78-720f-4af2-b2c0-395a1000b7d1",
+        "_score": null,
+        "_routing": "1ed2b128-b2f6-4784-984b-69ec5aae9c24",
+        "_parent": "1ed2b128-b2f6-4784-984b-69ec5aae9c24",
+        "_source": {
+          "uuid": "0151eb78-720f-4af2-b2c0-395a1000b7d1"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "019841c5-ec17-4a80-b92d-eeb0680682aa",
+        "_score": null,
+        "_routing": "888f773c-2655-4806-abdd-370f12716543",
+        "_parent": "888f773c-2655-4806-abdd-370f12716543",
+        "_source": {
+          "uuid": "019841c5-ec17-4a80-b92d-eeb0680682aa"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "01a34b4c-74fd-4a33-8bbf-79d3a25622f8",
+        "_score": null,
+        "_routing": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_parent": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_source": {
+          "uuid": "01a34b4c-74fd-4a33-8bbf-79d3a25622f8"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "01c35b3c-f014-4344-abf4-9cc03511ec5e",
+        "_score": null,
+        "_routing": "2ab6d7a9-4730-43f4-96ea-b7e943fe9640",
+        "_parent": "2ab6d7a9-4730-43f4-96ea-b7e943fe9640",
+        "_source": {
+          "uuid": "01c35b3c-f014-4344-abf4-9cc03511ec5e"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "01cf1085-c956-4597-a958-5adf29298ebf",
+        "_score": null,
+        "_routing": "95d7ee27-3a69-4f29-b7f9-4e0c6123264a",
+        "_parent": "95d7ee27-3a69-4f29-b7f9-4e0c6123264a",
+        "_source": {
+          "uuid": "01cf1085-c956-4597-a958-5adf29298ebf"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "01f4f3e3-632f-41bb-acbd-db138d35e03b",
+        "_score": null,
+        "_routing": "eb4640cf-4771-4dfe-89db-36372badd257",
+        "_parent": "eb4640cf-4771-4dfe-89db-36372badd257",
+        "_source": {
+          "uuid": "01f4f3e3-632f-41bb-acbd-db138d35e03b"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "02104779-3467-4775-8540-fad66ae1eabd",
+        "_score": null,
+        "_routing": "9d0077e2-574d-461c-8b67-d6e01221e81b",
+        "_parent": "9d0077e2-574d-461c-8b67-d6e01221e81b",
+        "_source": {
+          "uuid": "02104779-3467-4775-8540-fad66ae1eabd"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0251dfab-5668-4e01-bc77-88703b3dee95",
+        "_score": null,
+        "_routing": "fb6942c0-4577-4009-8c90-460b8d6650cc",
+        "_parent": "fb6942c0-4577-4009-8c90-460b8d6650cc",
+        "_source": {
+          "uuid": "0251dfab-5668-4e01-bc77-88703b3dee95"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "02546cb5-5284-497f-9aaa-66917f309fcf",
+        "_score": null,
+        "_routing": "836320a3-b003-490d-8712-3ca2375f8f21",
+        "_parent": "836320a3-b003-490d-8712-3ca2375f8f21",
+        "_source": {
+          "uuid": "02546cb5-5284-497f-9aaa-66917f309fcf"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "02607712-5923-4eff-91db-512db1fe6a84",
+        "_score": null,
+        "_routing": "460a8a37-121d-434d-ab97-1a79b30dafa8",
+        "_parent": "460a8a37-121d-434d-ab97-1a79b30dafa8",
+        "_source": {
+          "uuid": "02607712-5923-4eff-91db-512db1fe6a84"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0284bdfc-ec3b-4248-8b2d-99d348b81f1a",
+        "_score": null,
+        "_routing": "421db2c2-f39f-44e2-bb03-316efa33f66c",
+        "_parent": "421db2c2-f39f-44e2-bb03-316efa33f66c",
+        "_source": {
+          "uuid": "0284bdfc-ec3b-4248-8b2d-99d348b81f1a"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "028e3db3-a575-4261-a8b4-78c963300ac0",
+        "_score": null,
+        "_routing": "c4bbcb7a-5942-4148-98cf-4d802476b082",
+        "_parent": "c4bbcb7a-5942-4148-98cf-4d802476b082",
+        "_source": {
+          "uuid": "028e3db3-a575-4261-a8b4-78c963300ac0"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "028e4c83-dbb0-4e17-b2e0-9b7788fe6d50",
+        "_score": null,
+        "_routing": "edcc76a9-ccd0-477b-97e3-3ef3b5156e06",
+        "_parent": "edcc76a9-ccd0-477b-97e3-3ef3b5156e06",
+        "_source": {
+          "uuid": "028e4c83-dbb0-4e17-b2e0-9b7788fe6d50"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "028f8982-e28d-4f38-af58-6211f4ea8316",
+        "_score": null,
+        "_routing": "a3a90786-7774-4654-819b-79c991a5b485",
+        "_parent": "a3a90786-7774-4654-819b-79c991a5b485",
+        "_source": {
+          "uuid": "028f8982-e28d-4f38-af58-6211f4ea8316"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "02985101-ec9a-433e-823a-8258b04193cf",
+        "_score": null,
+        "_routing": "14f651aa-2ed6-4d4d-9566-39a5edc5b4e9",
+        "_parent": "14f651aa-2ed6-4d4d-9566-39a5edc5b4e9",
+        "_source": {
+          "uuid": "02985101-ec9a-433e-823a-8258b04193cf"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "02fbb412-8f3e-40e2-afa2-c3a340c10cd8",
+        "_score": null,
+        "_routing": "58a5591f-5979-4023-abf9-b1fd8211e76b",
+        "_parent": "58a5591f-5979-4023-abf9-b1fd8211e76b",
+        "_source": {
+          "uuid": "02fbb412-8f3e-40e2-afa2-c3a340c10cd8"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "03301337-9f1e-430b-af3a-f322cdc1ac8d",
+        "_score": null,
+        "_routing": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_parent": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_source": {
+          "uuid": "03301337-9f1e-430b-af3a-f322cdc1ac8d"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "03510df7-b380-46b1-8709-314d676550eb",
+        "_score": null,
+        "_routing": "83255e81-1685-4a79-840b-0ef82235ab8c",
+        "_parent": "83255e81-1685-4a79-840b-0ef82235ab8c",
+        "_source": {
+          "uuid": "03510df7-b380-46b1-8709-314d676550eb"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "036dfeb3-b1fc-4253-9350-4596a3663d5f",
+        "_score": null,
+        "_routing": "be5a87f5-76b0-41d8-8ce5-8c626b1e28ea",
+        "_parent": "be5a87f5-76b0-41d8-8ce5-8c626b1e28ea",
+        "_source": {
+          "uuid": "036dfeb3-b1fc-4253-9350-4596a3663d5f"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "038054f3-e87a-4e66-8501-bb4daf29ac90",
+        "_score": null,
+        "_routing": "e02cd9f0-ac0a-4a0a-9bf0-f97237e48397",
+        "_parent": "e02cd9f0-ac0a-4a0a-9bf0-f97237e48397",
+        "_source": {
+          "uuid": "038054f3-e87a-4e66-8501-bb4daf29ac90"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "03a3fbfe-1cbb-49f4-b4ce-c4560dc0a172",
+        "_score": null,
+        "_routing": "cc3ca348-444f-4787-8043-7dda29898b55",
+        "_parent": "cc3ca348-444f-4787-8043-7dda29898b55",
+        "_source": {
+          "uuid": "03a3fbfe-1cbb-49f4-b4ce-c4560dc0a172"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "03ad0e7a-2511-497f-88dd-1fde388b25a5",
+        "_score": null,
+        "_routing": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_parent": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_source": {
+          "uuid": "03ad0e7a-2511-497f-88dd-1fde388b25a5"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "03d39c02-9c79-4171-8d75-913246f746c1",
+        "_score": null,
+        "_routing": "fb6942c0-4577-4009-8c90-460b8d6650cc",
+        "_parent": "fb6942c0-4577-4009-8c90-460b8d6650cc",
+        "_source": {
+          "uuid": "03d39c02-9c79-4171-8d75-913246f746c1"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "03f0ffe5-caf3-4e6a-b68a-0f908ccd3097",
+        "_score": null,
+        "_routing": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_parent": "b1b1fd47-79c7-4e4d-8f87-0c27856049eb",
+        "_source": {
+          "uuid": "03f0ffe5-caf3-4e6a-b68a-0f908ccd3097"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0465e85c-4917-4f2e-977f-12b34ce5a129",
+        "_score": null,
+        "_routing": "7b3187a7-ce18-4bbb-973f-8a75c182e277",
+        "_parent": "7b3187a7-ce18-4bbb-973f-8a75c182e277",
+        "_source": {
+          "uuid": "0465e85c-4917-4f2e-977f-12b34ce5a129"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "04f2d4b4-9ce1-4ed9-8ccd-a4a9dae8f171",
+        "_score": null,
+        "_routing": "12035a01-47eb-4e72-b3f3-ed6fc465eea0",
+        "_parent": "12035a01-47eb-4e72-b3f3-ed6fc465eea0",
+        "_source": {
+          "uuid": "04f2d4b4-9ce1-4ed9-8ccd-a4a9dae8f171"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "050f03d4-c0aa-45e0-9dda-5b916cd2f7f6",
+        "_score": null,
+        "_routing": "4bd36c58-e935-4c2b-82f5-21a83b359557",
+        "_parent": "4bd36c58-e935-4c2b-82f5-21a83b359557",
+        "_source": {
+          "uuid": "050f03d4-c0aa-45e0-9dda-5b916cd2f7f6"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0534d962-8909-4157-a991-b439cad77e86",
+        "_score": null,
+        "_routing": "a5b19037-3b2f-4e02-bbc3-f31b17ddcd2b",
+        "_parent": "a5b19037-3b2f-4e02-bbc3-f31b17ddcd2b",
+        "_source": {
+          "uuid": "0534d962-8909-4157-a991-b439cad77e86"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "053c36a3-edd7-49a5-bcfc-8df1f8911a1c",
+        "_score": null,
+        "_routing": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_parent": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_source": {
+          "uuid": "053c36a3-edd7-49a5-bcfc-8df1f8911a1c"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0566dc2a-e1b0-408f-ab15-8eaca19addef",
+        "_score": null,
+        "_routing": "1a2ae543-db57-4d52-91e7-7879917cbf85",
+        "_parent": "1a2ae543-db57-4d52-91e7-7879917cbf85",
+        "_source": {
+          "uuid": "0566dc2a-e1b0-408f-ab15-8eaca19addef"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "056e8574-f500-4612-8f36-d88c3c30cfe7",
+        "_score": null,
+        "_routing": "5ea146c5-318e-4854-bc3e-c214d22b9dc4",
+        "_parent": "5ea146c5-318e-4854-bc3e-c214d22b9dc4",
+        "_source": {
+          "uuid": "056e8574-f500-4612-8f36-d88c3c30cfe7"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "057683ab-1d35-4784-ab59-63edcfdef852",
+        "_score": null,
+        "_routing": "dbfd579d-4170-42ae-ab17-a1f850b07dd1",
+        "_parent": "dbfd579d-4170-42ae-ab17-a1f850b07dd1",
+        "_source": {
+          "uuid": "057683ab-1d35-4784-ab59-63edcfdef852"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "05f2a0a7-ec10-4ce1-a1fa-78eddb7273c3",
+        "_score": null,
+        "_routing": "d0dbaa27-0eb1-4173-b4fd-a5d047d0c62c",
+        "_parent": "d0dbaa27-0eb1-4173-b4fd-a5d047d0c62c",
+        "_source": {
+          "uuid": "05f2a0a7-ec10-4ce1-a1fa-78eddb7273c3"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "079635a6-4d3b-4973-8044-11c40f499ddd",
+        "_score": null,
+        "_routing": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_parent": "5c19ad9f-f75e-4b0d-8c25-93975b9223b5",
+        "_source": {
+          "uuid": "079635a6-4d3b-4973-8044-11c40f499ddd"
+        },
+        "sort": [
+          0.90909094
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "07b24646-1ef8-4d40-98f9-b1e0eb595335",
+        "_score": null,
+        "_routing": "e90ff1f8-f7c2-464b-b680-ccf3b0f2f032",
+        "_parent": "e90ff1f8-f7c2-464b-b680-ccf3b0f2f032",
+        "_source": {
+          "uuid": "07b24646-1ef8-4d40-98f9-b1e0eb595335"
+        },
+        "sort": [
+          0.90909094
+        ]
+      }
+    ]
+  },
+  "aggregations": {
+    "rs": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+          "doc_count": 5576909
+        },
+        {
+          "key": "a6eee223-cf3b-4079-8bb2-b77dad8cae9d",
+          "doc_count": 5135183
+        },
+        {
+          "key": "fabcdc12-9d29-4bd2-912b-176e71818144",
+          "doc_count": 4596608
+        },
+        {
+          "key": "3c9420c9-c4a8-47dc-88b7-b5638ca5e716",
+          "doc_count": 3801254
+        },
+        {
+          "key": "36d35b23-113e-4633-90ec-19d265a3b5f6",
+          "doc_count": 3537264
+        },
+        {
+          "key": "7450a9e3-ef95-4f9e-8260-09b498d2c5e6",
+          "doc_count": 1372219
+        },
+        {
+          "key": "5386d272-06c6-4027-b5d5-d588c2afe5e5",
+          "doc_count": 928757
+        },
+        {
+          "key": "e6ccc2bd-9451-4802-8a51-8640d9f09793",
+          "doc_count": 819632
+        },
+        {
+          "key": "0583609b-202f-40d0-8021-4c019635d4c9",
+          "doc_count": 707693
+        },
+        {
+          "key": "953b0329-c3e4-4816-a038-7afbd2bb2547",
+          "doc_count": 698464
+        },
+        {
+          "key": "710a8a54-783c-41aa-ad9a-05544cdb4c55",
+          "doc_count": 609014
+        },
+        {
+          "key": "205fa34c-2fcb-4492-b992-972b18560f6f",
+          "doc_count": 608981
+        },
+        {
+          "key": "65536dcd-7bb2-44e5-af3f-4a13f08e53d0",
+          "doc_count": 543365
+        },
+        {
+          "key": "285a4be0-5cfe-4d4f-9c8b-b0f0f3571079",
+          "doc_count": 489273
+        },
+        {
+          "key": "271a9ce9-c6d3-4b63-a722-cb0adc48863f",
+          "doc_count": 468247
+        },
+        {
+          "key": "b6ec6203-09db-4d6e-8cba-ee4bebd2934c",
+          "doc_count": 417978
+        },
+        {
+          "key": "4e3043a6-d48a-4a35-b5fb-f67d50cbc158",
+          "doc_count": 408346
+        },
+        {
+          "key": "e60301d9-9b40-483f-92de-065769b9d3dd",
+          "doc_count": 380640
+        },
+        {
+          "key": "a4e6033a-d1eb-46d3-869d-7c0328f09aa7",
+          "doc_count": 343844
+        },
+        {
+          "key": "9e5aede6-bee5-4a3d-a255-513771b20035",
+          "doc_count": 316956
+        },
+        {
+          "key": "4523e216-ee13-4b15-a3f7-a6fd56431604",
+          "doc_count": 306235
+        },
+        {
+          "key": "137ed4cd-5172-45a5-acdb-8e1de9a64e32",
+          "doc_count": 299965
+        },
+        {
+          "key": "2d7910d9-7f63-4bde-918a-9e0265f1c245",
+          "doc_count": 294161
+        },
+        {
+          "key": "9151bc4c-8505-4b22-a16b-9dbf337535fa",
+          "doc_count": 294161
+        },
+        {
+          "key": "53091d18-f173-4fc0-b9d9-20a1494e2466",
+          "doc_count": 291399
+        },
+        {
+          "key": "beab5209-9628-4d4d-851e-2bc9bb1a0105",
+          "doc_count": 276792
+        },
+        {
+          "key": "3027c437-cdb3-4072-9410-5a46ec3b1fd5",
+          "doc_count": 275401
+        },
+        {
+          "key": "a2b36fdf-50bc-44ef-a6a4-ca6dc1dc148a",
+          "doc_count": 253201
+        },
+        {
+          "key": "72d4c3c7-3413-4588-a803-e1a63e0d7c6c",
+          "doc_count": 252250
+        },
+        {
+          "key": "ded380b5-1ba2-4089-8e0c-0aa1b4140785",
+          "doc_count": 245491
+        },
+        {
+          "key": "d53132e6-7997-4850-8607-4fec5a3f9c3f",
+          "doc_count": 241932
+        },
+        {
+          "key": "207b6c64-7b58-4d6a-816d-bc759c27eafc",
+          "doc_count": 241497
+        },
+        {
+          "key": "f1cf8457-237e-487a-9d13-5de7d81b9de4",
+          "doc_count": 238178
+        },
+        {
+          "key": "da67ebd9-52de-444d-b114-e23c03111ac6",
+          "doc_count": 220286
+        },
+        {
+          "key": "e2def7e2-1455-4856-9823-6d3738417d24",
+          "doc_count": 214256
+        },
+        {
+          "key": "f062cb7d-c03e-4762-b1c4-49118fee1a56",
+          "doc_count": 195002
+        },
+        {
+          "key": "db6c3db9-1e6d-4def-af29-33aa0339bfa9",
+          "doc_count": 192851
+        },
+        {
+          "key": "70abba3e-5f2a-4276-87f3-261706e24453",
+          "doc_count": 192778
+        },
+        {
+          "key": "40250f4d-7aa6-4fcc-ac38-2868fa4846bd",
+          "doc_count": 187242
+        },
+        {
+          "key": "e881a3e2-f7ba-43c8-ae9a-11fcbfd741bb",
+          "doc_count": 185371
+        },
+        {
+          "key": "0fd6e726-6828-4f62-ba8d-6ec316fe0b52",
+          "doc_count": 180782
+        },
+        {
+          "key": "01017cef-5065-48b2-9db8-3e428971d702",
+          "doc_count": 172853
+        },
+        {
+          "key": "58402fe3-37c1-4d15-9e07-0ff1c4c9fb11",
+          "doc_count": 171183
+        },
+        {
+          "key": "703b5bdc-4581-47e3-b4b6-e6f32d0eec54",
+          "doc_count": 170392
+        },
+        {
+          "key": "d4ea4495-c4b2-4d05-b524-163423f17cd7",
+          "doc_count": 168645
+        },
+        {
+          "key": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "doc_count": 166689
+        },
+        {
+          "key": "6c6f34ed-58a4-4ba2-b9c7-34524f79a349",
+          "doc_count": 163095
+        },
+        {
+          "key": "0dab1fc7-ca99-456b-9985-76edbac003e0",
+          "doc_count": 161405
+        },
+        {
+          "key": "59efaf7d-60b5-4295-abb3-27ba42eb5231",
+          "doc_count": 157291
+        },
+        {
+          "key": "1527b668-b797-42be-94d3-0058e1393e94",
+          "doc_count": 147919
+        },
+        {
+          "key": "8057906f-17c9-4e25-b173-4e7fb938078b",
+          "doc_count": 141503
+        },
+        {
+          "key": "48b4b812-c52e-4f47-9327-e761f6fc2e28",
+          "doc_count": 138133
+        },
+        {
+          "key": "6258d160-a7aa-4937-bce3-3538eebd374f",
+          "doc_count": 137717
+        },
+        {
+          "key": "cdb6ec43-935e-4da2-8798-71e40ca6d12a",
+          "doc_count": 134508
+        },
+        {
+          "key": "2c00c297-9ebd-498a-b701-d3ebde4b49f3",
+          "doc_count": 133295
+        },
+        {
+          "key": "96662fa9-ff60-495b-912a-284f3b98ed72",
+          "doc_count": 126289
+        },
+        {
+          "key": "cf42855e-a54a-4488-a79e-beac086ba1d4",
+          "doc_count": 123875
+        },
+        {
+          "key": "df22987f-d20d-41db-b8eb-8b5f5fca6df0",
+          "doc_count": 121441
+        },
+        {
+          "key": "beecd160-a96c-46fc-bdce-7dcb7024d473",
+          "doc_count": 120720
+        },
+        {
+          "key": "b531ea59-025d-4c29-9d23-99ae75bcd55f",
+          "doc_count": 118459
+        },
+        {
+          "key": "d2217bca-3a93-4407-bb56-087afa000cbc",
+          "doc_count": 107269
+        },
+        {
+          "key": "aca26f37-3ec8-4e9e-b927-50b4944a0096",
+          "doc_count": 102740
+        },
+        {
+          "key": "ba042ffa-8175-4a47-8eb1-08b4d6319ccf",
+          "doc_count": 102728
+        },
+        {
+          "key": "35c43eda-1f4a-4713-bb69-e3fbe1bf792f",
+          "doc_count": 102464
+        },
+        {
+          "key": "31c140bc-e6f1-4acc-beaf-b825cf288ad9",
+          "doc_count": 100206
+        },
+        {
+          "key": "215eeaf0-0a88-409e-a75d-aec98b7c41eb",
+          "doc_count": 100041
+        },
+        {
+          "key": "6cc31636-c3e5-4887-bbee-2e56621771c4",
+          "doc_count": 96684
+        },
+        {
+          "key": "f84d528a-7d08-467e-b532-ace707316f1d",
+          "doc_count": 95826
+        },
+        {
+          "key": "71bf994a-3af5-484d-983b-b146aa1512d1",
+          "doc_count": 93283
+        },
+        {
+          "key": "0bc60df1-a162-4173-9a73-c51e09031843",
+          "doc_count": 92054
+        },
+        {
+          "key": "ccd17772-d220-4088-8fa3-df3729f14df4",
+          "doc_count": 91822
+        },
+        {
+          "key": "995cc7f1-69c3-4317-ab77-28fd48f1e535",
+          "doc_count": 91120
+        },
+        {
+          "key": "02fceae6-c71c-4db9-8b2f-e235ced6624a",
+          "doc_count": 90591
+        },
+        {
+          "key": "f00b6a32-5337-406b-a850-17f5d78470ad",
+          "doc_count": 90018
+        },
+        {
+          "key": "61a1c0ce-8327-4e2a-9766-449751a49b7a",
+          "doc_count": 89789
+        },
+        {
+          "key": "781fd581-7b93-471e-a025-413e4bcd8491",
+          "doc_count": 89195
+        },
+        {
+          "key": "c481fbc6-4bd7-4c50-8537-ba1993d4eb88",
+          "doc_count": 87485
+        },
+        {
+          "key": "d78d13a7-3852-4244-ba34-86ef5765fa99",
+          "doc_count": 86774
+        },
+        {
+          "key": "26f7cbde-fbcb-4500-80a9-a99daa0ead9d",
+          "doc_count": 85734
+        },
+        {
+          "key": "7644703a-ce24-4f7b-b800-66ddf8812f86",
+          "doc_count": 85277
+        },
+        {
+          "key": "46c11153-2154-495d-89d2-7cdef6425cdb",
+          "doc_count": 85172
+        },
+        {
+          "key": "ee9d38ef-c1db-44de-b8f2-62acb7049370",
+          "doc_count": 82837
+        },
+        {
+          "key": "8b0c1f4b-9de7-4521-98c2-983e0bfd33c7",
+          "doc_count": 81586
+        },
+        {
+          "key": "c569e530-7322-40b8-9b66-1e0ed96fefcb",
+          "doc_count": 81456
+        },
+        {
+          "key": "cf641fbf-fa31-481a-993b-9204f2ee1884",
+          "doc_count": 80738
+        },
+        {
+          "key": "b667cef4-96fe-42e8-a9fa-6298aa80bb14",
+          "doc_count": 80713
+        },
+        {
+          "key": "83ad8494-136b-485a-87d4-8ce01dd6a8de",
+          "doc_count": 79509
+        },
+        {
+          "key": "b9ab58cf-785e-44a7-a873-1966e14a6715",
+          "doc_count": 79181
+        },
+        {
+          "key": "d7540872-1c53-48ac-a617-2d0739eadcbd",
+          "doc_count": 79113
+        },
+        {
+          "key": "ddef79ec-043c-4027-9876-c4a298feff6d",
+          "doc_count": 78656
+        },
+        {
+          "key": "b2b294ed-1742-4479-b0c8-a8891fccd7eb",
+          "doc_count": 77886
+        },
+        {
+          "key": "5e29dbcc-ce45-4f05-9bb0-212baffa8932",
+          "doc_count": 77700
+        },
+        {
+          "key": "264c48ec-8636-451f-a7e0-74131bc6f84c",
+          "doc_count": 77595
+        },
+        {
+          "key": "ba54ba45-caac-4708-a389-ac94642976f8",
+          "doc_count": 77466
+        },
+        {
+          "key": "20360fae-574a-4d63-b9f6-47b1cc07fd22",
+          "doc_count": 76898
+        },
+        {
+          "key": "ff89320d-e232-4edd-9cdd-4b6acc672ad3",
+          "doc_count": 76125
+        },
+        {
+          "key": "ec6cef7d-d8aa-43b4-b352-908f172a378e",
+          "doc_count": 75488
+        },
+        {
+          "key": "5835f642-2560-4e3e-9c25-741a12cc3fe8",
+          "doc_count": 75384
+        },
+        {
+          "key": "8dc14464-57b3-423e-8cb0-950ab8f36b6f",
+          "doc_count": 74455
+        },
+        {
+          "key": "7c1a1d78-aeaa-4501-87e1-83eceb8ca8ea",
+          "doc_count": 74122
+        },
+        {
+          "key": "dd232f5c-7f53-48ec-9bb7-7205702c3dc8",
+          "doc_count": 72999
+        },
+        {
+          "key": "844875a9-9927-48a5-90b4-76c5f227f145",
+          "doc_count": 70991
+        },
+        {
+          "key": "e5f57bb0-07ec-4405-90b6-dc89647a1cb5",
+          "doc_count": 70947
+        },
+        {
+          "key": "5a660a44-afdd-45ac-8c48-1a6c570ce0b5",
+          "doc_count": 70928
+        },
+        {
+          "key": "026a4216-957a-4efb-acf1-506499ec474e",
+          "doc_count": 70918
+        },
+        {
+          "key": "76fd34da-4892-4821-858d-98fe9e28ba8b",
+          "doc_count": 68987
+        },
+        {
+          "key": "e48bb88f-9594-461e-8230-522a3a5572fe",
+          "doc_count": 68353
+        },
+        {
+          "key": "4830ffb8-669a-4717-bec8-2f2374f52120",
+          "doc_count": 68346
+        },
+        {
+          "key": "1bb33d2d-0714-4fc9-968e-b66bab1cf3d3",
+          "doc_count": 66199
+        },
+        {
+          "key": "7809d96b-7edf-4ef7-9f12-59967e9a01a6",
+          "doc_count": 65733
+        },
+        {
+          "key": "767c78b4-1c16-4cac-ad04-66333ac5a7f2",
+          "doc_count": 65505
+        },
+        {
+          "key": "8ec76c75-a673-4682-bfde-00a18bc12794",
+          "doc_count": 65365
+        },
+        {
+          "key": "d82fa49b-915e-4aa8-acc6-51df3d431884",
+          "doc_count": 64222
+        },
+        {
+          "key": "5ab348ab-439a-4697-925c-d6abe0c09b92",
+          "doc_count": 63025
+        },
+        {
+          "key": "b26fa674-6300-4ea0-a8e3-fc0ce32b5226",
+          "doc_count": 62139
+        },
+        {
+          "key": "fc7b78d7-82d4-4648-8185-87a0ba209c20",
+          "doc_count": 60909
+        },
+        {
+          "key": "9ef17d55-0498-44cf-9da4-dde3e3acb570",
+          "doc_count": 60669
+        },
+        {
+          "key": "ea12da76-1b2e-4944-8709-1de3af1c65e2",
+          "doc_count": 58835
+        },
+        {
+          "key": "e5b0c46a-5eb6-4b94-9d4c-fb1000f534b0",
+          "doc_count": 58665
+        },
+        {
+          "key": "09a3fcf2-55a1-488f-aa42-f103bdce0536",
+          "doc_count": 58250
+        },
+        {
+          "key": "5626f61a-822e-4692-b432-51f53d053e4d",
+          "doc_count": 58071
+        },
+        {
+          "key": "e1b03497-7632-4ba4-a9e0-dd230d06638c",
+          "doc_count": 56827
+        },
+        {
+          "key": "ec4acc26-ff1b-4131-a1df-a950fe31bb0e",
+          "doc_count": 56622
+        },
+        {
+          "key": "cb33cf97-2a7b-4b45-9b73-5aca568332a6",
+          "doc_count": 55502
+        },
+        {
+          "key": "f0174bc9-0cca-450e-a941-655d80040139",
+          "doc_count": 54865
+        },
+        {
+          "key": "8f3b62fb-56ec-49e8-9f8f-bb257348291f",
+          "doc_count": 54453
+        },
+        {
+          "key": "9ff03c57-ba5a-4127-9439-4bf3e838c4df",
+          "doc_count": 54392
+        },
+        {
+          "key": "471835cc-feb6-4d05-a8d1-62ce71399326",
+          "doc_count": 54131
+        },
+        {
+          "key": "9b725e43-93c9-423b-adf8-a11d08a83d13",
+          "doc_count": 53487
+        },
+        {
+          "key": "1f2b44b8-8556-4d6e-8247-4611689551cf",
+          "doc_count": 53268
+        },
+        {
+          "key": "1701a75c-5a57-48c3-84c2-234a53f4c3e2",
+          "doc_count": 52027
+        },
+        {
+          "key": "b88033dd-5dbb-4377-b374-2210f32ece16",
+          "doc_count": 50850
+        },
+        {
+          "key": "fdf7bb59-aad2-4f10-879f-6c0e7d3baa64",
+          "doc_count": 50838
+        },
+        {
+          "key": "e36691ec-c4f8-4bec-b331-b48ffa82ff49",
+          "doc_count": 50713
+        },
+        {
+          "key": "62254613-2696-4834-8c58-5c465f70df56",
+          "doc_count": 50672
+        },
+        {
+          "key": "72b6dbee-bc4d-4e35-a32c-8df0422771fb",
+          "doc_count": 50672
+        },
+        {
+          "key": "005ac06a-3d9a-46ad-ac3c-062aaa5b7059",
+          "doc_count": 50655
+        },
+        {
+          "key": "667a12e7-c6d8-4de0-933f-ce2f07cb7a92",
+          "doc_count": 50445
+        },
+        {
+          "key": "14f8f83f-7a0c-458c-b6d5-6da7dc8eaa0a",
+          "doc_count": 49996
+        },
+        {
+          "key": "b5f4526b-f4fb-4d90-8ce0-975e0cda8ff6",
+          "doc_count": 49612
+        },
+        {
+          "key": "910eadc8-8131-428c-b28a-91d0e2890f1d",
+          "doc_count": 49530
+        },
+        {
+          "key": "40987883-03cf-494a-a5cf-7c77c7aadb79",
+          "doc_count": 49396
+        },
+        {
+          "key": "2ec3b31e-c86b-4ce9-b265-77c8c3f9643c",
+          "doc_count": 49335
+        },
+        {
+          "key": "3998ec8d-4aae-46db-9370-179c19b69356",
+          "doc_count": 48835
+        },
+        {
+          "key": "15aa4812-aad2-4b26-a1d8-d4f8d79e6163",
+          "doc_count": 48468
+        },
+        {
+          "key": "b688c17c-3761-4ccd-a42f-88219f5fcff4",
+          "doc_count": 48321
+        },
+        {
+          "key": "e34cf41b-196c-4199-85d5-4d2ca5954b09",
+          "doc_count": 48249
+        },
+        {
+          "key": "ef77ec72-6537-41ab-a418-17f9a58e6e73",
+          "doc_count": 48030
+        },
+        {
+          "key": "e6eba8cd-fa2c-4ba2-bec0-6841e7633695",
+          "doc_count": 47925
+        },
+        {
+          "key": "f31a5f98-efd3-476a-9627-de3add582acd",
+          "doc_count": 47407
+        },
+        {
+          "key": "a16dc8d8-ff4a-4d62-a684-2937fb292b8d",
+          "doc_count": 46459
+        },
+        {
+          "key": "645bcd10-a74f-4207-a375-0254b954b7ad",
+          "doc_count": 45833
+        },
+        {
+          "key": "7f497d81-4c7e-4e06-b166-a459968b14e3",
+          "doc_count": 45585
+        },
+        {
+          "key": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "doc_count": 45123
+        },
+        {
+          "key": "7a31ab80-1cc0-4456-9dea-61c2e9031a6f",
+          "doc_count": 45032
+        },
+        {
+          "key": "120d557c-c5be-474d-98f0-1ba00ae16b40",
+          "doc_count": 43931
+        },
+        {
+          "key": "be31dfd1-c721-4697-8ee0-f7043c070810",
+          "doc_count": 43179
+        },
+        {
+          "key": "2cf2843f-567c-45c1-a328-cc210af76fc1",
+          "doc_count": 42486
+        },
+        {
+          "key": "e794b292-4a94-471e-ab84-6aaef1fea1b3",
+          "doc_count": 41979
+        },
+        {
+          "key": "a69decc7-76ba-496a-a66e-f91049c02cf0",
+          "doc_count": 40857
+        },
+        {
+          "key": "e7ac8c4a-64bd-491b-b764-232de9b4bfe5",
+          "doc_count": 40732
+        },
+        {
+          "key": "8f689b8b-5b65-4638-9555-f2a5d237a624",
+          "doc_count": 40574
+        },
+        {
+          "key": "d0d1c390-e662-4980-97e3-ae0039a06de8",
+          "doc_count": 40469
+        },
+        {
+          "key": "6b5e29d3-b462-44d8-ba38-d68af5088067",
+          "doc_count": 40079
+        },
+        {
+          "key": "46374ee7-7c70-48d8-bf16-2e6c1626565e",
+          "doc_count": 39597
+        },
+        {
+          "key": "0f19f6d6-79a4-434e-ba0b-a4f49f334078",
+          "doc_count": 39118
+        },
+        {
+          "key": "8e58cd34-3cbb-46f7-9c25-527251881a6f",
+          "doc_count": 38676
+        },
+        {
+          "key": "c55ac6d0-180d-41be-829a-e82898c5ca54",
+          "doc_count": 37628
+        },
+        {
+          "key": "8fc08919-1137-42e4-9fa5-9e64f1e5757b",
+          "doc_count": 36996
+        },
+        {
+          "key": "d2c71720-e156-4943-8182-0a7bbe477a37",
+          "doc_count": 36771
+        },
+        {
+          "key": "32d433aa-9e2b-4ff9-bc55-5c3e30112207",
+          "doc_count": 35816
+        },
+        {
+          "key": "9e66257f-21a9-491a-ac23-06b7b62ceeb7",
+          "doc_count": 35406
+        },
+        {
+          "key": "8445ab25-ff89-44b0-90f8-bf0790f50afc",
+          "doc_count": 35403
+        },
+        {
+          "key": "23a47a5f-2ac1-4f81-acd3-21d5b82ed22a",
+          "doc_count": 35280
+        },
+        {
+          "key": "589ad4bd-a0aa-4949-bb92-0533ba7edaf2",
+          "doc_count": 35108
+        },
+        {
+          "key": "3056112e-97c6-4d0d-b6c2-3c0a9adaca24",
+          "doc_count": 34921
+        },
+        {
+          "key": "e39f6dee-f2cf-4eff-afc9-4600cafe660c",
+          "doc_count": 34553
+        },
+        {
+          "key": "99b04c9f-908e-42bd-92bc-41aa94b72949",
+          "doc_count": 33449
+        },
+        {
+          "key": "aced32f9-e511-48c7-8e9e-b625777bdf7f",
+          "doc_count": 33118
+        },
+        {
+          "key": "e4ff51ba-5007-4c40-9a86-e8c6f4db77b7",
+          "doc_count": 33097
+        },
+        {
+          "key": "0266a3f4-872b-4d21-a6b4-5c9818d8742b",
+          "doc_count": 32818
+        },
+        {
+          "key": "9a06cc34-be24-4ebf-b599-cbb1d4b8ac7b",
+          "doc_count": 31844
+        },
+        {
+          "key": "c5b7dae8-b483-4742-9954-d7f9226daa34",
+          "doc_count": 31809
+        },
+        {
+          "key": "ced8c9bc-e8b5-49e7-860a-289fc913860c",
+          "doc_count": 31549
+        },
+        {
+          "key": "6b565194-9707-42da-8052-9f9cf5f9aa60",
+          "doc_count": 31217
+        },
+        {
+          "key": "e0e37702-32af-405b-b652-ee54b5bb94e2",
+          "doc_count": 30656
+        },
+        {
+          "key": "5e893602-84ca-4c8c-bac1-99111c777582",
+          "doc_count": 30515
+        },
+        {
+          "key": "244ee82a-438c-4e77-a2ce-4e2af9ddbe4d",
+          "doc_count": 30171
+        },
+        {
+          "key": "774a153b-e556-47f6-95d1-bab49e61cc58",
+          "doc_count": 29572
+        },
+        {
+          "key": "654e092c-edbd-456c-8cce-2bcbdff71a04",
+          "doc_count": 29162
+        },
+        {
+          "key": "9cecfba6-6501-401c-9043-e95ba70164f3",
+          "doc_count": 29159
+        },
+        {
+          "key": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "doc_count": 28729
+        },
+        {
+          "key": "678dc436-3370-4992-a361-761dab8c3fda",
+          "doc_count": 28624
+        },
+        {
+          "key": "9b27c2f1-8b0a-4482-8424-8a9bb3bf0cf9",
+          "doc_count": 28520
+        },
+        {
+          "key": "570dcca6-a84f-43aa-8053-1a2ac60d9ead",
+          "doc_count": 28478
+        },
+        {
+          "key": "4f8c3594-d7b2-4985-8dd9-1ae77f9187d4",
+          "doc_count": 28155
+        },
+        {
+          "key": "e27f0218-47e0-41bc-9086-9d9169096e90",
+          "doc_count": 28062
+        },
+        {
+          "key": "e185415c-15c4-4612-89f3-27cfebbca0d9",
+          "doc_count": 27982
+        },
+        {
+          "key": "0220907a-0463-4ae0-8a0b-77f5e80fff40",
+          "doc_count": 27865
+        },
+        {
+          "key": "d29b9265-07e6-4e73-8f72-fc42d3d83fb1",
+          "doc_count": 27711
+        },
+        {
+          "key": "4db72a36-c08b-4a6b-8c68-ab45ebb0efce",
+          "doc_count": 27680
+        },
+        {
+          "key": "6bb853ab-e8ea-43b1-bd83-47318fc4c345",
+          "doc_count": 27614
+        },
+        {
+          "key": "37213da3-a1c7-4644-917e-8f8440e1c4d4",
+          "doc_count": 27344
+        },
+        {
+          "key": "181352ea-3598-4f32-b919-c8f6097f4c65",
+          "doc_count": 27092
+        },
+        {
+          "key": "a7020dbf-35fc-46e8-a441-c0a6b957193c",
+          "doc_count": 26701
+        },
+        {
+          "key": "7fbf76b1-6bd6-4217-a5bc-1d89e45f6a68",
+          "doc_count": 26605
+        },
+        {
+          "key": "e1e0f2cc-a50c-40d4-9031-c2d90a826247",
+          "doc_count": 26601
+        },
+        {
+          "key": "51b958bb-9d5f-48d7-9a97-e372c0c747c3",
+          "doc_count": 26514
+        },
+        {
+          "key": "1a44dfa0-6a54-4584-8c57-d98669d7f033",
+          "doc_count": 26323
+        },
+        {
+          "key": "025a810b-28f6-427d-b342-16fdf5f74f4b",
+          "doc_count": 26260
+        },
+        {
+          "key": "7ad07cff-f782-4ddf-b780-3a757cdb77e0",
+          "doc_count": 26149
+        },
+        {
+          "key": "d598446c-2b25-4d5d-a983-99be53001203",
+          "doc_count": 26125
+        },
+        {
+          "key": "1bfc0147-2df1-4488-bcf7-d140e24dda51",
+          "doc_count": 25733
+        },
+        {
+          "key": "dfd53a42-8f63-4040-93a5-3f1347ce7686",
+          "doc_count": 25569
+        },
+        {
+          "key": "f1a78c0f-449c-45fa-9472-0b92cc2a58da",
+          "doc_count": 24997
+        },
+        {
+          "key": "1c729855-f3dd-439d-b326-54d62f57b0fd",
+          "doc_count": 24922
+        },
+        {
+          "key": "364a24d9-d4a8-4e0b-8e50-07b90f844548",
+          "doc_count": 24529
+        },
+        {
+          "key": "6b2c3ca9-69ad-4316-a2d1-33399e9f547e",
+          "doc_count": 24481
+        },
+        {
+          "key": "518518b7-9e85-42ea-b419-2d23a3ef546a",
+          "doc_count": 24109
+        },
+        {
+          "key": "ef59f7cc-ed42-45fc-9abc-5edfb2c8caec",
+          "doc_count": 23979
+        },
+        {
+          "key": "fccc3c1d-d9df-4ffd-b7e1-1b9eb11f95b1",
+          "doc_count": 23820
+        },
+        {
+          "key": "531537fc-6349-4a20-ae42-540d61797086",
+          "doc_count": 23767
+        },
+        {
+          "key": "7e4aacd3-0a24-49ab-b019-518b7069b682",
+          "doc_count": 23576
+        },
+        {
+          "key": "04d9b721-259c-4d6b-b48f-2e23edf66c9f",
+          "doc_count": 23409
+        },
+        {
+          "key": "7110b8ba-0ead-4666-8279-e30f53e343d0",
+          "doc_count": 23286
+        },
+        {
+          "key": "c49bc91d-0a50-497b-8b17-d77808745cf9",
+          "doc_count": 23045
+        },
+        {
+          "key": "45544aa4-8762-4bf0-bfc6-890d08dc6ead",
+          "doc_count": 22907
+        },
+        {
+          "key": "2941b767-e90b-41b9-9627-6e589e0c0c85",
+          "doc_count": 22552
+        },
+        {
+          "key": "042dbdba-a449-4291-8777-577a5a4045de",
+          "doc_count": 22203
+        },
+        {
+          "key": "21b563bc-70c2-46d5-bce8-2489db2db3d8",
+          "doc_count": 21645
+        },
+        {
+          "key": "1e054b9b-0193-4ff3-b623-9264cf982d4d",
+          "doc_count": 21052
+        },
+        {
+          "key": "5aef068f-efd3-4851-a623-f542e97350cd",
+          "doc_count": 20465
+        },
+        {
+          "key": "e7016bd5-cb10-45b9-8959-0f5750f7a5db",
+          "doc_count": 20384
+        },
+        {
+          "key": "b000920c-6f7d-49d3-9d0f-2bb630d2e01a",
+          "doc_count": 20310
+        },
+        {
+          "key": "3f508496-c860-4701-93e4-84e940c8395e",
+          "doc_count": 20172
+        },
+        {
+          "key": "98ece30d-bf85-4122-b872-7786031b457f",
+          "doc_count": 19756
+        },
+        {
+          "key": "77b762ba-7cda-4617-97d7-e78df7f6dfab",
+          "doc_count": 19665
+        },
+        {
+          "key": "9e1958fb-1dc4-4375-ae35-67ba7f9c7afe",
+          "doc_count": 19660
+        },
+        {
+          "key": "48f5d475-7381-4d06-88eb-119796b9d189",
+          "doc_count": 19451
+        },
+        {
+          "key": "f630e3ea-697f-404a-8683-b86712c26c43",
+          "doc_count": 19168
+        },
+        {
+          "key": "e9b69a0a-497d-4201-b114-51519a4dfef9",
+          "doc_count": 19118
+        },
+        {
+          "key": "d100843b-d592-4024-8d15-fb1d8e218acd",
+          "doc_count": 19101
+        },
+        {
+          "key": "4ef6540c-e6cf-4678-bc43-b57435354de0",
+          "doc_count": 19067
+        },
+        {
+          "key": "1b6bb28e-e443-4cd3-910a-c6c43849c2cd",
+          "doc_count": 18944
+        },
+        {
+          "key": "a2a17035-1e6c-46df-9178-a610df825336",
+          "doc_count": 18851
+        },
+        {
+          "key": "1f5a1b81-e361-4d65-ab1c-6fb7e30c9910",
+          "doc_count": 18565
+        },
+        {
+          "key": "8e5fffb5-0b22-472d-8386-de291d17d513",
+          "doc_count": 18376
+        },
+        {
+          "key": "cb65cf5e-07b8-4d53-a91a-7dce9b8ccf80",
+          "doc_count": 18304
+        },
+        {
+          "key": "50cfe20a-9100-4710-89f9-a97bc3aa53d7",
+          "doc_count": 18060
+        },
+        {
+          "key": "92dd8c8e-c048-4f0a-9b5d-2ee627d2f553",
+          "doc_count": 17946
+        },
+        {
+          "key": "65007e62-740c-4302-ba20-260fe68da291",
+          "doc_count": 17883
+        },
+        {
+          "key": "79488fda-8310-42cd-b98e-8c3c2dd7d415",
+          "doc_count": 17834
+        },
+        {
+          "key": "c9dad611-5e60-4456-934e-75b0e0842ddd",
+          "doc_count": 17782
+        },
+        {
+          "key": "437826f3-69f9-43d9-b3c3-c0de0e26cd88",
+          "doc_count": 17715
+        },
+        {
+          "key": "bf9066a2-2c5f-4cf2-821a-1a68b4df5b1b",
+          "doc_count": 17648
+        },
+        {
+          "key": "aac5fd7f-8043-4aa8-811f-e50de70d96f3",
+          "doc_count": 17478
+        },
+        {
+          "key": "f33e9494-7b3c-4ac6-a735-59693b5a9638",
+          "doc_count": 17427
+        },
+        {
+          "key": "821c1855-6817-40ee-8732-7f472d238513",
+          "doc_count": 17079
+        },
+        {
+          "key": "a062eb42-d5c6-4332-8c88-64b4ac1af892",
+          "doc_count": 17036
+        },
+        {
+          "key": "2b45c778-b10c-496b-b8cb-1e414da59ccf",
+          "doc_count": 16711
+        },
+        {
+          "key": "c3134980-bf5c-49b8-a289-790d45f02c86",
+          "doc_count": 16504
+        },
+        {
+          "key": "7ae4d15d-62e2-459b-842a-446f921b9d3f",
+          "doc_count": 16477
+        },
+        {
+          "key": "4fed055b-3c46-4ec4-b76d-84d43df9258b",
+          "doc_count": 16341
+        },
+        {
+          "key": "8295ea14-c4fd-499b-bc68-2907ed36badc",
+          "doc_count": 16217
+        },
+        {
+          "key": "c5eeb223-0515-423a-a51a-151426c8f60d",
+          "doc_count": 16149
+        },
+        {
+          "key": "b30a7dd2-d974-4073-bdd0-cb4ea5402bae",
+          "doc_count": 15961
+        },
+        {
+          "key": "1e798b2d-7f97-49b0-a864-79c968af91d3",
+          "doc_count": 15664
+        },
+        {
+          "key": "53af19e1-9cb3-4834-8974-62adc640491c",
+          "doc_count": 15560
+        },
+        {
+          "key": "ad4e4ea0-2ac9-4030-b4bd-bf4206e79bcc",
+          "doc_count": 15339
+        },
+        {
+          "key": "6ae7221e-2085-46cf-9ad0-353269e95bc8",
+          "doc_count": 15175
+        },
+        {
+          "key": "cd177f63-761b-44f6-866e-ee19d2ac134e",
+          "doc_count": 14855
+        },
+        {
+          "key": "0038ce2e-43bb-4f70-8dd6-dca34efd3fca",
+          "doc_count": 14808
+        },
+        {
+          "key": "50b0bbe4-f075-4427-8dfc-fcc469dd3e78",
+          "doc_count": 14583
+        },
+        {
+          "key": "92e4e092-6dcb-46bc-85a0-dea8310aba45",
+          "doc_count": 14534
+        },
+        {
+          "key": "837d99c6-3045-4ba3-8951-643ddb3d6676",
+          "doc_count": 14434
+        },
+        {
+          "key": "bbf5f8ed-f33f-40ba-9d0d-1c24dfec4193",
+          "doc_count": 13613
+        },
+        {
+          "key": "a4378725-7967-47bc-aada-0220e02e1f96",
+          "doc_count": 13552
+        },
+        {
+          "key": "c9bff84f-8de4-43e6-b195-f515f187a68a",
+          "doc_count": 13487
+        },
+        {
+          "key": "662b1aa5-9c19-4eb9-9766-1da78a117456",
+          "doc_count": 13461
+        },
+        {
+          "key": "e3c0918d-ec6e-4ecd-a1db-15ec6880dade",
+          "doc_count": 13426
+        },
+        {
+          "key": "5a9ae910-9e4b-488b-af8e-88074fabc3a4",
+          "doc_count": 13374
+        },
+        {
+          "key": "e23109b4-e143-437c-b329-3dff7cb35488",
+          "doc_count": 13082
+        },
+        {
+          "key": "87017793-00dc-4f5d-b95b-09e7d17327cc",
+          "doc_count": 12983
+        },
+        {
+          "key": "341611f4-8b65-4655-b244-9be91a1109cd",
+          "doc_count": 12978
+        },
+        {
+          "key": "c3f05887-ffa9-44c4-b1af-e38fea5557bf",
+          "doc_count": 12961
+        },
+        {
+          "key": "e4b33221-1e2c-405c-ac02-a39d93f9a69b",
+          "doc_count": 12914
+        },
+        {
+          "key": "bd7cfd55-bf55-46fc-878d-e6e11f574ccd",
+          "doc_count": 12632
+        },
+        {
+          "key": "13510466-6232-4313-9e46-ea197b82750c",
+          "doc_count": 12631
+        },
+        {
+          "key": "86b2bfc9-ca99-4250-b93a-f86f3777236d",
+          "doc_count": 12457
+        },
+        {
+          "key": "91c5eec8-0cdc-4be2-9a99-a15ae5ec3edc",
+          "doc_count": 12373
+        },
+        {
+          "key": "063825dc-b8c3-4962-aea4-9994bcc09bc8",
+          "doc_count": 12238
+        },
+        {
+          "key": "139f2c47-4051-4c44-b95a-45fd20b1a8b9",
+          "doc_count": 12151
+        },
+        {
+          "key": "3c367a2d-eec0-4ef1-b3bc-4cbebb320c5a",
+          "doc_count": 11895
+        },
+        {
+          "key": "b5e5c781-765f-4981-af2a-c19c250e2cf0",
+          "doc_count": 11662
+        },
+        {
+          "key": "93e97f6c-0ab6-41a7-9b58-7e230a80ec1e",
+          "doc_count": 11634
+        },
+        {
+          "key": "2532cbd0-2752-4211-b249-4a9811a280f2",
+          "doc_count": 11614
+        },
+        {
+          "key": "04fe30b4-c1e5-4482-addb-67a4c2cd39ef",
+          "doc_count": 11602
+        },
+        {
+          "key": "cd46dc32-5e36-414b-a8d7-dea9df1f9106",
+          "doc_count": 11272
+        },
+        {
+          "key": "4d89070b-5dea-4a12-8a09-3f65ba33dba1",
+          "doc_count": 10956
+        },
+        {
+          "key": "1ad40bde-8a2a-46bb-9252-0cdc53df5683",
+          "doc_count": 10874
+        },
+        {
+          "key": "3ac8f738-bc3e-43e4-8358-00a32594954d",
+          "doc_count": 10763
+        },
+        {
+          "key": "5082e6c8-8f5b-4bf6-a930-e3e6de7bf6fb",
+          "doc_count": 10677
+        },
+        {
+          "key": "f89ada44-88df-46f0-bc61-cc46d9c84673",
+          "doc_count": 10668
+        },
+        {
+          "key": "3e86e072-2597-4849-87d5-565afe40f988",
+          "doc_count": 10594
+        },
+        {
+          "key": "6d09cfc1-a17c-4067-b1a0-557b8e5334ea",
+          "doc_count": 10542
+        },
+        {
+          "key": "ab4b6a2b-a90a-44ce-95a1-2c44c911fcc6",
+          "doc_count": 10504
+        },
+        {
+          "key": "a2a7754b-2346-496d-b681-eb754ef32b9e",
+          "doc_count": 10384
+        },
+        {
+          "key": "12018be6-3795-43a3-a073-a2b9d60c0af3",
+          "doc_count": 10183
+        },
+        {
+          "key": "bfa3c276-a3a9-48cd-8d4a-4ac42f4fe10a",
+          "doc_count": 10134
+        },
+        {
+          "key": "06c35934-1b75-4196-838d-29d509951bf9",
+          "doc_count": 10044
+        },
+        {
+          "key": "81dc7cdb-66be-4683-ae79-068a784378b1",
+          "doc_count": 10033
+        },
+        {
+          "key": "c94a06a5-df24-4546-adba-4f7940661826",
+          "doc_count": 9963
+        },
+        {
+          "key": "7cc1fb18-45c1-499f-8476-682daa14a4a3",
+          "doc_count": 9890
+        },
+        {
+          "key": "79aa7602-a963-44f3-82dd-e141a387adb8",
+          "doc_count": 9861
+        },
+        {
+          "key": "15e04168-22cc-4283-9042-247ab053c7ca",
+          "doc_count": 9804
+        },
+        {
+          "key": "dddf9315-7819-4289-b587-6be72e4894d2",
+          "doc_count": 9761
+        },
+        {
+          "key": "252a0a12-f114-4fb5-aa9a-678c523d6dcd",
+          "doc_count": 9535
+        },
+        {
+          "key": "e701ecce-f9ab-445f-afcb-24f279efbc9c",
+          "doc_count": 9475
+        },
+        {
+          "key": "3c6f1ea5-f2e7-4203-9cfe-74ec2fb1b035",
+          "doc_count": 9426
+        },
+        {
+          "key": "c004cf67-eafc-49f9-99bd-b8198e2234ed",
+          "doc_count": 9370
+        },
+        {
+          "key": "abe3903e-ceba-4864-aa5d-bd985c70fa21",
+          "doc_count": 9205
+        },
+        {
+          "key": "3a5b5c9b-b241-4883-904a-b167a7edb41a",
+          "doc_count": 9155
+        },
+        {
+          "key": "90739622-5232-4048-8121-9af9ec69604f",
+          "doc_count": 9154
+        },
+        {
+          "key": "5889291d-9105-4740-a30f-2d9d2469c264",
+          "doc_count": 9100
+        },
+        {
+          "key": "f0599190-e5b7-42ed-bec8-810905f50c34",
+          "doc_count": 8900
+        },
+        {
+          "key": "ec248223-f277-4c02-b1fa-60056b5a689a",
+          "doc_count": 8865
+        },
+        {
+          "key": "9d2a4189-6048-46e9-bac4-e5ef566334bb",
+          "doc_count": 8857
+        },
+        {
+          "key": "dbb2acdc-a808-4deb-9dc2-542d70368a3f",
+          "doc_count": 8797
+        },
+        {
+          "key": "0272afc1-36ee-4899-8c28-dde9d8a211d9",
+          "doc_count": 8788
+        },
+        {
+          "key": "414a5bf5-061e-4e47-8410-0f76a04f7d1d",
+          "doc_count": 8715
+        },
+        {
+          "key": "5ffc8bc6-e366-4157-b1ba-00859f1048a4",
+          "doc_count": 8701
+        },
+        {
+          "key": "f08c31ea-0e90-4cc1-b471-dfd0584ae7cf",
+          "doc_count": 8470
+        },
+        {
+          "key": "9756b9a4-c070-4359-8a07-2383b09d0d04",
+          "doc_count": 8361
+        },
+        {
+          "key": "bdf65f9c-a730-4083-bd8d-a2def3037637",
+          "doc_count": 8345
+        },
+        {
+          "key": "ef04e127-bb7d-4bf0-82d3-767d43108f81",
+          "doc_count": 8289
+        },
+        {
+          "key": "e7db896a-c95b-4a18-99a4-866fff238ca5",
+          "doc_count": 8046
+        },
+        {
+          "key": "331b6d1b-842e-4c63-aa23-75ef275d8a9f",
+          "doc_count": 8010
+        },
+        {
+          "key": "81d00e23-92aa-45d7-b289-5cf045ddfbf4",
+          "doc_count": 7958
+        },
+        {
+          "key": "cfe5c00e-bec3-4120-a8eb-62c5353f3e80",
+          "doc_count": 7903
+        },
+        {
+          "key": "cf60ed8a-2c79-4b85-a259-15a8e216dae4",
+          "doc_count": 7897
+        },
+        {
+          "key": "665f34ed-bfa3-4b25-a838-3b97f4dce586",
+          "doc_count": 7829
+        },
+        {
+          "key": "7e44229a-e8fa-4570-ada1-0cd7843a66d7",
+          "doc_count": 7747
+        },
+        {
+          "key": "6539877e-82dc-485c-ad3d-038f383d5431",
+          "doc_count": 7721
+        },
+        {
+          "key": "eaa5f19e-ff6f-4d09-8b55-4a6810e77a6c",
+          "doc_count": 7647
+        },
+        {
+          "key": "4960f30c-c1c7-490e-966a-61ad02969e38",
+          "doc_count": 7577
+        },
+        {
+          "key": "540e18dc-09aa-4790-8b47-8d18ae86fabc",
+          "doc_count": 7567
+        },
+        {
+          "key": "364b1f8d-5975-48d9-bba1-c97ab172986c",
+          "doc_count": 7551
+        },
+        {
+          "key": "1ffce054-8e3e-4209-9ff4-c26fa6c24c2f",
+          "doc_count": 7491
+        },
+        {
+          "key": "e77108de-88dd-4931-8085-0ea59d7ca4ee",
+          "doc_count": 7378
+        },
+        {
+          "key": "3501e0a6-1420-45b9-bbf9-77349e79e9d7",
+          "doc_count": 7307
+        },
+        {
+          "key": "c7ae0ade-c23e-4fe6-a3d4-79bd973374c2",
+          "doc_count": 7276
+        },
+        {
+          "key": "75e3aff5-b3d0-45c3-835c-5ffde192c63f",
+          "doc_count": 7170
+        },
+        {
+          "key": "5fd5a403-8e94-4865-8c77-ee92cb4a95f2",
+          "doc_count": 7150
+        },
+        {
+          "key": "4f436daa-01d5-4be6-b5c3-fdd255677536",
+          "doc_count": 6994
+        },
+        {
+          "key": "e80fe2bb-547d-4e98-84ce-01176379e3a8",
+          "doc_count": 6843
+        },
+        {
+          "key": "482990c6-da88-4d99-8cf4-ccd27ee82f44",
+          "doc_count": 6836
+        },
+        {
+          "key": "d6c6e57a-4ccb-4707-b87d-c91d01d6aa42",
+          "doc_count": 6814
+        },
+        {
+          "key": "d840624f-42d5-40d9-9daa-2260f85feb54",
+          "doc_count": 6806
+        },
+        {
+          "key": "a83151ae-e1db-4166-9dde-438f6544dca9",
+          "doc_count": 6732
+        },
+        {
+          "key": "ea9de87b-7231-4a05-809f-4b658ea4173d",
+          "doc_count": 6722
+        },
+        {
+          "key": "cd7b335e-6f5c-4259-ba45-5e334a719464",
+          "doc_count": 6667
+        },
+        {
+          "key": "73236de8-c2cc-458c-b0c3-743c7b57db3a",
+          "doc_count": 6634
+        },
+        {
+          "key": "b00cf471-6bbe-4f94-846e-288900398b65",
+          "doc_count": 6626
+        },
+        {
+          "key": "69037495-438d-4dba-bf0f-4878073766f1",
+          "doc_count": 6610
+        },
+        {
+          "key": "b4bcc255-4acf-4966-b9b3-af9dd4e458d1",
+          "doc_count": 6576
+        },
+        {
+          "key": "5ab5f23d-292e-4bea-ba06-12db0f8a8c86",
+          "doc_count": 6530
+        },
+        {
+          "key": "7ed2ce52-26e5-4847-9563-955ae3e97455",
+          "doc_count": 6526
+        },
+        {
+          "key": "c38b867b-05f3-4733-802e-d8d2d3324f84",
+          "doc_count": 6400
+        },
+        {
+          "key": "959c0dc4-fcf3-477e-af63-c00a005dbc0a",
+          "doc_count": 6384
+        },
+        {
+          "key": "beb74dc2-22ea-49e4-b1e3-bedb8e06e8f2",
+          "doc_count": 6365
+        },
+        {
+          "key": "b1ed65bb-f27e-4695-a0f5-7ca52fc0c3e6",
+          "doc_count": 6275
+        },
+        {
+          "key": "2c662e9e-cdc6-4bbf-93a5-1566ceca1af3",
+          "doc_count": 6268
+        },
+        {
+          "key": "5486b66d-2082-433d-9223-bd789ebca29c",
+          "doc_count": 6172
+        },
+        {
+          "key": "d5a1b706-c624-43df-afcf-9cea7094e75b",
+          "doc_count": 6164
+        },
+        {
+          "key": "e5cb850f-de98-45ce-9872-95262732809f",
+          "doc_count": 6015
+        },
+        {
+          "key": "8eabbc48-2b30-419d-bd8f-eece9185eca1",
+          "doc_count": 6001
+        },
+        {
+          "key": "55e724a4-336a-4315-99e7-01bf0c94f222",
+          "doc_count": 5924
+        },
+        {
+          "key": "1eca069b-09e0-406d-9625-cb9c52e1e5cc",
+          "doc_count": 5917
+        },
+        {
+          "key": "954ec5e0-4fcd-414d-8ad2-46b4b75cfc74",
+          "doc_count": 5902
+        },
+        {
+          "key": "d5c32031-231f-4213-b0f1-2dc4bbf711a0",
+          "doc_count": 5891
+        },
+        {
+          "key": "22436fe4-5049-4266-9849-335dd3f161aa",
+          "doc_count": 5863
+        },
+        {
+          "key": "c1122f57-9ab9-4552-9393-7d56b0bbe852",
+          "doc_count": 5797
+        },
+        {
+          "key": "8bcb95b2-ab5c-4368-8ead-14588eeb9c98",
+          "doc_count": 5756
+        },
+        {
+          "key": "6f470382-cb0b-4634-a796-2248bfa97fdc",
+          "doc_count": 5696
+        },
+        {
+          "key": "44328ef7-fc7f-4ff6-b51b-ed9049857e11",
+          "doc_count": 5680
+        },
+        {
+          "key": "9368e302-f8e7-4714-aed4-db2faa861e5c",
+          "doc_count": 5642
+        },
+        {
+          "key": "67893f3c-c409-41c6-a8f2-47956739a911",
+          "doc_count": 5541
+        },
+        {
+          "key": "ec135c9b-ff89-4f28-aa18-88b16d932d94",
+          "doc_count": 5441
+        },
+        {
+          "key": "5af1bae4-35c0-4ab7-9d08-08bbe22ca003",
+          "doc_count": 5428
+        },
+        {
+          "key": "347579f4-d44a-4c8e-a578-09c2a8132573",
+          "doc_count": 5391
+        },
+        {
+          "key": "a5fdee09-34c4-48bc-99ff-a503c93a9d7e",
+          "doc_count": 5227
+        },
+        {
+          "key": "66427724-af1d-43f8-bc00-cb744e55ac2c",
+          "doc_count": 5222
+        },
+        {
+          "key": "fd14095c-3658-4e00-8cec-729a89459e92",
+          "doc_count": 5138
+        },
+        {
+          "key": "7cea906d-ae65-420c-a6f7-a9a3ad64fb93",
+          "doc_count": 5121
+        },
+        {
+          "key": "589ee0cf-456c-4d9c-8e7e-3adc3cec0e09",
+          "doc_count": 5111
+        },
+        {
+          "key": "de5203b1-5a44-4010-948c-b7d33f46397a",
+          "doc_count": 5099
+        },
+        {
+          "key": "f5d395b8-c3c9-43df-b4ff-63d65c6a971e",
+          "doc_count": 5037
+        },
+        {
+          "key": "6cab4420-11e4-4b55-85ac-6ecfdda70184",
+          "doc_count": 5023
+        },
+        {
+          "key": "43c69d2a-0fd2-4d34-a1ef-50d0f9c01353",
+          "doc_count": 5020
+        },
+        {
+          "key": "d14d21fe-da24-47e5-81fb-4bfe962ce828",
+          "doc_count": 5003
+        },
+        {
+          "key": "a4babe52-5740-44e4-9ea2-acef4797f127",
+          "doc_count": 4970
+        },
+        {
+          "key": "2f740a87-8049-435d-9d06-1c393c9c11b7",
+          "doc_count": 4851
+        },
+        {
+          "key": "196c4f1c-53f9-480f-a012-dc0522629047",
+          "doc_count": 4660
+        },
+        {
+          "key": "282fe9c2-d6cb-4325-b3b5-b70ab1d22bbb",
+          "doc_count": 4611
+        },
+        {
+          "key": "fe04dab1-5a3d-4c28-a450-012658e982d8",
+          "doc_count": 4570
+        },
+        {
+          "key": "9b34b218-efb2-43b9-9b9e-dac3c470a9f9",
+          "doc_count": 4552
+        },
+        {
+          "key": "b1beb057-bc34-49a9-b784-2a50af226712",
+          "doc_count": 4442
+        },
+        {
+          "key": "25cd5e12-7830-4f46-bf6d-9b6deb706f44",
+          "doc_count": 4339
+        },
+        {
+          "key": "295a8445-346f-4ea2-b0cf-4a3863c72cdb",
+          "doc_count": 4301
+        },
+        {
+          "key": "6e922c92-b37d-4c46-8982-19d945ff8fd1",
+          "doc_count": 4272
+        },
+        {
+          "key": "23b85d9d-4669-40db-901f-aaad686fe0b8",
+          "doc_count": 4241
+        },
+        {
+          "key": "2b03a9d6-3575-43ea-8f43-38cbe0ee72e6",
+          "doc_count": 4231
+        },
+        {
+          "key": "9e046dad-2b23-4f95-8eaf-c0346de2556e",
+          "doc_count": 4226
+        },
+        {
+          "key": "69d150df-eba4-4ab3-9156-71cb0db41830",
+          "doc_count": 4207
+        },
+        {
+          "key": "c5d42fed-eed0-4e14-9625-f8a9c0ff6bb1",
+          "doc_count": 4196
+        },
+        {
+          "key": "497d74c2-d07f-4325-ac9c-8e80bcb53f61",
+          "doc_count": 4187
+        },
+        {
+          "key": "4bec11d1-f8c3-43a7-9e70-ee0256fcedaf",
+          "doc_count": 4187
+        },
+        {
+          "key": "4790a6a0-ce11-4cd8-8cad-4b2032a55c1b",
+          "doc_count": 4168
+        },
+        {
+          "key": "fc628e53-5fdf-4436-9782-bf637d812b48",
+          "doc_count": 4153
+        },
+        {
+          "key": "eeb4872b-7fb4-4ecd-8ce5-82e194f04735",
+          "doc_count": 4138
+        },
+        {
+          "key": "7370af7d-07b5-4fc6-9eca-0204b4d6e33e",
+          "doc_count": 4122
+        },
+        {
+          "key": "093030d9-a124-42a8-8cf3-8c6904fefbe7",
+          "doc_count": 4116
+        },
+        {
+          "key": "6f510e69-96b2-4817-bab7-3a36c8250c79",
+          "doc_count": 4074
+        },
+        {
+          "key": "2bbafa00-3162-4e8e-947c-64a13b8d3fef",
+          "doc_count": 4069
+        },
+        {
+          "key": "11170c5e-033a-4410-aed1-3dee2458bc43",
+          "doc_count": 4063
+        },
+        {
+          "key": "0e5201c0-bad2-4e28-9322-5c5dca8862c8",
+          "doc_count": 4010
+        },
+        {
+          "key": "9c963109-9898-4953-a351-d5ee36d6115b",
+          "doc_count": 4010
+        },
+        {
+          "key": "6ac89a16-4604-4a78-9047-dcc57e5c0130",
+          "doc_count": 3961
+        },
+        {
+          "key": "d6f12b28-bb9f-44f9-9000-08f644658bf8",
+          "doc_count": 3955
+        },
+        {
+          "key": "833306f7-91b6-4ff7-bc16-0e406334d991",
+          "doc_count": 3949
+        },
+        {
+          "key": "677f57a9-9a0d-4e69-8622-96aa1e6392c2",
+          "doc_count": 3921
+        },
+        {
+          "key": "9fab87bf-c5a7-4296-acdc-f22859cfe620",
+          "doc_count": 3898
+        },
+        {
+          "key": "d1b25dcd-472e-4902-b53c-3b164269e049",
+          "doc_count": 3879
+        },
+        {
+          "key": "9d9b81f1-3a9a-4515-b741-a145293f1fef",
+          "doc_count": 3849
+        },
+        {
+          "key": "2d4658e3-0d1a-43fc-97ff-b4813dd1f86e",
+          "doc_count": 3831
+        },
+        {
+          "key": "b8972f6b-c67f-45c0-b348-954866e04a0f",
+          "doc_count": 3777
+        },
+        {
+          "key": "560ba8f5-0dab-46f6-985d-7b37397344cd",
+          "doc_count": 3755
+        },
+        {
+          "key": "49153f74-2969-4a6a-a145-309fcb970308",
+          "doc_count": 3748
+        },
+        {
+          "key": "64b54f96-91f0-4442-b6de-173aa1a5c31b",
+          "doc_count": 3740
+        },
+        {
+          "key": "196bb137-2f82-40d5-b294-e730af29749f",
+          "doc_count": 3738
+        },
+        {
+          "key": "09a76937-b01a-4f4a-aefd-825876453015",
+          "doc_count": 3678
+        },
+        {
+          "key": "a50e98bd-13e9-41fe-a5cc-aee4f240628b",
+          "doc_count": 3674
+        },
+        {
+          "key": "66e00116-15fa-4149-a94a-eb91b98b622c",
+          "doc_count": 3632
+        },
+        {
+          "key": "1f8c7572-5cda-44be-9a78-0658217fc279",
+          "doc_count": 3622
+        },
+        {
+          "key": "6b6c13d9-7789-4da0-99d7-6786322e2612",
+          "doc_count": 3597
+        },
+        {
+          "key": "a2bc3d61-3c37-4aca-b47d-c3413f7e3b87",
+          "doc_count": 3591
+        },
+        {
+          "key": "4c9d08ce-71c1-47b8-a572-2d40e5984c49",
+          "doc_count": 3564
+        },
+        {
+          "key": "34cad268-8226-4280-b637-dde38c82a29e",
+          "doc_count": 3514
+        },
+        {
+          "key": "b880344e-22b2-4540-a56a-1de5f5601a20",
+          "doc_count": 3480
+        },
+        {
+          "key": "ff111763-e72d-4f24-8914-b5b2dd94908c",
+          "doc_count": 3478
+        },
+        {
+          "key": "55b17f44-8c6b-4dc5-a31d-d9955b425790",
+          "doc_count": 3458
+        },
+        {
+          "key": "0e0e9bbc-1dea-4de4-95ae-aecc90844bbf",
+          "doc_count": 3338
+        },
+        {
+          "key": "9a09745d-4449-46a2-b8b3-60f3c0d25e83",
+          "doc_count": 3334
+        },
+        {
+          "key": "b40e13f7-a79a-4265-93d9-3b4878dfc988",
+          "doc_count": 3303
+        },
+        {
+          "key": "4900d7ce-9442-4305-9889-c9cbbb953eaa",
+          "doc_count": 3296
+        },
+        {
+          "key": "2292f5d5-d39f-4944-be72-fa5dd62f581c",
+          "doc_count": 3287
+        },
+        {
+          "key": "7026b70a-7245-42bd-8162-81ae9a6cfbcb",
+          "doc_count": 3262
+        },
+        {
+          "key": "bf897c17-06cc-48c1-a7cc-f41b45166880",
+          "doc_count": 3244
+        },
+        {
+          "key": "8728ef71-fdcc-4027-8139-38b2c0628fba",
+          "doc_count": 3205
+        },
+        {
+          "key": "df516dc6-6ef0-426d-94e3-8a2bbb0439a5",
+          "doc_count": 3174
+        },
+        {
+          "key": "e85a9948-9c9e-451d-9485-b2b4cb7b73d5",
+          "doc_count": 3161
+        },
+        {
+          "key": "ef637c01-c551-4d47-8a48-4442b8ad5ecd",
+          "doc_count": 3152
+        },
+        {
+          "key": "79be41bc-8142-485a-9d57-d6195f9a7c81",
+          "doc_count": 3137
+        },
+        {
+          "key": "fcbcb214-cd62-4453-af56-b4b49161a261",
+          "doc_count": 3137
+        },
+        {
+          "key": "fc40fabd-0a70-48fa-b142-79990cd259a5",
+          "doc_count": 3107
+        },
+        {
+          "key": "d1983d53-434a-436e-a698-3a2745eb61dc",
+          "doc_count": 3090
+        },
+        {
+          "key": "0bfd2d69-2a35-4291-9e73-bd311463bd15",
+          "doc_count": 3076
+        },
+        {
+          "key": "6d4b658a-90b4-4639-8b06-b7f07637f6aa",
+          "doc_count": 3062
+        },
+        {
+          "key": "b4d4e884-a2ef-4967-b4cb-2072fc465eaf",
+          "doc_count": 3043
+        },
+        {
+          "key": "b20588fd-61f4-4765-8025-30c81a5f4250",
+          "doc_count": 2975
+        },
+        {
+          "key": "47ac1531-5213-4848-a32d-5bb396ab9348",
+          "doc_count": 2966
+        },
+        {
+          "key": "d81c6ad6-fb8f-4c31-bba3-f2b65f780893",
+          "doc_count": 2962
+        },
+        {
+          "key": "2e3a8e5c-eef9-462d-a690-3a91fe111e13",
+          "doc_count": 2959
+        },
+        {
+          "key": "9fa0a48c-7dd2-4372-a768-9aea3cbd35bb",
+          "doc_count": 2919
+        },
+        {
+          "key": "5277e72c-9e53-4c98-85f1-ee413bc473cd",
+          "doc_count": 2909
+        },
+        {
+          "key": "9f3bbc7b-c682-4f66-88b3-48eef3a38f38",
+          "doc_count": 2865
+        },
+        {
+          "key": "39289378-eed8-442c-ba0b-fce8b1679d8f",
+          "doc_count": 2856
+        },
+        {
+          "key": "333ac26a-30bc-4e0c-a6ef-c57a40f6bd99",
+          "doc_count": 2830
+        },
+        {
+          "key": "8783e947-93cf-4b60-b387-d10642b0eee0",
+          "doc_count": 2829
+        },
+        {
+          "key": "19daf0a7-5e37-41e6-97f8-4494553c358c",
+          "doc_count": 2822
+        },
+        {
+          "key": "5e8863ea-56ec-40f3-8075-d42b35d12e72",
+          "doc_count": 2789
+        },
+        {
+          "key": "59734d15-8edb-41a4-b3f2-f9bd3407460b",
+          "doc_count": 2778
+        },
+        {
+          "key": "d08a71aa-fe87-4bf5-ac68-8e7497bf585c",
+          "doc_count": 2745
+        },
+        {
+          "key": "40d35f62-cf89-488a-bad3-66e66d38c10c",
+          "doc_count": 2733
+        },
+        {
+          "key": "ef30a918-b583-41f1-9ac4-4a37591b515a",
+          "doc_count": 2692
+        },
+        {
+          "key": "cc11b4e3-823d-4490-95b2-afe6a1f3a9d2",
+          "doc_count": 2679
+        },
+        {
+          "key": "7c927849-94ed-4034-90e9-af34ac0cb47c",
+          "doc_count": 2664
+        },
+        {
+          "key": "2eb8ff2f-4826-4fc3-be68-22d805bcae88",
+          "doc_count": 2658
+        },
+        {
+          "key": "33bac15d-b1d0-42a1-8801-86149887eeef",
+          "doc_count": 2639
+        },
+        {
+          "key": "1aa66130-6668-4c4b-8383-a51b8e8389ec",
+          "doc_count": 2506
+        },
+        {
+          "key": "96588aed-3b7a-4179-b92b-2159427f4fcb",
+          "doc_count": 2479
+        },
+        {
+          "key": "5ddcbd44-1802-46b0-bae5-11126409c03d",
+          "doc_count": 2432
+        },
+        {
+          "key": "b5234343-b0f1-472a-9db7-dfa78affd402",
+          "doc_count": 2396
+        },
+        {
+          "key": "7232e59b-b0e1-49cd-9632-b8ae1f49f828",
+          "doc_count": 2390
+        },
+        {
+          "key": "0dabd609-2505-4492-8b7a-3f8301d8d5e1",
+          "doc_count": 2381
+        },
+        {
+          "key": "e38af226-7109-4f99-a6f1-9fd3bec5638d",
+          "doc_count": 2364
+        },
+        {
+          "key": "0072bf11-a354-4998-8730-c0cb4cfc9517",
+          "doc_count": 2351
+        },
+        {
+          "key": "d315c4a3-0bee-49d1-8d03-726358937cde",
+          "doc_count": 2308
+        },
+        {
+          "key": "9354db6c-4019-4351-a822-cb87b1b73a44",
+          "doc_count": 2247
+        },
+        {
+          "key": "e73fedf0-90ee-4c6d-88dd-49399878fc54",
+          "doc_count": 2227
+        },
+        {
+          "key": "3a0d8092-c577-4775-a586-1542574edc53",
+          "doc_count": 2188
+        },
+        {
+          "key": "18c215c3-c02f-47e9-bb66-196c33c8f672",
+          "doc_count": 2056
+        },
+        {
+          "key": "b985f284-eac5-4efe-8a7c-c726cdf7cf33",
+          "doc_count": 2055
+        },
+        {
+          "key": "82541f90-fe8e-4d66-84d8-4fe515dc5533",
+          "doc_count": 2035
+        },
+        {
+          "key": "3ad82604-c4b3-4fd0-b03e-d8f874062146",
+          "doc_count": 2009
+        },
+        {
+          "key": "db4bb0df-8539-4617-ab5f-eb118aa3126b",
+          "doc_count": 2002
+        },
+        {
+          "key": "8157bc94-5fba-4bf6-98bd-9ba653b595e8",
+          "doc_count": 1963
+        },
+        {
+          "key": "994b60a2-88f1-49ec-a6da-27d56dfa6f16",
+          "doc_count": 1958
+        },
+        {
+          "key": "fb97dfb4-72be-4dc1-9f5a-2faea75341b4",
+          "doc_count": 1883
+        },
+        {
+          "key": "30ab9c2a-0b54-4c04-84ca-bc7abdd90b52",
+          "doc_count": 1876
+        },
+        {
+          "key": "f9a33279-d6ba-41c7-a511-ef6adfcb6e20",
+          "doc_count": 1831
+        },
+        {
+          "key": "a0ec3ce6-fc8a-48b7-9105-cecf27602e37",
+          "doc_count": 1812
+        },
+        {
+          "key": "5d7869be-8526-43d8-af53-f16a15ebadb5",
+          "doc_count": 1808
+        },
+        {
+          "key": "401fec56-515d-4fa8-87d1-507e742f4f6f",
+          "doc_count": 1802
+        },
+        {
+          "key": "045aa661-f985-4203-80ff-98daafdfe377",
+          "doc_count": 1792
+        },
+        {
+          "key": "09b18522-5643-478f-86e9-d2e34440d43e",
+          "doc_count": 1782
+        },
+        {
+          "key": "8e4ff036-d38e-455f-a0fe-4ac50823f4fb",
+          "doc_count": 1742
+        },
+        {
+          "key": "2e65e24b-b7e2-40a4-a40c-09edafc1e3f4",
+          "doc_count": 1687
+        },
+        {
+          "key": "241d64f1-480a-48ae-8ec2-cd12af4a16e9",
+          "doc_count": 1685
+        },
+        {
+          "key": "7e43ea77-d2e5-4bdc-a4f7-a4792866f53f",
+          "doc_count": 1664
+        },
+        {
+          "key": "ff0d1543-247c-4039-a8ff-cf4fc224c449",
+          "doc_count": 1663
+        },
+        {
+          "key": "87c45c90-ba1d-409e-a9d7-9baf5a5cbb1c",
+          "doc_count": 1631
+        },
+        {
+          "key": "0e2f3962-e905-48f2-a1c6-19d16e2bd5ba",
+          "doc_count": 1630
+        },
+        {
+          "key": "7340c0df-8829-4197-9dc7-0328b8e7f5dd",
+          "doc_count": 1590
+        },
+        {
+          "key": "1e86442f-35a5-4e7b-9a38-4599e4d3b510",
+          "doc_count": 1582
+        },
+        {
+          "key": "f3327705-8d69-4d9c-88b7-584a08c74653",
+          "doc_count": 1579
+        },
+        {
+          "key": "e506c5e0-99b6-4e97-b7b4-4536cb80209b",
+          "doc_count": 1536
+        },
+        {
+          "key": "a545560f-a02a-4b8a-af4c-ed09f1f05df7",
+          "doc_count": 1485
+        },
+        {
+          "key": "5aac25d2-bcfb-4084-a700-584311ea539d",
+          "doc_count": 1480
+        },
+        {
+          "key": "ba77d411-4179-4dbd-b6c1-39b8a71ae795",
+          "doc_count": 1469
+        },
+        {
+          "key": "2c2cc29c-3572-4568-a129-c8cbec34ccbe",
+          "doc_count": 1458
+        },
+        {
+          "key": "3d2b5be0-7c1d-4693-9226-94bc0061123b",
+          "doc_count": 1417
+        },
+        {
+          "key": "56879e73-bf9d-4bd9-a7a4-4f2f940d0f62",
+          "doc_count": 1408
+        },
+        {
+          "key": "82c60e09-2939-4896-9ce9-5c63fe19cac9",
+          "doc_count": 1381
+        },
+        {
+          "key": "f5c38252-89f1-4753-af3a-da8818fe3a86",
+          "doc_count": 1325
+        },
+        {
+          "key": "99e84c7d-dd3c-40d9-9526-54f4342cda95",
+          "doc_count": 1287
+        },
+        {
+          "key": "feb74628-8724-466f-8c8c-b3d3b72f2417",
+          "doc_count": 1274
+        },
+        {
+          "key": "3bbf3659-4b21-40b7-b74f-f17a60097154",
+          "doc_count": 1267
+        },
+        {
+          "key": "08bfaeb8-abb4-4b33-b0e7-ed1242377bbd",
+          "doc_count": 1241
+        },
+        {
+          "key": "a4b888a2-94bf-4680-b912-84964a236c82",
+          "doc_count": 1209
+        },
+        {
+          "key": "9a861ebe-f8d7-4eb1-a2c8-3006f07cfec2",
+          "doc_count": 1205
+        },
+        {
+          "key": "ea9d9c05-11b3-4514-898e-66bd8560ec5b",
+          "doc_count": 1202
+        },
+        {
+          "key": "0a410c4a-cd4f-4bd8-b6ba-a0c2baa37622",
+          "doc_count": 1185
+        },
+        {
+          "key": "442246b3-6610-45e6-b2bf-c11ee15917b8",
+          "doc_count": 1184
+        },
+        {
+          "key": "1da2a87d-4fc7-4233-b127-59cb8d1ca5ee",
+          "doc_count": 1167
+        },
+        {
+          "key": "50b4c365-5472-4fe8-8825-b1fa0ac57fb3",
+          "doc_count": 1132
+        },
+        {
+          "key": "3ff3bf5c-7aba-40c3-80b2-1b00ea1abdd5",
+          "doc_count": 1123
+        },
+        {
+          "key": "2d853a6d-50ec-4931-8e91-48fc2491fdee",
+          "doc_count": 1122
+        },
+        {
+          "key": "b12b08da-3d05-4406-a051-0139a33ecf35",
+          "doc_count": 1118
+        },
+        {
+          "key": "76015dea-c909-4e6d-a8e1-3bf35763571e",
+          "doc_count": 1100
+        },
+        {
+          "key": "15a1cc29-b66c-4633-ad9c-c2c094b19902",
+          "doc_count": 1090
+        },
+        {
+          "key": "dd783e7e-36d8-4fcd-b7fe-9a481d785560",
+          "doc_count": 1086
+        },
+        {
+          "key": "1e6c8187-1521-4501-b205-ac8f513d5e04",
+          "doc_count": 1068
+        },
+        {
+          "key": "4aecf17c-154a-42fb-a3c0-f5e621c791e6",
+          "doc_count": 1054
+        },
+        {
+          "key": "50ca2a08-0e76-4f56-9976-d344dd201a9b",
+          "doc_count": 1053
+        },
+        {
+          "key": "8cd3a748-7f59-40e9-9cf3-3951e1e6430d",
+          "doc_count": 1053
+        },
+        {
+          "key": "bfb53140-79c1-4625-81aa-3f37de7c0c2f",
+          "doc_count": 1026
+        },
+        {
+          "key": "e8a10a16-86af-42b2-be40-9d6a1b21859a",
+          "doc_count": 986
+        },
+        {
+          "key": "af60ac71-fbfb-4648-95fb-0eb5fe24765b",
+          "doc_count": 984
+        },
+        {
+          "key": "93341fe7-38f8-4ef2-8dfc-ae550aa522dc",
+          "doc_count": 976
+        },
+        {
+          "key": "b3976394-a174-4ceb-8d64-3a435d66bde6",
+          "doc_count": 972
+        },
+        {
+          "key": "96a6898e-1fb6-4c49-a1f2-afb96058dbf8",
+          "doc_count": 967
+        },
+        {
+          "key": "d601bd5e-4f4c-4637-9196-4bd821dbd2e2",
+          "doc_count": 928
+        },
+        {
+          "key": "f4666aa7-93f0-41f7-83c2-497af7a06887",
+          "doc_count": 885
+        },
+        {
+          "key": "75c7a013-8dab-4f9c-ae6d-3a7cc24b67ce",
+          "doc_count": 882
+        },
+        {
+          "key": "da46ceaf-6084-48da-9e53-4d1ae2a51ddf",
+          "doc_count": 865
+        },
+        {
+          "key": "886f3b02-e2f2-4c49-9ace-df25bf5d091a",
+          "doc_count": 856
+        },
+        {
+          "key": "c882214e-8ba4-482b-9998-070b5547dc54",
+          "doc_count": 853
+        },
+        {
+          "key": "4efa66cf-8adb-414b-b78c-8e651d20f84d",
+          "doc_count": 852
+        },
+        {
+          "key": "49db9725-7bdc-4c38-8548-c32994e811c1",
+          "doc_count": 838
+        },
+        {
+          "key": "c3a7b339-122e-4fe9-8851-371b1fdf584e",
+          "doc_count": 803
+        },
+        {
+          "key": "41350373-fc6f-4dd9-b908-27805fff9155",
+          "doc_count": 800
+        },
+        {
+          "key": "f266a75c-3529-4868-8669-9f98822e033f",
+          "doc_count": 795
+        },
+        {
+          "key": "2b89de41-42bd-46c6-ab61-d386f855f7fb",
+          "doc_count": 790
+        },
+        {
+          "key": "b764863c-de93-4d7c-b0cf-1bb57166141d",
+          "doc_count": 765
+        },
+        {
+          "key": "2936c837-ad9f-40d8-bea0-58b2a635c637",
+          "doc_count": 747
+        },
+        {
+          "key": "781b461a-2788-4fa6-b3df-bbed9447f5a3",
+          "doc_count": 741
+        },
+        {
+          "key": "b027383d-6705-4d06-8514-db6ef16efdb5",
+          "doc_count": 736
+        },
+        {
+          "key": "3c919328-94fd-4657-b81d-21f4707253ed",
+          "doc_count": 697
+        },
+        {
+          "key": "0c9378fa-3ccb-4342-be2e-5b5080691dd1",
+          "doc_count": 691
+        },
+        {
+          "key": "a5fe6f13-2121-41dd-a036-dae15546ad91",
+          "doc_count": 661
+        },
+        {
+          "key": "c359c2e5-cd20-4057-9179-35a7a5b5da72",
+          "doc_count": 648
+        },
+        {
+          "key": "ad5c4ec7-ed56-4d3e-881a-963af217d334",
+          "doc_count": 627
+        },
+        {
+          "key": "c96ca51c-908e-41cc-ae10-ac1fb72ca3d9",
+          "doc_count": 624
+        },
+        {
+          "key": "fb4cc282-eba5-4156-b7c7-df41e0581b68",
+          "doc_count": 619
+        },
+        {
+          "key": "932e8ecc-fb16-4ce1-9863-e0e586e3ab34",
+          "doc_count": 610
+        },
+        {
+          "key": "6659b6dd-d487-4b72-b0c8-ae65942a6f15",
+          "doc_count": 594
+        },
+        {
+          "key": "2e03b83d-d2b9-4a8e-90b5-42b5b1301a92",
+          "doc_count": 587
+        },
+        {
+          "key": "4cdf5c2f-1a44-4fd5-bdd8-de08c8a660e2",
+          "doc_count": 566
+        },
+        {
+          "key": "e7bc6545-f14f-4fc4-9902-1aa38040f184",
+          "doc_count": 561
+        },
+        {
+          "key": "8456dc3d-99e2-407c-ab55-4746d382496b",
+          "doc_count": 552
+        },
+        {
+          "key": "aa977d4a-0dd6-4441-87d4-5efb60435a0b",
+          "doc_count": 544
+        },
+        {
+          "key": "539721d9-f5f8-489b-a816-abc28b2748e8",
+          "doc_count": 523
+        },
+        {
+          "key": "abb0a03c-4dcb-4f6f-a31d-55268f63d44c",
+          "doc_count": 515
+        },
+        {
+          "key": "27b2b46f-4cae-4ffa-870d-b17e51d627f2",
+          "doc_count": 504
+        },
+        {
+          "key": "2ee56f8c-db1d-43aa-bfb7-3fb2a19601df",
+          "doc_count": 500
+        },
+        {
+          "key": "1c8ec291-8067-4b48-848b-410c2c768420",
+          "doc_count": 470
+        },
+        {
+          "key": "f4f833ea-0abf-4059-948e-132c64dda1be",
+          "doc_count": 456
+        },
+        {
+          "key": "41e1a09b-bd55-4d20-a480-5d8187f7afca",
+          "doc_count": 450
+        },
+        {
+          "key": "e2a12ef3-cf03-4ce4-8aff-802ccf2aec1d",
+          "doc_count": 440
+        },
+        {
+          "key": "b7a79601-c07b-46d5-bd09-d4472b0d9431",
+          "doc_count": 427
+        },
+        {
+          "key": "f3a5ec1a-49dd-4a52-8bd8-67cacae7a7ac",
+          "doc_count": 426
+        },
+        {
+          "key": "4efa0623-a625-4949-aea4-7cb60a99b6f8",
+          "doc_count": 411
+        },
+        {
+          "key": "47e638be-2983-4d22-b05d-260dd5881e9c",
+          "doc_count": 409
+        },
+        {
+          "key": "8dd13cdf-1425-497d-a4ff-bb5dadfe21a8",
+          "doc_count": 403
+        },
+        {
+          "key": "6aca6f67-a2e9-440d-a503-9501db6e6f36",
+          "doc_count": 397
+        },
+        {
+          "key": "9aa11cc8-6c2d-4202-b30b-c8454338bbd2",
+          "doc_count": 394
+        },
+        {
+          "key": "1ae056ac-8834-43a8-ad44-d1148b6e075f",
+          "doc_count": 358
+        },
+        {
+          "key": "0df55e93-0fce-4ba6-a344-1d9918b60816",
+          "doc_count": 346
+        },
+        {
+          "key": "00df4fe2-0025-45ec-814a-36777155e077",
+          "doc_count": 328
+        },
+        {
+          "key": "f271128e-2e79-430b-81a4-a92ec7c969b8",
+          "doc_count": 326
+        },
+        {
+          "key": "4f5fc75f-f983-4ef8-9723-ba375615d926",
+          "doc_count": 324
+        },
+        {
+          "key": "314f66a9-2b8f-4085-b10c-0f083ce2f1eb",
+          "doc_count": 307
+        },
+        {
+          "key": "d3412433-4df9-4828-89e0-73956898f749",
+          "doc_count": 305
+        },
+        {
+          "key": "07c47dd3-a0a9-434a-b144-71c32996f278",
+          "doc_count": 304
+        },
+        {
+          "key": "3451a762-d117-430e-968c-dd747ed53887",
+          "doc_count": 298
+        },
+        {
+          "key": "85ae9fb4-de87-41ce-abb3-44fda2fb24a8",
+          "doc_count": 292
+        },
+        {
+          "key": "d0769c31-e4f1-42b1-a21f-cd6bf2257edb",
+          "doc_count": 291
+        },
+        {
+          "key": "d9d38b3f-5173-4051-98a6-2efad16fc8da",
+          "doc_count": 285
+        },
+        {
+          "key": "a7463c8a-27f0-485e-b794-fb78d94beda7",
+          "doc_count": 277
+        },
+        {
+          "key": "697b5707-b86f-43c5-a114-93a3fc602719",
+          "doc_count": 276
+        },
+        {
+          "key": "fd36e434-8c4d-4d97-a15d-e4d55f312d73",
+          "doc_count": 270
+        },
+        {
+          "key": "e27dc54d-8114-4927-b400-694caab9872e",
+          "doc_count": 261
+        },
+        {
+          "key": "71e55d91-4c0c-4a13-9421-c732348b0a47",
+          "doc_count": 253
+        },
+        {
+          "key": "639ae683-0a66-4a59-9c09-36304bf11424",
+          "doc_count": 245
+        },
+        {
+          "key": "a5d9992f-ebbb-457c-b56a-b6cd0429e2d6",
+          "doc_count": 245
+        },
+        {
+          "key": "b3d53973-5bac-432a-90d3-7956baa09c5d",
+          "doc_count": 237
+        },
+        {
+          "key": "57b1a2a3-78ab-4e69-a77e-a8fd4394ee5a",
+          "doc_count": 221
+        },
+        {
+          "key": "011880b9-7697-4626-946f-258a68f754cb",
+          "doc_count": 201
+        },
+        {
+          "key": "7fcdca8e-7469-480c-8516-cce4e24c37c9",
+          "doc_count": 193
+        },
+        {
+          "key": "433d3c37-8dde-42e4-a344-2cb6605c5da2",
+          "doc_count": 190
+        },
+        {
+          "key": "25e4ea2d-74ef-4251-b461-6ceb3c812bf1",
+          "doc_count": 187
+        },
+        {
+          "key": "03eac319-23c7-429e-9fa4-480640007d62",
+          "doc_count": 184
+        },
+        {
+          "key": "997c4dda-0465-40c0-af8d-67f8f90dea3b",
+          "doc_count": 182
+        },
+        {
+          "key": "e2c129bc-e45b-43d1-ab52-86e52093080b",
+          "doc_count": 175
+        },
+        {
+          "key": "67dfbfc8-bfc8-4a69-a63c-0918539e4dee",
+          "doc_count": 173
+        },
+        {
+          "key": "f3d1fbbb-93d5-432e-8808-ebc08c42ef6d",
+          "doc_count": 172
+        },
+        {
+          "key": "9b62118d-9b90-46b1-854d-06a5a9a22a90",
+          "doc_count": 171
+        },
+        {
+          "key": "9764480a-6e4a-4800-9bb7-b6fb73bccc50",
+          "doc_count": 169
+        },
+        {
+          "key": "1d14acd1-20ef-4a55-8206-f04c8a75ea3e",
+          "doc_count": 168
+        },
+        {
+          "key": "b761d317-a36e-4a05-a5f4-bd3e3963daf6",
+          "doc_count": 164
+        },
+        {
+          "key": "4c46db9d-74d7-4e45-9ed2-0da40ec6b44f",
+          "doc_count": 161
+        },
+        {
+          "key": "87fee729-2a4e-4d23-ad8a-5e03e1ab7c1a",
+          "doc_count": 161
+        },
+        {
+          "key": "e6b4d68a-59b5-4b74-a5ce-daadd930d3ca",
+          "doc_count": 159
+        },
+        {
+          "key": "c6e89321-fc23-4cba-ad79-be3e52edfb6d",
+          "doc_count": 144
+        },
+        {
+          "key": "c19c539d-2f8c-4a99-b956-15921ec345ed",
+          "doc_count": 138
+        },
+        {
+          "key": "b3f10d7b-6763-4f79-9789-f6abc68b9720",
+          "doc_count": 137
+        },
+        {
+          "key": "6acaebd6-e8d2-454a-8f50-e7a6734b8c79",
+          "doc_count": 136
+        },
+        {
+          "key": "4bf197cb-6fbc-4b22-82d0-849fffb5906e",
+          "doc_count": 134
+        },
+        {
+          "key": "07389fe4-c6dc-4e6c-87d2-345e2d183050",
+          "doc_count": 131
+        },
+        {
+          "key": "8a54c5fa-2900-4859-a2d6-1b7faedafac4",
+          "doc_count": 130
+        },
+        {
+          "key": "ec8f29eb-6d25-4a48-841c-49d6217761a4",
+          "doc_count": 129
+        },
+        {
+          "key": "fbac84f2-8db7-4af5-96b1-9d8885370c10",
+          "doc_count": 127
+        },
+        {
+          "key": "f8944362-0f02-4ccb-bbaf-3149b2de8e22",
+          "doc_count": 118
+        },
+        {
+          "key": "21ea1ef6-4a2a-4ff2-a18b-5c0f297fc1cf",
+          "doc_count": 108
+        },
+        {
+          "key": "b3d3a357-9fa6-453c-9f02-d86a1bbc762a",
+          "doc_count": 106
+        },
+        {
+          "key": "95773ebb-2f5f-43f0-a652-bfd8d5f4707a",
+          "doc_count": 105
+        },
+        {
+          "key": "bcbae485-1286-4452-bbc9-bcb38c6c3573",
+          "doc_count": 94
+        },
+        {
+          "key": "974f7564-a7fb-409a-bb67-35b7cafec327",
+          "doc_count": 84
+        },
+        {
+          "key": "ba4b4a05-f01f-4b16-b36a-83bf997a8722",
+          "doc_count": 84
+        },
+        {
+          "key": "94dd2cee-ed7d-4f98-894f-efafeac92b5b",
+          "doc_count": 82
+        },
+        {
+          "key": "4fecde59-9f59-44eb-ab6f-4a50b4ed85cf",
+          "doc_count": 76
+        },
+        {
+          "key": "2e746628-f895-4367-ae31-62e81e0b6b98",
+          "doc_count": 70
+        },
+        {
+          "key": "2148b4f7-a770-4bca-b276-da70ae948690",
+          "doc_count": 69
+        },
+        {
+          "key": "5302ea7f-1c6f-4fc9-8c20-97dd38c0c783",
+          "doc_count": 48
+        },
+        {
+          "key": "86b1f54d-ac01-4c5e-8ed8-09da2689c7a9",
+          "doc_count": 47
+        },
+        {
+          "key": "0e0d4dba-9c5d-4dbf-9ac8-09114c56ec03",
+          "doc_count": 44
+        },
+        {
+          "key": "17cea35c-721f-4d9b-b67f-d29250064d25",
+          "doc_count": 43
+        },
+        {
+          "key": "bc41afff-4d56-421e-bc87-45e18b4fe64a",
+          "doc_count": 43
+        },
+        {
+          "key": "473400bf-fe83-4bd6-9f69-c4608f4cdf4f",
+          "doc_count": 41
+        },
+        {
+          "key": "bdaa6842-3055-465e-82f6-da577e987cde",
+          "doc_count": 40
+        },
+        {
+          "key": "513dd822-f211-42c3-9af2-ee3c798cd1b8",
+          "doc_count": 36
+        },
+        {
+          "key": "6f6bf083-d27a-417d-9205-e5a70c2b7a0d",
+          "doc_count": 36
+        },
+        {
+          "key": "3617a6a3-d384-48de-948d-2d1e1c54e090",
+          "doc_count": 29
+        },
+        {
+          "key": "2c00d087-1df6-4744-807d-056be36eed0d",
+          "doc_count": 28
+        },
+        {
+          "key": "adae5c6c-72f3-4cd8-a00b-3ea71d516abc",
+          "doc_count": 27
+        },
+        {
+          "key": "1fc07b28-43f5-49d1-badf-63005e1c3e9a",
+          "doc_count": 26
+        },
+        {
+          "key": "2c84db50-bab1-40a6-a9ef-405f3ffcec7e",
+          "doc_count": 26
+        },
+        {
+          "key": "ab820732-0844-4323-ba14-c58c24f3fc7e",
+          "doc_count": 26
+        },
+        {
+          "key": "fb7db48e-1599-420e-8f10-1f20fe1c6aa3",
+          "doc_count": 24
+        },
+        {
+          "key": "656d1c9a-cbb7-4dde-ac24-62323af5b831",
+          "doc_count": 22
+        },
+        {
+          "key": "7400877a-13b8-423d-9074-5371a8234157",
+          "doc_count": 21
+        },
+        {
+          "key": "a4c4e0ee-38dd-47fd-9b06-ce4cc011e111",
+          "doc_count": 21
+        },
+        {
+          "key": "76aab8f5-69d4-4ce9-b0c9-837b64a2dd06",
+          "doc_count": 20
+        },
+        {
+          "key": "80daac2f-e496-4c65-b196-6be7a9c4c98e",
+          "doc_count": 20
+        },
+        {
+          "key": "cb4882a8-19d3-41a1-9373-c1a868b5ac9b",
+          "doc_count": 20
+        },
+        {
+          "key": "061dfaff-0c45-459e-ac56-738fe4cbe213",
+          "doc_count": 19
+        },
+        {
+          "key": "88271bd3-1985-4fa7-9e33-f82cc24dfad3",
+          "doc_count": 18
+        },
+        {
+          "key": "a8add96d-651c-488e-8ca3-ed3f85c7a117",
+          "doc_count": 18
+        },
+        {
+          "key": "4d9103e7-fe58-4dc5-9fa8-e739949fd3f3",
+          "doc_count": 17
+        },
+        {
+          "key": "62c35d43-f15c-451d-a8be-1b9c6928b8bd",
+          "doc_count": 17
+        },
+        {
+          "key": "f93c403b-d0f0-4be1-8a4b-ed9aa3b513e3",
+          "doc_count": 17
+        },
+        {
+          "key": "72059315-e131-42ba-b7c6-489415e297b9",
+          "doc_count": 16
+        },
+        {
+          "key": "879d475f-4b76-4d18-8cf6-a7e5a6d44926",
+          "doc_count": 15
+        },
+        {
+          "key": "90d6f994-d652-49d0-b6e6-924c65c4c079",
+          "doc_count": 12
+        },
+        {
+          "key": "b1c7a275-21f6-4b66-895d-d497359b34a1",
+          "doc_count": 11
+        },
+        {
+          "key": "c16e25c8-1e93-4571-881f-b757d3e48700",
+          "doc_count": 11
+        },
+        {
+          "key": "e1c7bc41-50a4-4723-b8b3-f970844ffb65",
+          "doc_count": 11
+        },
+        {
+          "key": "8f62e9b0-96e5-4d64-8008-b2b8692050db",
+          "doc_count": 10
+        },
+        {
+          "key": "a8cafd75-ca3b-42c6-8b8e-52aafa15753b",
+          "doc_count": 10
+        },
+        {
+          "key": "0c15e83e-79ee-4ee3-86e3-e5f98a51dc11",
+          "doc_count": 9
+        },
+        {
+          "key": "372d25cd-e4c6-4c58-8d3f-abe16887c805",
+          "doc_count": 9
+        },
+        {
+          "key": "5bd3bf29-b78d-4bf3-bbd7-bbfb4eaf36a1",
+          "doc_count": 9
+        },
+        {
+          "key": "a8d88237-2f62-4ad5-b1f7-ab13ace304df",
+          "doc_count": 9
+        },
+        {
+          "key": "5f681b65-9a7e-4b79-8a17-fc95cc26b837",
+          "doc_count": 6
+        },
+        {
+          "key": "6226705f-4867-464d-9fab-4e81ecee731f",
+          "doc_count": 6
+        },
+        {
+          "key": "73b2abe8-93ea-4343-bc37-35693035dea0",
+          "doc_count": 5
+        },
+        {
+          "key": "84006c59-fead-4b84-b3b5-cedf28f67ea9",
+          "doc_count": 5
+        },
+        {
+          "key": "bf1a26f8-6e89-4b95-b512-16430cccb6df",
+          "doc_count": 4
+        },
+        {
+          "key": "a3b54f92-360f-49a9-ae3b-9f5361549ef9",
+          "doc_count": 3
+        },
+        {
+          "key": "e5f377de-c662-4eec-a4d4-b41b18441f3a",
+          "doc_count": 3
+        },
+        {
+          "key": "3c6099e4-3a0c-44c8-942a-f44860aea12b",
+          "doc_count": 2
+        },
+        {
+          "key": "41800344-33b3-4201-b9d2-cabbbf564fbc",
+          "doc_count": 2
+        },
+        {
+          "key": "48e1b8c1-91aa-4b87-8ca0-de1f81232eaf",
+          "doc_count": 2
+        },
+        {
+          "key": "53feaa83-e3b6-4ad3-8597-293b153e7548",
+          "doc_count": 2
+        },
+        {
+          "key": "a73b61c5-812c-453b-b12b-5c65929e947a",
+          "doc_count": 2
+        },
+        {
+          "key": "abf5b4f3-ed39-4bb9-acd6-9ee50acac0ad",
+          "doc_count": 2
+        },
+        {
+          "key": "c2dcb184-6c90-4aa3-9ebb-33b2d53837b9",
+          "doc_count": 2
+        },
+        {
+          "key": "c7883ffb-d381-4748-9694-e5abdaa46dbc",
+          "doc_count": 2
+        },
+        {
+          "key": "d07e7b8a-2222-477f-a7f3-f098bbfdaf54",
+          "doc_count": 2
+        },
+        {
+          "key": "de67ccab-7d04-43b9-8083-81e45f628505",
+          "doc_count": 2
+        },
+        {
+          "key": "0395f3c4-0277-43b6-a36d-e07720588790",
+          "doc_count": 1
+        },
+        {
+          "key": "0da18fe6-2e2a-43fc-9d2a-ffb2cefc05c0",
+          "doc_count": 1
+        },
+        {
+          "key": "237d30ca-7675-4840-b4fd-96771fabf518",
+          "doc_count": 1
+        },
+        {
+          "key": "53064db5-a272-46f9-85d2-d1b78e9a3293",
+          "doc_count": 1
+        },
+        {
+          "key": "54ae6783-dbb5-403a-b0e6-11a3b07d491a",
+          "doc_count": 1
+        },
+        {
+          "key": "74ba1d92-d9a5-486e-8e52-bb44d51e1788",
+          "doc_count": 1
+        },
+        {
+          "key": "8a9e3b42-e6e8-4485-b304-3cbf6d709a6c",
+          "doc_count": 1
+        },
+        {
+          "key": "a9bb4417-af3e-46e7-a2e0-167d61b49d10",
+          "doc_count": 1
+        }
+      ]
+    },
+    "max_dm": {
+      "value": 1674657431736,
+      "value_as_string": "2023-01-25T14:37:11.736Z"
+    }
+  }
+}

--- a/__tests__/mock/search-b5f8d575c436ec8bde6eb10d702d72db.json
+++ b/__tests__/mock/search-b5f8d575c436ec8bde6eb10d702d72db.json
@@ -1,0 +1,17224 @@
+{
+  "timed_out": false,
+  "_shards": {
+    "total": 48,
+    "successful": 48,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1310,
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bdaf32eb-1713-4390-a96a-1dca49671b34",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.3299451488425,
+            "lat": 45.68320932749771
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1d2e551d-a8bb-45fa-a6eb-22634c1a32ea",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.93333,
+            "lat": 2.58333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d0811d28-1a8a-4a5d-8fc3-066849be8b83",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9037942234,
+            "lat": 33.37659
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "55a75c3e-f4cf-4795-9056-d5f2fdd3aa7d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.083882957,
+            "lat": 34.431897
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a2619b87-f2ff-40ba-a364-47f655e0123d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1976118178,
+            "lat": 34.402723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2b34b030-809d-4cf1-9f24-31a09f74e264",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.96191,
+            "lat": 38.37945
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "095b86fa-4f0a-4f73-b2aa-6f80db9f9c11",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.413883,
+            "lat": 39.851096
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "726b16bb-423e-4543-8e98-84c6d642fa3d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.0039,
+            "lat": 26.1072
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0ac32d72-f63e-46bc-9e29-9e1f355284fd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.3306175,
+            "lat": 35.45903097
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "04d2254f-a241-421c-85f9-2ed8b56935fb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.506447,
+            "lat": 43.840464
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e3b8e1ea-fce8-46df-84b0-ad27d0ec93cb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.3990529,
+            "lat": 33.65522057
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d5d38397-c1f6-4410-bf02-4fa650ac841a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.862103,
+            "lat": 47.417428
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d726e664-1efd-42fd-a267-5e5b775f650a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.1333,
+            "lat": 45.7833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f4a8d0aa-111d-4473-b050-ba7c168ec231",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.6108017,
+            "lat": 33.2715999
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d2d912b3-d1b2-4445-b6e8-5bf9257ed769",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.704013,
+            "lat": 43.051827
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c8d3bb81-e57f-4ae3-b4a5-763fad51e8cd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.5775612,
+            "lat": 32.92391365
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5a8fd659-3099-4721-b82c-e85989549491",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.5513964,
+            "lat": 36.65197017
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "751ea1ad-4ecd-4a79-855b-fc8482e8cc32",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.6108016,
+            "lat": 33.0971983
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "607c1f63-a672-4560-ad32-ae057c46c676",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.398097,
+            "lat": 41.343335
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7f44d2a8-dff0-407e-99ab-28043d1ecee6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.5000214,
+            "lat": 36.93661798
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "81f65220-3347-4e17-978f-cb38d4454d7f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8980459,
+            "lat": 36.94990921
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f172b54b-5a62-443b-95ab-5724141f3af9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.8463059,
+            "lat": 33.06670221
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b560fbac-846c-4ff3-b695-74ceeca65d56",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.839157,
+            "lat": 32.064445
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a3d2fc1a-7348-4abf-be61-2a0107821dff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.453883,
+            "lat": 44.889588
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "afa71196-0f4e-46a2-bc04-d7fe8dca8fe3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.00895,
+            "lat": 32.20008
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "59116ffd-61a9-424e-b4f8-58385a940fba",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6d2855f6-4efd-4402-94fa-51bf7b1f644b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fdfa8a08-154f-47f5-822a-b9f4012f4804",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.023447,
+            "lat": 31.205281
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2483e949-8581-46b5-a74a-0c4733933819",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.193023,
+            "lat": 42.650472
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0f83a8cd-8e81-4c7e-9642-621a6f14e2df",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.836547,
+            "lat": 44.941823
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "153decf6-03ac-4588-bee1-d0e44bad9e94",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.8590515,
+            "lat": 32.0150703
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "165209b1-1929-45ff-bdfd-2ed4a94fa02f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.8833,
+            "lat": 46.0167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1c30494c-55b2-4b40-9fb9-a44ff9a4758a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.439479,
+            "lat": 42.389635
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "31b6b7fd-deb1-4270-a035-580cc9ca98d8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.3327093,
+            "lat": 35.96393964
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "901efb09-d016-410c-9671-be8f6e80baee",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.6679820779544,
+            "lat": 47.87203858912037
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3332e492-1668-48ab-9630-f0c2e3fe0495",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.03092781327021,
+            "lat": 46.758468841048824
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aac2dc63-e1f4-4678-afc3-40a978822aef",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.371391,
+            "lat": 33.646389
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b590eb33-59a1-4e5c-a027-2403edbe9b6f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.398433,
+            "lat": 41.571013
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a7d0a2f5-8ad3-4014-a79c-57da60a50d2e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.003878,
+            "lat": 36.736608
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "40c9cedb-0795-4ccc-8a65-e5bab1085d22",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.267818,
+            "lat": 31.657602
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bd334ca1-ec18-45db-9bd4-ba1641049431",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.948747,
+            "lat": 31.97208
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "829dfc17-5695-42fb-bf94-e3f831cb66a5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.538789,
+            "lat": 29.492256
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "86bf5f48-c5a2-42a8-844b-1b9094bca319",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.90498,
+            "lat": 38.26932
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e525b068-3f42-48bd-a1a8-055a989bee84",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.3075,
+            "lat": 16.8127778
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1355c007-2d3f-4ea8-8470-413bda4d482b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.05,
+            "lat": 28.76
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a51f533d-7845-43ed-aee0-a2da4f6882ea",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.68,
+            "lat": 29.83
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e7cbe74c-2e2f-427c-ac9d-20b4c72f3bd3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.58529,
+            "lat": 32.78286
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fadd49c1-da35-4820-9796-f49067f24883",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3814233,
+            "lat": 35.68598484
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f3d3317a-b063-473f-8628-a00659f15b22",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.552364,
+            "lat": 45.498218
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cecf4cfd-49e9-4d0f-86e6-b06a94c25627",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.6670405,
+            "lat": 36.13310831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d4327937-8878-42fd-b9d1-a04db63dce5a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.55,
+            "lat": 46.4333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6fa3d0f9-a184-48a4-990e-294f1ebf4ae0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.661108,
+            "lat": 42.185463
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5482f549-5017-4836-a06c-31a5b58ea740",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1b92c68b-6827-498f-9881-f3be90072acb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.6118402,
+            "lat": 35.96377309
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "35f8bb5c-d996-429f-a820-40a63fce05fc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.284249,
+            "lat": 41.979667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "765b0291-33c2-4ea9-afe4-ca5468da6ebc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5370025,
+            "lat": 32.6563984
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "83f8d04c-0ade-4c80-a8f5-18d2d2c0c461",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.228852,
+            "lat": 42.098255
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "95f595ab-c3e7-4b95-89aa-4e3e55c4c1ed",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.6167,
+            "lat": 41.6
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fe6e811c-3f52-4ee3-86ab-5203c3f495d6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.583333,
+            "lat": 49.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0d670b84-227e-43e8-a6e0-54a62fb70a98",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4815,
+            "lat": 32.3723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8a0e83a9-10a9-4fd8-8399-6a7601d51440",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.358505,
+            "lat": 43.889692
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "27667ae6-fdf3-4a81-b5f1-d0bb89b0eb9b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.922679,
+            "lat": 32.781433
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "72c4e360-ba36-4fd4-99f8-42138ea823ed",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.05644,
+            "lat": 38.36354
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8ca9bf98-35c8-48aa-97c2-3ed45264f398",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.89839,
+            "lat": 38.41026
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "17944548-e9f9-476e-aa30-70af60a1d858",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.2351420523,
+            "lat": 32.923296
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f4f66adb-ff07-41bf-ba3c-84777e007432",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.5287552,
+            "lat": 40.4555206
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a3339626-e91f-46a6-87c8-97bdc6b34216",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f0a79060-71e7-41ca-98d5-81e59801b5c0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.6167,
+            "lat": 45.95
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b0c1e7ce-f980-4e74-bd1e-aa48ee28f936",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.965763,
+            "lat": 31.3436806
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cf9824a9-e309-4268-933e-da7f9262fd1e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.0833,
+            "lat": 45.5833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d63f7c7a-26b1-41f9-afcd-9518187b51d0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.840656,
+            "lat": 42.693656
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d7a85ab2-6122-4912-a698-bf967913c622",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.7144,
+            "lat": 45.5225
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d80ba8b1-ff63-4cd1-9785-3440016ecd5a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1783,
+            "lat": 43.4405
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e28df87c-ea40-45f7-8481-e24005e3047f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0696879,
+            "lat": 36.42752366
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9499ff09-747f-4d55-ab51-ddd098c8601b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.7167,
+            "lat": 41.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6dd30cfd-2ab7-40b2-b1fa-0d0da857226f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.3056,
+            "lat": 47.6738
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7f76d4a5-e259-41e4-a109-fe2dba391a91",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.4,
+            "lat": 37.3667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a600ea3a-ff31-43cf-be99-810883a402d5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.25,
+            "lat": 44.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7f3d3a21-d348-4c37-bdfe-4c8735b9b30b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.0652778,
+            "lat": 16.7088889
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "13a73c3d-7b20-4826-9cd0-222a6f99cadd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.2264202,
+            "lat": 33.62859905
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0159ac0a-cb8f-40e3-a661-8ec1c7fa022c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.8643,
+            "lat": 34.0606
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4ffa167a-0ba4-49c5-8f50-cbe6948f261d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.9413313,
+            "lat": 32.0665106
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "31d7e680-d467-472d-b9c0-1658b3c12525",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45199,
+            "lat": 31.83121
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "60fe3388-9eb7-45c4-9c48-03c84c5675e4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.3167,
+            "lat": 42.6833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "62c726f3-0772-4d38-b52d-0ce81b72ed89",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.7694707,
+            "lat": 32.69712368
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "62e3e9aa-2e6f-4842-b45e-f530ac9d773c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.8451115,
+            "lat": 33.195911
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "742e99d3-1215-4684-ad0f-5e0dbde3999f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.7156996,
+            "lat": 36.58222839
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bfed732b-a008-4220-baae-b00d9330a2b8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.9967684039,
+            "lat": 34.189772
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2504720a-f699-4d4a-9208-7fcb8d71b0bb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.211826,
+            "lat": 30.644952
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "708018f6-f101-4b22-ac3f-702d24fe8b39",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.45690199622679,
+            "lat": 34.64113964333336
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aafd9371-ab43-40a5-9b4e-545b0f1650f0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.3538889,
+            "lat": 34.5394444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "279b7707-0a61-4779-b96e-979dd7f783da",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.0744444,
+            "lat": 34.9855556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f755d2cc-1397-48de-9207-d4f57b5d3b3f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.51666,
+            "lat": 2.83333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1d76ef00-1869-47bd-9a1e-c74cf90c7cb5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -71.9,
+            "lat": 45.3833333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9f5c2bf0-7d24-4443-98c9-8443e94c987b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -93.1,
+            "lat": 16.7269444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5b2f4fde-a0b6-4e8c-8402-198a58e0b5e4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.999116,
+            "lat": 34.110751
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b0dc0bbc-d801-423b-8dc4-16428c1d0374",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.065862,
+            "lat": 30.422836
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c6b8f1d4-589c-4205-a164-eb55909230da",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -100.771401,
+            "lat": 31.449556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3396d9f8-75c0-43d4-abc7-9b76c298e21b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4488694187,
+            "lat": 32.574107
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f68f7c15-c693-48ab-989a-0f16816d6965",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9439,
+            "lat": 31.987097
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9abe8355-7703-49fb-a5bb-67864df77ffa",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.26508,
+            "lat": 38.18831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "277ad874-3362-4e13-8d5f-bef4dbf84194",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.23666,
+            "lat": 38.09507
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a4841f1a-382e-4eac-8bf0-b603d7599a83",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.30007,
+            "lat": 38.21662
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5c22bc93-d196-4f80-a873-f0312e6d158e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.98949,
+            "lat": 32.22925
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "966a5632-7378-4165-9f96-73db5da10fb2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.222013,
+            "lat": 33.159427
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2eefed3e-1a72-44ba-b0db-cac697526c73",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.726741,
+            "lat": 47.216651
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ee36a32b-2fb1-409c-a3d1-c4b489fa0161",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.578063,
+            "lat": 42.412688
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4b70abcf-fda4-4421-b9df-a27a250fe472",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.709701,
+            "lat": 41.965476
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "33873a34-06bb-47b2-acaa-3b143cabf1d4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3833,
+            "lat": 47.2833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3dbb6726-b608-4bb3-850f-e271e6bff3a3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3f01b8d1-548d-4b52-b748-b9da9e47de38",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.583333,
+            "lat": 49.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7aaf0bd7-1f73-42e8-9a47-2285e6f0122a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.421653,
+            "lat": 36.69517459
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "878831ac-9552-41bf-95cd-0795f97f5a46",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.3230203,
+            "lat": 36.30656257
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ce4a3519-800c-40d1-805a-7bf4eb4d9baf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.8,
+            "lat": 48.1833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ce87c7a6-4a62-42d2-b973-cb57c3052869",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.6167,
+            "lat": 47.3
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "be86df96-79f3-4e61-b5ce-5fe58fb14165",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.1211,
+            "lat": 48.3636
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b468f258-3d81-42a7-8cc1-c882a7d54be9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.04793,
+            "lat": 47.80817
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5f887e06-66e6-4785-b9ab-b9442e6074b0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.8342125,
+            "lat": 35.20982735
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "56afc10d-12fa-469e-a4b8-8694fe4f1dc2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.3667,
+            "lat": 35.0167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "35765763-a99b-408d-a2b4-77d903821dd7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.70534803117107,
+            "lat": 32.430375237105956
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "57239a6d-997a-424c-8a43-e12b5cc06e50",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.1411111,
+            "lat": 34.4794444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "12459d9b-4215-49eb-b61c-2e4d51910e9b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.27936495043488,
+            "lat": 48.07011148501395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8fda4206-9583-4e86-ae25-f92268ca7353",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.2430860186517,
+            "lat": 50.01652199931778
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d7b0c864-475c-4e55-85df-5dafdc15650b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.7966667,
+            "lat": 34.4919444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6b4f762f-1fe5-4c0a-841f-6203af1c4b3d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.8,
+            "lat": 43.05
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "07be1a02-1b72-46e0-9443-bfaf43d3c906",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.4,
+            "lat": 45.95
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d6123dc4-7fd5-40f3-b5d0-478f6cae9dae",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45699,
+            "lat": 31.84704
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cae71985-f582-41b3-9e11-68a9d56d208f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.843887,
+            "lat": 32.019165
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ec2fc924-218a-4355-a432-8eb0df93ef41",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.839157,
+            "lat": 32.064445
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "be4e8153-eee2-4ed9-a3e6-d633a0833d39",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.618973,
+            "lat": 47.869207
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ff0a435d-c973-4c96-b604-428babec38ca",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.034706,
+            "lat": 49.023421
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e8820983-b0f2-42c0-a364-b6588de133ef",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.023447,
+            "lat": 31.205281
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0c8b47e7-5ea8-4941-a225-b5ee18ea2e90",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.75904,
+            "lat": 38.24872
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5c78c797-ee03-4939-ba96-09b57ccae9b6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.837393,
+            "lat": 47.240458
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "304e7637-15fd-4bf9-954b-75c1d3200275",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.062077,
+            "lat": 44.49517
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "40edcab4-c0ed-4729-8d4d-4af70961e542",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.358505,
+            "lat": 43.889692
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "830c9e63-b540-495c-b4be-3e81f70a9dc9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3,
+            "lat": 47.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9e3d4374-d04b-4767-9ce6-02e2b05babfe",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.2377,
+            "lat": 43.3675
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8e0f4b41-b948-4414-a048-2c17c5fbf6fc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.55,
+            "lat": 45.3667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "87e529ab-8217-4a71-abfb-e2527fe0e3b8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.663485,
+            "lat": 35.078382
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "66dd332c-ebab-4709-a060-c4537937aaff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.116331,
+            "lat": 34.4620667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6c7eaab4-0f4c-4b76-a88f-316d82c5069e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.588315,
+            "lat": 42.624914
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7d28e4cc-7bc9-465e-bc62-fd430d824826",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.980266,
+            "lat": 42.072418
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "92046b97-09c5-48e5-8fe7-88222564e424",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.5997222,
+            "lat": 19.5325
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bb8b2932-d3f3-4f41-8495-e2137e5b436e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.5997222,
+            "lat": 19.5325
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "96d10f1d-c5ce-49fe-895d-f70c5376f0d3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.24921,
+            "lat": 2.94472
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8bfd0ceb-7e8b-4d5f-b43a-8f6c7c87f30a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ad15ca0e-5a43-49ef-927e-5550a77a28f0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.9366,
+            "lat": 38.24785
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1722d42b-2bfe-4832-a893-d2980fc30660",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.77487,
+            "lat": 38.26303
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "04188ddc-5022-466d-9a4f-146a6fc08f8e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.8442,
+            "lat": 38.29893
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "177872a6-2276-4ae0-8b89-34d50884811c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1,
+            "lat": 43.3017
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2afb120f-a2a2-43b6-a46f-328755694655",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3283997,
+            "lat": 33.7977993
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2f3180a7-3898-493f-b836-a7fe2ece8855",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.2667,
+            "lat": 42.3
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ebabba0f-a7ae-4411-901d-b8fc1dd66c11",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.4667,
+            "lat": 47.7833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ed7732ca-bbc4-4aa8-b41b-e50183f4407a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.7,
+            "lat": 43.9667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5a5b8b94-dde6-48d8-8478-61035372fcf0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.54017,
+            "lat": 32.53162
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "607953d3-6f27-4cbd-aede-020e10fe71ba",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.980266,
+            "lat": 42.072418
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "39f7a18f-ad6e-4a82-8371-1d40d616488a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.0444,
+            "lat": 47.1056
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ce9d1ad2-4117-475d-ba3e-13af2629b41f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.6833,
+            "lat": 46.6167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7de285f2-adf3-40ac-a9ae-7bd6c8d4e83b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8241289,
+            "lat": 36.19842254
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "82ab2427-ef35-4266-a615-91e9d7b3f732",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.5520091,
+            "lat": 35.60248571
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "84b9a798-ff7d-4652-b01b-6533817b67a1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.971101,
+            "lat": 33.568315
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "99f641a3-04fb-4b90-928c-4f5d3b504929",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0675816052,
+            "lat": 34.423023
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2c95b12d-852f-483c-9582-0dca98e164d4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.2432676797999,
+            "lat": 31.14081461087519
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "69175896-2bfe-43e0-bb8c-432722d641da",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5167,
+            "lat": 46.8167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3fb55b80-ae44-4c62-9f0f-d2da4283ed1c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45,
+            "lat": 31.8333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "36de0ab2-dfa5-4556-a104-ced17852ced9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5108333333,
+            "lat": 32.4488888889
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d83b3bd8-56e5-4515-89f0-077302f73165",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.9586111,
+            "lat": 34.5730556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "98aeadf8-e261-4159-a191-afb86511a58f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.7,
+            "lat": 29.84
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7136b240-d6be-48df-9167-441ec4c01b83",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -60.2666667,
+            "lat": 6.3166667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ca28148c-bb78-490c-b2ba-38d51d6837bb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -83.05,
+            "lat": 27.68
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "32d92189-6a0f-47b0-98a9-1530ed066a57",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.78,
+            "lat": 29.96
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8e88b825-8e77-4fbd-beb7-df2ff5939cdf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -100.4470627740817,
+            "lat": 25.337229522704224
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "384ca38d-0e69-44a4-912a-efe5e9eaa7df",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.0666667,
+            "lat": 16.7
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1f5bd021-dab8-4034-85fa-3efca177265a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.8733726,
+            "lat": 33.209141
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "23581901-6ad2-408f-9dd7-08b9efe4638f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.70963,
+            "lat": 32.72195
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "89247554-bb0f-4f98-aef8-a1872d272d17",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.988198,
+            "lat": 29.47668
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "23e4234a-2ed1-44a1-b3be-1ba8a46bd051",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.49459,
+            "lat": 38.39973
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fbf2a7b0-af72-4c2a-9221-ac7ed11b11d2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.5842,
+            "lat": 48.0905
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0c4c1e31-a905-4111-b1c2-856aa21ffb8f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.578063,
+            "lat": 42.412688
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "02bb9181-7fdf-4b2f-882f-f3f0ea719d41",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.7167,
+            "lat": 41.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e561b5aa-d190-4fa8-9a2a-1e13f5e7b6ac",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.930399,
+            "lat": 34.007188
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d50522ec-b8f8-4916-a742-d9df230de319",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.55388,
+            "lat": 32.46175
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d6c24f0e-3bc5-4e42-a53c-4e82ee326103",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.4456449,
+            "lat": 36.32419911
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dfb83ba7-8cbd-46b4-8eab-7b627407b39e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.685653,
+            "lat": 45.875337
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "eaa7295d-767f-4216-9184-32dcb35565af",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.2,
+            "lat": 43.35
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "19b484c4-6dbe-4261-bd19-3cacac0e9378",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.25,
+            "lat": 45.7
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1c35abd3-fae4-4cb6-9064-e5bd11c75a32",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.9613,
+            "lat": 47.4772
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "466954b4-9589-4d8a-a73b-d9c0ba339f71",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.1,
+            "lat": 42.0167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "48daee55-7ce0-4471-954e-634918a98917",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.4428684,
+            "lat": 33.55887072
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a47f789-20f1-422c-bc48-a53a0fae8656",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.358505,
+            "lat": 43.889692
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a68e9d2-27ef-48e7-825d-06cf8e586761",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3814233,
+            "lat": 35.68598484
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2ef3fd7b-ba82-48b6-ae1e-4cee200d4451",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.568312,
+            "lat": 42.455749
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a6c91518-3873-41a5-9ddc-21828ba44530",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.73811,
+            "lat": 32.68619
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7e034595-0fb4-40ab-bd9d-157474c55ef8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5355555556,
+            "lat": 32.7852777778
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "98aff395-166f-48c6-870c-b758ff0e1910",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.5667,
+            "lat": 40.95
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "991cc3d0-82ce-4baa-86a4-235a5fea294f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.6,
+            "lat": 47.2833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7c2498e1-a9c8-4253-ad84-0b10ce7cfc1b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5370025,
+            "lat": 32.6563984
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9539fbc0-15fa-46e1-b6df-ca5ba98378f4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.45,
+            "lat": 44.1
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "85b2e690-0f3d-45c6-8cf9-162f918f36bb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.6167,
+            "lat": 43.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "22d943d9-1972-4c60-944d-10d010607ea7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.24090689809088,
+            "lat": 34.04001250669102
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4691aba6-8f00-4e17-a83e-8ad1650a7a75",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.5301184634637,
+            "lat": 31.32117132075479
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4d45a71e-3f05-41ef-ac18-5fc6d605784a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.62,
+            "lat": 30.07
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "97a655c3-326d-4edf-b264-72b429d3f693",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.48946065773008,
+            "lat": 43.865971809834356
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8ff1e92c-ee30-431a-9cf0-a80afce8dd58",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45,
+            "lat": 31.8333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ace925b8-0c38-457c-b9fa-f319262e1225",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "37a0ce0a-36ea-4672-a687-5ae26be6a045",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.996594,
+            "lat": 34.169938
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7cf7435b-1bee-4e21-9a7d-53b5b30c3ea9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.587784,
+            "lat": 32.934803
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "de2477be-db30-4bdc-9c64-01006d9c05f1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.305555,
+            "lat": 37.191825
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e8ce411a-a255-44dd-b1ef-490eaa5a65d4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.7,
+            "lat": 29.84
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8b8a6649-0861-4dec-b617-94141d78e4ec",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -88.72792,
+            "lat": 17.9291
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "20baaa69-e3dd-48ee-b213-4ff3ab1bd587",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117,
+            "lat": 48.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0efe9ebc-221b-42f3-ad0f-d4c6e6bdeada",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.2833,
+            "lat": 43.65
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0f413177-d24a-456a-8c41-ab0141143989",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.3,
+            "lat": 41.9167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4452f55f-cdb7-47c9-8d7e-089eed516a9b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3,
+            "lat": 47.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "625e44dd-b0b7-41b7-999e-7e0da71a6145",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.280416,
+            "lat": 45.63822
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "544950c0-66f2-4cee-b2db-2cc4a5883785",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.879841,
+            "lat": 48.610556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "71bc48ee-d234-4141-8c1f-d6526a274499",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4913888889,
+            "lat": 32.5752777778
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "72708c81-f440-4f7e-8dee-0cec9e549297",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.031824,
+            "lat": 47.252699
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5dd13686-f7c7-401d-832a-7f08aef3ef8d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4320983,
+            "lat": 33.6151996
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bb27672e-6418-4291-8ec9-05b0d82b16ca",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.0995322,
+            "lat": 33.32427036
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cf20f65c-61ff-4103-a49f-d965b550ad82",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.7980283,
+            "lat": 36.55532371
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fa2508c1-673f-4203-af89-3f6a2f05a320",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.4333,
+            "lat": 45.4667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b15bf8c8-979e-432e-bde8-0f9067051c69",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1359,
+            "lat": 43.6463
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9ae589a8-b2c4-49b4-a4fb-a3b1f6ef3e2c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.179865,
+            "lat": 46.602404
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "38bfdb8b-b3af-4400-a08d-e8a5aa266919",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3814233,
+            "lat": 35.68598484
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f3f85832-56c6-4af6-8229-1b6fa1da4845",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.498829,
+            "lat": 42.569645
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a68ad1c4-2333-4375-b0df-f2fdf49d802a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.57184434571354,
+            "lat": 51.43505948090899
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "df1fbedf-c8d6-41c6-b16a-4ecdef00fd55",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -100.280366,
+            "lat": 29.361793
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ab2e5b8d-057c-430a-b697-d52d0cc27e39",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -100.762938,
+            "lat": 29.783718
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7e12b152-bd2c-41b0-8fa9-6299f2ed41de",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.7583138889,
+            "lat": 34.8923638889
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ee0a0d66-965b-448a-af32-d245fe152e16",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.030955,
+            "lat": 33.176485
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3cc3a718-5ce3-483e-9300-5cafd76f2a60",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1976118178,
+            "lat": 34.402723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "918bd012-7155-4e81-bcd5-d630fe7975b9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9035778406,
+            "lat": 33.385604
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "db5a6c40-e49e-4efa-91e6-de1ac944c2fb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.3789,
+            "lat": 43.4867
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6e636695-8b0f-44da-a694-8a5cf4030fa9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.839157,
+            "lat": 32.064445
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6a2be626-10c8-47bc-96fc-71f093a5fe48",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.5667,
+            "lat": 47.85
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "785a4a17-0594-40ce-a3c0-f3bf965f372f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.3700028,
+            "lat": 31.4379009
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7aaac359-a1bf-443f-84eb-01f91e8976ae",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.5333,
+            "lat": 43.65
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7ab35e71-bf39-41d9-9f5f-b20fe84a07c2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.71766,
+            "lat": 32.74083
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "88f89dc9-47ea-48f9-9c57-1037c63f4342",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5951281,
+            "lat": 35.0441862
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "22eb2dee-487f-4378-8437-bca5fd308007",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8892102,
+            "lat": 36.12980468
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "46d751ce-b97a-4a6b-9348-343578574b15",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5386964,
+            "lat": 32.4817997
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "424147e6-e77b-4122-a211-66ce15fef8a1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3814233,
+            "lat": 35.68598484
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9846785d-ac3d-40e4-bd7b-113afb46f321",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5667,
+            "lat": 46.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "993674f5-37bd-4328-997a-9ef286ef4733",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.8553,
+            "lat": 47.3779
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "843ddc55-da56-4950-92a4-40f918376fa9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8421335,
+            "lat": 36.49110212
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "603f236f-7470-49ee-b2d0-809078677b07",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.069495,
+            "lat": 50.005021
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1004fe18-54cf-450e-8b5b-159a7a4bbc11",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5370025,
+            "lat": 32.6563984
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0dac5b06-e696-4811-9fe7-a4f5adeedf43",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "011c3e74-e6a1-44b6-a52e-5427320d445e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.458487,
+            "lat": 46.772398
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fa7db773-c693-402c-bdb9-dc8836dfab0c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.3230863,
+            "lat": 36.59449928
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dba2ce29-d39c-468a-ab8c-5939b3130821",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.32,
+            "lat": 47.81
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6ad15302-6a94-4a93-a10d-9c52f166f29f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.7,
+            "lat": 29.84
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5d08f8fd-c6f9-4be2-8ca9-d20a4b0e2d57",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.8752778,
+            "lat": 34.445
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "120f036a-1d3c-43e7-90ac-fcbada0ded89",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.2427778,
+            "lat": 34.875
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2c47512c-e221-4595-aa6e-1209b14b44e2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4869614,
+            "lat": 33.9358292
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2e2ab618-0cf9-4a84-ad1b-992ec62fa8bc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.881692,
+            "lat": 41.707223
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "edd5c017-143e-4a1b-8749-3b7d51f43bfc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.4,
+            "lat": 44.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f1737125-836e-46dc-8e1e-b78eb85e79ed",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.5667,
+            "lat": 40.95
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "16af005d-15ff-4965-bd73-0a078d8955a6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.083,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7f75c0c0-4ef4-420b-9936-eaaa27c095a1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.7167,
+            "lat": 41.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "155c3c39-0bac-4d90-ab22-21cb1be43942",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.6666666667,
+            "lat": 39.0333333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "022f5815-5815-41bb-984f-223fbe582a5c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.0067,
+            "lat": 47.9031
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d9e6d5c5-0a2a-4108-8a30-e980deaaae7b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.6333,
+            "lat": 46.4667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e6e36ccb-d6b3-4ded-9036-d8007bdffe08",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.9278,
+            "lat": 42.9634
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3440511e-9d53-48fe-9eba-a1cc7906e7ab",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.7,
+            "lat": 46.25
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "63652294-6589-41f5-a28d-428f1969fcb0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cabc54e7-2300-4b88-bdb3-c3d03f46b7f9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.371391,
+            "lat": 33.646389
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "949ff09b-7d86-4cd6-803f-d640b4722c4e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.980266,
+            "lat": 42.072418
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a4fb779f-9f0e-401d-b453-ef70f2bc6e6b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.5165075,
+            "lat": 36.61380764
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8878ae7b-48f1-4566-a4ab-a49a04414688",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.9802671,
+            "lat": 34.32554235
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "88c0f13c-3028-4ed2-910d-551708366302",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.638757,
+            "lat": 47.812111
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1a7ee4cb-3bfc-41ed-8f7e-53f8cc29e791",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.36599,
+            "lat": 38.27911
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4493e4b5-8e50-498d-8e4c-9b3de8c02a38",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.80493,
+            "lat": 38.26413
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b82d350d-0e0e-4576-abae-b6be2a46aee2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.10036,
+            "lat": 38.36833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "788a38f9-6c64-489d-9bf4-9f2a4ce427ed",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.81584,
+            "lat": 38.27669
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "abb3ec93-5ef1-45f7-ba76-ce0ace24cb05",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.14532,
+            "lat": 38.70966
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "410268c6-c222-4119-9b28-6469635e14e2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45699,
+            "lat": 31.84704
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8737e7d3-ceb6-4c54-96a5-48a5b3b32c37",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.4527048,
+            "lat": 31.862281
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "89687a6c-9c50-49fa-8876-2d803f28fd33",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.85455,
+            "lat": 34.56332
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3290828e-e796-4bda-8e14-dd2e1159dae8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45699,
+            "lat": 31.84704
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "452d4333-3cc1-4eee-959d-f50a84ed6184",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.85494719366714,
+            "lat": 34.136005696895964
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7416f7c9-b740-49ee-bd09-e8777dd555b7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.69464044233644,
+            "lat": 26.902984615965437
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a8cfc488-445f-44dd-b366-cb0ef7c706ab",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.42611562621818,
+            "lat": 31.391169068081208
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "17e2ad34-e9ec-4244-a0a3-5c4d82827532",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.99149672648753,
+            "lat": 47.20429803474714
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6adf8020-8673-4c73-833b-b6ec104baddd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.8167,
+            "lat": 44.3167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ba2eac48-ae43-472a-a656-7725a4eb1e1b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.928287,
+            "lat": 33.216822
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0377bda7-4d77-4dcb-b219-f556b01f4a07",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.00895,
+            "lat": 32.20008
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d2b41713-f0e7-4187-99f3-ea6622c2b2d1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.0302,
+            "lat": 38.40462
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "00c4c593-7ca6-4bd3-8c7c-09876986ab64",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.930399,
+            "lat": 34.007188
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "231ea4a4-8a03-4e57-bc7d-abdfda31374b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.7667,
+            "lat": 46.6667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "24594de0-9913-4dad-bd25-f172c6b191b6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8957343,
+            "lat": 36.4001229
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "25053e10-ea9a-4d5e-b8bf-9ca7a7a91bfc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.561397,
+            "lat": 42.248246
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "269e1237-3add-46d1-827a-57e1d6ccb033",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.8752406,
+            "lat": 32.74177948
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2c3a63db-f4d6-493f-a968-24634eafd06c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.186558,
+            "lat": 35.95853287
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3ed6b714-9025-4829-991d-2081136825e1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.4600536,
+            "lat": 32.95146251
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3fc166b8-53b9-4663-973c-3effc25c9837",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.85,
+            "lat": 46.3333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d019a432-d11c-4b2f-90bf-5308786bed93",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5167,
+            "lat": 46.8167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bc2ecc4e-f498-4144-a895-fc58634d3d04",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.127167,
+            "lat": 43.91853
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b0cbfb1d-f5e6-4514-a5b1-0f4719ee7657",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.515625,
+            "lat": 44.664062
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6d5997e9-96e9-4d83-b0f7-22162aef8e92",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.1753028,
+            "lat": 36.3858875
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "61960904-faf5-454e-a841-8e14a494c302",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.8667,
+            "lat": 41.7
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8bc080dd-b448-439d-92fe-1c6b4d35c6c4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.7279843004,
+            "lat": 31.8404445412
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7c408d83-6e8f-4f15-afb0-c2383b9b56a9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "347ce222-5bdc-4b51-bb93-1e81e9f0f60d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.6894489,
+            "lat": 33.55473024
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "84e87309-a894-447b-b877-10dc8ec91137",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.9833,
+            "lat": 41.4333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ebc192ef-3c16-41ef-95cb-ef8e329039aa",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.632402,
+            "lat": 43.373292
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c0a1ebfd-eabf-4a25-b5a4-d73b04bda913",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.10468,
+            "lat": 33.42485
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c2016bbe-2743-429f-b1f5-1d970e52fa25",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.676375,
+            "lat": 42.678524
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6f8df9b9-2282-4110-9fc1-cd7b164c5dba",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.70136792562936,
+            "lat": 33.18755451730115
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aba187ac-2f2f-45d7-ab04-054f0b11d498",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.0652778,
+            "lat": 16.7088889
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "566504fb-aa86-4b31-a220-cefbf0db3f17",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f6a28ff9-36b5-4844-90f6-d646c3fe37d7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "40181ebf-e5e7-4fc2-a9f9-e30c6479eaff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.399,
+            "lat": 47.3925
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7c6929fe-6fa5-4b08-aec2-354d0e300a55",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.9572222,
+            "lat": 34.5733333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "eb5e4be8-edd1-47e2-adaf-05bf8d39cf58",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.42614340128415,
+            "lat": 17.471761465164693
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4a8c2764-f55e-480e-bd2d-33260e756d16",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.08446,
+            "lat": 34.434365
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "829aa392-5f86-488f-bec5-72635712454c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.00542,
+            "lat": 34.10544
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4013e0a5-0e4f-47c5-ab08-1c39d87fa4ac",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.5151030141,
+            "lat": 31.89959
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "119d0f2b-cfc4-4c03-9f34-ac17109b8696",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.93061,
+            "lat": 32.05676
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5a91102c-1365-45be-9eb0-88e1ac09d5b6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5bf96646-8860-4d67-86fb-e3fe8a676031",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4235381,
+            "lat": 36.9188647
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4ef620b7-9035-4960-a529-04550b5cbe65",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0530009,
+            "lat": 33.19238112
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "72d362b7-00a1-4f55-bad7-8ab751e3144b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.012824,
+            "lat": 40.977423
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "765827e1-519f-4d22-a8e8-db569801b06c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.119714,
+            "lat": 42.131583
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "91c4b863-5e67-46e0-9c48-91d5032ec203",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.751261,
+            "lat": 45.122378
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b6c74cf7-4297-43d7-a84d-dac9da91a6cf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.186165,
+            "lat": 45.102615
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8b130567-959e-44de-a999-e1395efc08a4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.7322018,
+            "lat": 33.09368738
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a3a0c621-72e3-4514-8e68-584c72a54d5a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4815,
+            "lat": 32.3723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dcbcd22e-bd45-4ba6-81a3-b19c5b94ffe7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.412674,
+            "lat": 47.575193
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ebffcd19-4c30-4f79-b160-2ff8d73d17bb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.70534803117107,
+            "lat": 32.430375237105956
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "55a2fa38-4930-4294-b1fe-c14d850a585a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.63631602658984,
+            "lat": 48.0959373892604
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e9b28552-1945-4a61-a41b-c49341b8589d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.69464044233644,
+            "lat": 26.902984615965437
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "717c94b2-03e2-46b4-80db-9de3b47cc34d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.402,
+            "lat": 40.16329
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f9e288e2-2d98-45e1-ba2d-a3603728dbfd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.7,
+            "lat": 29.84
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d0230bfa-436f-469f-8f10-ad41701c7da1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.93333,
+            "lat": 2.58333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "996d4c05-8374-4927-9946-d7206c298bcc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -81.5,
+            "lat": 28.76
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8ea639c9-b355-4b57-b122-f540deb3da86",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ece8b75d-ead2-488e-b27c-6cfc1410bc41",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.0652778,
+            "lat": 16.7088889
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0be0aa0a-0d34-4d1f-a418-b2ea942d5bdd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4629567,
+            "lat": 36.68926527
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "06625189-a0ae-49c5-9b4f-7c79d708097b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.9167,
+            "lat": 42.7333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "08420f0e-ec94-462d-a990-190b3c5ba3c1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.330878,
+            "lat": 36.97136655
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "30b4da97-8f8f-48a7-8e0e-065418a7e69c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8307448,
+            "lat": 36.00451235
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6e5769cc-24fc-41bc-bf0a-06f679159f7f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.5,
+            "lat": 46.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6b5b7e9c-4a29-4412-b415-700ab0b9bce1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.75,
+            "lat": 44.9667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "655a3a8d-3d11-453b-905c-98dc873fdd03",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.044246,
+            "lat": 43.893791
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "67d18be1-4028-4909-85b4-5a1e95cb051a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3283997,
+            "lat": 33.7977993
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "77e4af69-ed74-4822-b7d4-2217e0bac4bc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.6167,
+            "lat": 46.7833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "558dfd33-25ba-4ce3-b08f-472a80f28d79",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.412674,
+            "lat": 47.575193
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "563c9d00-c1dd-4a7c-aef0-d507e275c833",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8719146,
+            "lat": 35.86865783
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4f35ba1b-6ea6-4ca9-a4c6-6e7877e38fc1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.5889628,
+            "lat": 33.32216539
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "48ecb6b4-a855-4608-a08d-906755be8390",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.8187677,
+            "lat": 34.0845659
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b6d820de-3d01-4956-80e6-e425c08ecf3f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.401033,
+            "lat": 48.656324
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e5462206-fc98-44a6-815c-88eb224e57d1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.240617,
+            "lat": 31.592321
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cb7a1e50-41f6-4523-8509-5135a4886f52",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.7,
+            "lat": 48.4167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ecab0aa1-3659-459a-9d90-da1ae51b3434",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5167,
+            "lat": 46.9167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8c205c15-e262-413b-82dd-0c5dbb590d5f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45,
+            "lat": 31.8333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bd0734aa-6c6d-4982-90e3-35f3c4d9f3d6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.675907,
+            "lat": 44.254635
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a1808fb8-7b8e-4317-9e8e-af11b59bb3fa",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.4553,
+            "lat": 48.1048
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8d56bbae-0ab4-4426-a4f5-469c74302435",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3283997,
+            "lat": 33.7977993
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9b8b1779-211e-4fa9-a724-ba90a5e7d3f2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5951281,
+            "lat": 35.0441862
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c2fed92c-21e0-4b93-8348-2e57687f4d41",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.228838,
+            "lat": 32.420674
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9a314016-71ef-4dcd-83bd-7d83a09bd423",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.4,
+            "lat": 47
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "94b17f2a-90d3-4ecc-be7d-f9fddf4b0d7a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.583333,
+            "lat": 49.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "14cdf49f-2d57-4206-a7e9-188531aa6fbd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4716035,
+            "lat": 33.300701
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "33e3e56e-b25d-4490-af3b-ec759e94822f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.6368231687,
+            "lat": 33.045015
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "482d5f43-bf64-4721-9f48-35a8f0fa71b3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.0141666667,
+            "lat": 31.7394444444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8e5d46e3-3cf1-4ed9-8acb-8eafdb98e019",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.19463967646935,
+            "lat": 35.22880270194663
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "59d731d9-287d-4b9c-b350-67ff64b85a83",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.038887,
+            "lat": 34.7777786
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6694e46a-44ca-48db-aa80-a440f7750e2e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.57184434571354,
+            "lat": 51.43505948090899
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c5e82b45-b59d-45bb-ad1b-43d817eb94cc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.2446518,
+            "lat": 29.3631592
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ddef5fe3-969b-4f18-87c3-14d0adf8baa7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.5022088,
+            "lat": 36.58913748
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e10b25ad-0dc3-4288-bdd0-46152d86c92e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1006,
+            "lat": 48.0797
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e1a533bb-e8cf-43fa-a160-7666b4f20a18",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.6197801,
+            "lat": 35.80051308
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e56d4d4d-83d9-4c6e-835a-d7e2b44d3f69",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.5667,
+            "lat": 47.85
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a10c5a42-4fda-4ef1-a869-67f0359f231c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.228838,
+            "lat": 32.420674
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a3332135-9725-4901-9f92-0430021a17fd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.297303,
+            "lat": 43.463785
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bcf62f2d-eca3-4e37-89dd-85d245173c54",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4894444444,
+            "lat": 32.5325
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b418adf9-ad6c-447f-bc37-8418eca74426",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.111577,
+            "lat": 42.098688
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b734a4e0-0962-4e66-91f8-b2208d5ea8b3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.98941,
+            "lat": 31.78605
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d6a0c232-ba09-45dc-8a8a-db354eced465",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.8343198,
+            "lat": 32.93148319
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d8484ef5-edc6-426d-9dec-91b7ef4c0ee3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.32556,
+            "lat": 45.41263
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ef4e76da-9f0e-4849-9bd2-ce270735f336",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.386267,
+            "lat": 34.67610615
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5dceb0cb-8e79-4a52-aa4c-7a473df4af7f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.201177,
+            "lat": 47.37235
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cbe3bab3-537b-4fd8-bfb2-97b62a07e739",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0758512,
+            "lat": 34.464825
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cde4fb79-acfa-4f66-b54e-9016e569f5a2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.49399,
+            "lat": 38.25271
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "578a1b06-bf2e-4cbb-9dbf-0e32fdf6d756",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.51666,
+            "lat": 2.83333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fcdec691-1910-4078-b28b-3f15b8e81f96",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.48,
+            "lat": 29.41
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ff2dc298-5f77-4fec-abdc-cca6feae98e6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0567057953,
+            "lat": 34.423206
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4f589d95-9435-4152-a123-fc61771fe535",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.008946,
+            "lat": 32.200082
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "65f73e97-3d20-406f-a8eb-d7ab2ffb6c73",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.9967684039,
+            "lat": 34.189772
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1f98f351-1c1c-47ae-9d91-d58eb52d0390",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.14,
+            "lat": 45.5451
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "39d90867-08d4-4902-a917-dd0e05752f04",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.578063,
+            "lat": 42.412688
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5de975a2-4b08-4bae-9eed-bd9b7a682c8a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.600088,
+            "lat": 42.283881
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "87cb3d47-5dd5-4c35-b5c7-cbed08732c36",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.600088,
+            "lat": 42.283881
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aec30f49-9c68-438a-af7d-6004e49aa43c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.583333,
+            "lat": 49.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8e619fae-e053-4198-bc1c-c25a7ee7686b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.16512,
+            "lat": 46.014636
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "92d29d48-e90f-42dd-8102-0dd4f5a7b4f3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.836547,
+            "lat": 44.941823
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8126e1a2-47dc-4b56-b979-bda08c771b6f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.284249,
+            "lat": 41.979667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "82d0cd2d-d27a-44c0-8b98-a97ca83884b3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.8333,
+            "lat": 45.5167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "83f31f4f-f0e9-49dc-b3a5-7c69584f65ac",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.2333,
+            "lat": 42.5667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "983d5aa0-5b57-4750-8954-bd1381e27f9d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.240617,
+            "lat": 31.592321
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a8c444b1-6311-4166-9730-0d16f24c1a78",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.119714,
+            "lat": 42.131583
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b023dd39-f913-45df-a1de-c5e6c05a5f0c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.083,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "13eba4e3-b56e-42e6-8de9-73ca35d7c448",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.4167,
+            "lat": 46.6833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "012a759d-8635-4aaa-add1-87917b6a524a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.942665,
+            "lat": 46.961838
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ea0052fa-3a50-4845-b5a9-23cbbf25d9e8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.4167,
+            "lat": 45.3167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fc27ad9e-4b8d-4c38-ba88-a249d9694bce",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0818641,
+            "lat": 36.41028167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cdcb5560-2a87-40b3-9ffe-48f7394cff31",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.7333,
+            "lat": 45.4833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e66949e2-cccc-488a-99e9-ac9260ad6b1e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.2667,
+            "lat": 43.6833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f3444ed1-c75e-44c3-a182-8302cdeb50c4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1535,
+            "lat": 43.5537
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "19a312f4-15ce-4dc8-99e5-3c03614c5e8f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4f34b4f0-6f16-4cbe-b5bd-777878774156",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.4667,
+            "lat": 42.2
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "835b0def-b95f-42c7-9544-d00581be7f0f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8481709d-494b-452f-adeb-ffb9618b1d0a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.091973,
+            "lat": 33.346183
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7930e63f-5018-439c-a48e-c23115216aae",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1153381,
+            "lat": 33.40545506
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6671f846-32ab-4afc-bdc5-d67ecd36b3c7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.2124,
+            "lat": 42.6743
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "59bcffab-0efe-41f7-9407-306f3ab9557b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.4333,
+            "lat": 45.4667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c1dd0b4b-6e27-4a28-b38b-89efa0bc4348",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.839157,
+            "lat": 32.064445
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9b82253b-f5db-4cf0-a3ff-21b14727b82e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.662,
+            "lat": 30.306
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5f47a532-4c15-401e-b52f-d621c12e98b7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.51666,
+            "lat": 2.83333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "49ebc0cc-7f92-4caf-a120-7be3597d7f89",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.084478,
+            "lat": 34.434229
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "09613ba2-8242-4aca-b25f-57acaf14e39c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.97402602,
+            "lat": 34.145057
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d9832dbb-3cdc-4f9c-b570-d4fa1c70ac01",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.999116,
+            "lat": 34.110751
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8ada5ef2-e93e-4199-8f12-0c3773607cb7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.005311,
+            "lat": 34.105622
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7782429e-8c6a-4f62-81f8-3fd6fd80bd2e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45,
+            "lat": 31.8333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "da0f6cdd-6a62-4c8b-b16f-46753e8b47f9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.8763,
+            "lat": 38.25538
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cfb7623b-523f-4605-9d28-6879fbad4556",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.83888,
+            "lat": 38.21945
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3896bc0e-0eca-4e4b-93eb-b8f7bcaa25dd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.660983,
+            "lat": 34.678735
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "39d3bbd9-087d-4586-9a26-e421bd3fbfbb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.57670559226793,
+            "lat": 33.76922795495304
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "036eb6e8-c4a6-4a66-bde2-f6835615149e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.9594444,
+            "lat": 34.5727778
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9455e763-44b9-4e34-a839-982e96195c9c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.2253579454,
+            "lat": 32.9595416107
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9ad53277-59a6-4626-896a-e41806e81516",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.023447,
+            "lat": 31.205281
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9fe2fb30-bf33-448c-b5a0-3ac7a38bc049",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1163888889,
+            "lat": 33.3308333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cbe21117-51eb-48b1-b50e-c51b13a5aabe",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.97402602,
+            "lat": 34.145057
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c5e3f6f8-1fa8-4939-b324-bb63f303963f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "73606500-c6fa-4e89-947c-03ad3095f05b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.8043,
+            "lat": 38.22658
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "820b0d2a-9ce0-46ad-ad77-05aecf9f2f25",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.79542,
+            "lat": 38.17156
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b675b68a-1c24-4c5a-8e53-83e8535ddbcd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.984703,
+            "lat": 39.739154
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e66dbe05-e1c4-4a11-ac1b-b11e3c90ab5b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -100.2769444,
+            "lat": 28.0769444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "10da513a-6075-45e5-b0f2-b39559c5854d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1359,
+            "lat": 43.6463
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "11c9534a-0970-4640-a130-a15ed7a6c2b1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.6201,
+            "lat": 44.894871
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "12a99758-3461-40b6-9b36-dad56fce2cf7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.062077,
+            "lat": 44.49517
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1cd0ef6f-0778-40cb-9b06-1f1518f1732d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.65,
+            "lat": 45.3167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1d2a72bb-48d4-45d3-8c5c-e4e85aaa1f4d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.7228809,
+            "lat": 36.09342829
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "73aa0613-fe0c-4aec-9ea2-1479098b20d4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1163888889,
+            "lat": 33.3308333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "60fdbb8b-a4d7-486a-92f4-b509e5cdbace",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.5421288,
+            "lat": 36.85675719
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5870c450-5a5f-460a-b954-58ee36e5dc3d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.414391,
+            "lat": 37.299671
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5d93e679-37ec-439e-a8eb-e97b4a244494",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.35,
+            "lat": 46.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "705e6112-73c7-4305-96de-8b2e6799ddaf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d2d263c2-cc21-41d3-8215-a2a8bd2e7a96",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.3,
+            "lat": 43.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c50f25c5-4953-41ad-bc65-2798bf4c897e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -97.145248,
+            "lat": 25.956192
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d571ceac-9d64-416a-bd83-570e41b667c6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.358505,
+            "lat": 43.889692
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "adf633a6-ea15-47dd-aec8-f58d85512596",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4320983,
+            "lat": 33.5285997
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bcff121d-d35a-4184-a4d5-eec43969a998",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.45,
+            "lat": 42.2833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2235ed3a-bb72-4ebc-944d-6fbd2997ba72",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.3252,
+            "lat": 31.60105
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "299b3228-ff6e-4c86-b779-84b331f84195",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.1667,
+            "lat": 44.0833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "318e97c2-a64d-431d-90da-d7539cfc4bd2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.4905229,
+            "lat": 32.75574484
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3f824013-d5dd-49e8-83f6-134fad89963e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.583333,
+            "lat": 49.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "388c2e48-00e8-427b-8d89-7f44733bb9d8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.7419,
+            "lat": 35.2672
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e2bbc357-e584-40fa-b177-20f1d776c755",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.652633,
+            "lat": 45.812124
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a9528189-86dc-4bd6-ab25-a53dd9646edd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.6520977,
+            "lat": 35.69214844
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "922f02a7-dddf-4dab-a6ca-37b75c3c7d10",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.49916,
+            "lat": 32.55842
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "933dd5f0-29ba-4813-9ac1-3b85754c6d64",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8841533,
+            "lat": 36.38227872
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f3ca36a7-95c5-407b-9da5-095a9146c3c6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.6555556,
+            "lat": 34.2722222
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "71dcbab3-8d6f-492d-b154-af550d76c976",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.321194,
+            "lat": 45.228806
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cd88ae0d-ac94-4c3a-8d00-57e74b526ff4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.4627778,
+            "lat": 34.6163889
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "71f67429-742b-4629-bf47-6985fd06c0b0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.083,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "735ba573-8e63-41ac-95f4-ee5c7661cd43",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -75.02184,
+            "lat": 44.479677
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "20c505d4-cc73-4a47-a12c-68c069add6ee",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.292468,
+            "lat": 42.395473
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1b71ad9f-69a7-418d-8848-e322022376b5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.633874,
+            "lat": 33.882056
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "18426a8e-3932-4a08-b097-9c5aff4b21a6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.5659798,
+            "lat": 32.72280989
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "00170cbf-5381-4d61-8cfe-85e101517e65",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.2487166,
+            "lat": 32.88261318
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d0f26ae0-d8ce-4a6f-9a6c-3040b0784a1f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "eec216a1-fb73-4bfd-bc80-b28423eb3465",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.55,
+            "lat": 44.2333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f01f344c-df8a-4d9b-af37-267796b22ee5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5333,
+            "lat": 44.4667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ec69813f-9d13-4fb4-ba4b-554f9470d587",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5132151,
+            "lat": 36.36268205
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f7b48cef-2316-4487-855f-4e30ef0e5586",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.770554,
+            "lat": 32.773888
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5ba176f4-8eb8-46f6-8fe4-b648b5ff667a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.8833,
+            "lat": 45.5333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "92fbca48-9cb3-44d0-933c-7799d2c5b4ae",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.89822,
+            "lat": 46.92156
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a7aa811a-f931-4741-829d-3895130160ed",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.407925,
+            "lat": 47.137142
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ac7d5f89-afc0-4f87-9ce9-f88ff0539d3d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.8333,
+            "lat": 47.2167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3aa4bb20-1a43-406e-9a82-2b16389e6939",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0207569,
+            "lat": 36.62619108
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ff9ca24c-0554-4a26-a0b8-1a39dbced23d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.685439,
+            "lat": 44.957319
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a0ec1b46-d673-4d95-a22e-8d180e1bdc81",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.008946,
+            "lat": 32.200082
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d4473657-a4c7-4889-8b45-1baa0ce00bb3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.35,
+            "lat": 31.6
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0048c521-16e5-4763-80e7-443c37f7a932",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.3903,
+            "lat": 42.1976
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aa8a5263-952c-4aab-8f5f-301511f38cd4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.83917,
+            "lat": 38.35783
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "785ef1fe-4c4a-4f02-bad6-8d5ed202a597",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.984703,
+            "lat": 39.739154
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ccf10c68-7fd3-4666-8c2e-8bfbd20dfa33",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.825508,
+            "lat": 32.114555
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b575b5c9-8131-449a-b1be-bc1449ab0fd5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0460495616,
+            "lat": 34.432401
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f3714f3d-2ab8-4481-b9f2-2f15d80165c7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.7679437,
+            "lat": 33.60786187
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f92fc094-15e5-4e4e-a556-3a4ca0002afc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.921,
+            "lat": 47.105
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "121787cd-cf18-4b73-883c-ccd58564ca18",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.024439,
+            "lat": 41.744369
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "08f17061-844d-4475-9ae0-cf80fb9b9814",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.8184586,
+            "lat": 37.2969437
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "03197478-b969-413d-bd4b-5c00feb6d995",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3,
+            "lat": 44.55
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "de237c51-47db-45e9-9a4b-054120a80bd9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.5667,
+            "lat": 47.85
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d872fbb4-ed44-4f5b-93fd-a28774af0a86",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.031824,
+            "lat": 47.252699
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "da8dbc78-a04e-4338-8d50-7cc68a95ad9d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.334944,
+            "lat": 35.92108499
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "59d85e3f-54fd-4a1d-ad64-fd6f1f36078b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.646393,
+            "lat": 33.080833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8ff882e4-d887-46a3-ad73-d8c982018b52",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.3612304,
+            "lat": 31.6035623
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aa4f85ee-4b4b-4f2b-8a14-146485028670",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.582892,
+            "lat": 44.468233
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ad9e348c-d61b-4e79-91b1-a20ef50b626c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.587784,
+            "lat": 32.934803
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b13a0f90-3d73-4473-96d8-35836984ffef",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.22239,
+            "lat": 47.548532
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c1a29a6d-2471-4921-92d2-cc4f4a686476",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.8125992,
+            "lat": 32.89554585
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4eaf50a8-a10b-4065-84d6-0b54a928baae",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9343ca9d-6a4e-4335-ab7f-07154e7f6bca",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.259753,
+            "lat": 44.698534
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "978a10c5-0f69-4aa4-aa7b-e6a0deddb768",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.996556,
+            "lat": 34.18074477
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6d0895d9-5207-40ff-9d40-bd99d1c791d5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.875,
+            "lat": 47.0004997253418
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "99e03792-681a-4bde-b6db-18d2e4fbfe29",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.43,
+            "lat": 25.57
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0e888de8-69a3-40f6-93e9-8703d13368a2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.78,
+            "lat": 29.96
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cfa25222-063e-4000-ad2e-95cf68a2f8eb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.069495,
+            "lat": 50.005021
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ebd99172-fb19-4614-b06a-9b137b82b059",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.663485,
+            "lat": 35.078382
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f093ae22-533c-4a2b-9649-e9359135d282",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.558184853,
+            "lat": 32.73515
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ae38d528-053a-486d-92de-062e675e21da",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f418346a-c41b-4dec-ba11-086a41968ae7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.82347,
+            "lat": 27.03037
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c72367d4-0db2-46b1-bbcd-a64648aa1b15",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.09944,
+            "lat": 38.39354
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7dde1912-3ae6-4eee-8bf5-f748d9b43120",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.98615,
+            "lat": 38.30474
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b5f4c300-c3d5-4041-a6a1-056bf6d77059",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.50616,
+            "lat": 49.458596
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bd5e35a7-fb36-4f17-822c-e1d41cb0b914",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.43,
+            "lat": 25.57
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f1c125d7-4f23-4d78-b4bb-f7a0ca2c21e2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.2710972,
+            "lat": 29.2735444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4f486049-9638-4b0b-a09f-eea01fd4daf8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -76.52,
+            "lat": 0.5
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "76c0f5f0-163d-4bf9-a999-4a96a9fd845c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.082324,
+            "lat": 44.911577
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1c213379-4605-4483-a33f-d754322e131f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.6450234,
+            "lat": 33.37458017
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "278185c6-c3cb-47e5-b2f7-dd00d131673c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1006,
+            "lat": 48.0797
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c3a2a667-9b9c-4d0e-b0ba-c6c507e2c25f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.52583,
+            "lat": 32.62175
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c980ccd3-4755-4145-80e9-be06b6ae14ed",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.3,
+            "lat": 42.6
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "55de6140-4789-4ba7-88f9-9773dde58235",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.646393,
+            "lat": 33.080833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a2e43d3-e25c-473d-8c18-510e4eda089f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.4043769,
+            "lat": 34.02822225
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "90cd8fbb-e98a-400f-a812-94e2597bbb30",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1228508,
+            "lat": 34.46935551
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "94ab6da9-e663-4d3b-be9a-08f608844f7d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.236109,
+            "lat": 42.597132
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "846508c8-473d-43e3-9f67-224fc1473867",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.407925,
+            "lat": 47.137142
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9c8a2e3c-be9e-4e7e-ac39-72e36dea7500",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.65,
+            "lat": 46.9
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ada27c57-5c72-4ab6-9122-b1ac4e3a8a1f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.5,
+            "lat": 44.55
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b8cb74e5-49c9-4cb2-ac25-fb38831c1916",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.077256,
+            "lat": 34.367841
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a31834c4-b069-4dcd-be1e-de1980547542",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.80364,
+            "lat": 38.26347
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "42e2cb40-63f1-40ba-b3a2-c71a80d19296",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.197133,
+            "lat": 38.538268
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f4733d56-8a80-4743-a0a4-fd9ae05ea236",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.55388,
+            "lat": 32.46175
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "db01e1cf-b84b-4a40-930e-3ea36428c598",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.167705,
+            "lat": 40.978566
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "16eec2bf-ed68-43c5-a6ea-da59106b94fc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.023447,
+            "lat": 31.205281
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "be60121c-a28b-44f0-bb9c-eaf6a741579b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -98.6833,
+            "lat": 33.6167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4a271537-8a0f-4ad5-ba07-651d96c36e2f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.433644,
+            "lat": 31.474494
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3f661b4b-a0cd-4679-97bc-4828d75edc9e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.943948,
+            "lat": 32.006756
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "eb5f2d9e-e7be-4586-901c-6e8280ea4a5a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0675816052,
+            "lat": 34.423023
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9d7b04e0-174a-4999-bbeb-2bb49e8e10c6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.53944,
+            "lat": 26.33583
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e158dfa5-787c-4085-a494-cec3cab843c1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0634510079,
+            "lat": 34.438672
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "756f89da-2de2-4def-9aa1-c5dc14ca5627",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.92302,
+            "lat": 37.693865
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d2f4fd3e-2e79-434b-b9e0-e956aa779c16",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.5,
+            "lat": 27.69
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "82e6224f-359d-46b8-b31e-73f7a75dfa4d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.1625,
+            "lat": 16.8125
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2326b114-d275-4e35-8a13-4e4f19008df3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.64935,
+            "lat": 35.4708
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2edb3928-5127-4943-ab07-744253c36dc1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.771556,
+            "lat": 44.967243
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5f0fa7d6-a8b8-42c8-8a15-cf8e8140dc2d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0833,
+            "lat": 33.3167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6a2895c3-8975-43f7-bfcb-e80b93000446",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.5667,
+            "lat": 42.9167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6b201010-93c1-4b2f-8f39-a9dd981a574e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.600088,
+            "lat": 42.283881
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "30175f46-5700-4a95-b1ef-6c6ac4651dd0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.386713,
+            "lat": 43.255182
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cc496b8c-5aa7-409a-b9b3-17173970c302",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5059371,
+            "lat": 36.65544902
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b834cd93-a2c9-4067-b31c-1cb010a5bb9c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.7106238,
+            "lat": 33.50951381
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "05fdc407-a136-4d83-b75e-633d4e4d8ff3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3333,
+            "lat": 40.3
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8d14a541-3a40-44c1-84ff-f68bac577938",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.980266,
+            "lat": 42.072418
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "87336274-1eb6-458d-8840-8dbb7eceb8cc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.50944,
+            "lat": 32.56814
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "89093e24-4480-4f73-ac15-217b7d03b047",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.10468,
+            "lat": 33.42485
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3dcf90c4-50f9-45f3-b251-3444cfc4c514",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4596660322,
+            "lat": 32.583002
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "28db33c5-ebb6-4542-b9c0-568f27f18e23",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.0191667,
+            "lat": 34.5883333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6da36cc2-9c3e-48e1-9cd6-35f5969ad5d4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.77239,
+            "lat": 38.29688
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6528660f-2f84-4ffa-a2b6-79aea3ce51b2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.745159,
+            "lat": 38.230954
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f843b8c2-1044-4314-a44c-e83ebed8234f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.5512,
+            "lat": 47.6509
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "049faa11-cb49-477c-9da9-ccf8704bbdd5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.745813,
+            "lat": 44.068202
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0fb6e543-3f0b-45a5-af1f-c0df39e9ebee",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.119,
+            "lat": 43.5719
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "13798251-57ac-4ba3-8e93-26bb01f8b0f1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.825508,
+            "lat": 32.114555
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "31582a50-cbf5-4f92-802d-109eab7c6f51",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.470155,
+            "lat": 46.800732
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2b22e4da-cf9f-4f99-9844-71d48ed18dd0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.70963,
+            "lat": 32.72195
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "da5e8648-249c-48c2-8d36-819deeb06514",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.5094578,
+            "lat": 33.3959339
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cc6337d7-2888-4e65-abc8-f612ea4aaf44",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.7331914,
+            "lat": 36.09739588
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "560e5178-9dc1-4a36-932a-16a8818e7e47",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.3323,
+            "lat": 44.0342
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "57cb91e3-fb9a-4dd6-81ba-65242f76ebd2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.933362,
+            "lat": 40.50728
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5d0e8201-01a3-4350-9cd4-80dfad3ef9a8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.670197,
+            "lat": 35.051358
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "39e2676b-f96e-4da9-8b45-ee330056c3e8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.0461673,
+            "lat": 32.8803531
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aa1b7883-4688-45a1-a8cc-d89d72eeec57",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.198354,
+            "lat": 39.546077
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "752a0c2d-3360-4931-8035-ae83924ee959",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1113105223,
+            "lat": 34.431291
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2be8ad34-d49b-4bf9-8a98-b2244fda0d36",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.824463,
+            "lat": 35.550313
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "857aa0af-c4d1-4031-baeb-2435ff81e585",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.42614340128415,
+            "lat": 17.471761465164693
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9086b8b2-f948-489e-b5cd-875a403e6453",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.6844444,
+            "lat": 34.9469444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "24fa75dc-5b96-46a4-bce5-d6582e56df4f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.15657750549326,
+            "lat": 47.916773045271675
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ce53e09b-e8fd-4866-89ad-4149e229618b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.008946,
+            "lat": 32.200082
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "41818727-4ff9-40f1-a43d-7e22b8177796",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.2471,
+            "lat": 44.3786
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8417840b-fc75-438e-a1e7-150d148d855c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.85,
+            "lat": 46.8
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "da649429-ffc8-46a4-8989-83be588e5aae",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.33996,
+            "lat": 38.21152
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cf30809d-d626-429c-b188-c73d046f74ef",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.71865,
+            "lat": 33.83834
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fd347d3a-3922-46ed-9391-966c40921609",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.05,
+            "lat": 43.5833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f6b312d6-5999-4466-a37e-43ab53c7f33a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.9711111,
+            "lat": 34.4455556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f2a511ed-1f78-4c10-a5b7-71d1b04e39f7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.2430860186517,
+            "lat": 50.01652199931778
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1949385d-5ddb-4a83-9a19-6bc2a579b2e3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.731787,
+            "lat": 44.970178
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "021f1a47-7043-439c-ac45-1199865373a7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.184723,
+            "lat": 34.048332
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5e485f51-74d2-4d53-9126-54a07bbdd870",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.9167,
+            "lat": 43.8167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "605e790f-524c-467c-bcd7-99e6e4a3373e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.7863362,
+            "lat": 36.49195201
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "91d51156-0763-4a0b-8f51-8c0a5ccf2cb2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5214699,
+            "lat": 36.47737501
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7857b49c-cf03-44ad-86be-7543a602b883",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8518749,
+            "lat": 35.99246858
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8846ad34-be95-4637-b9bb-667d0198c2d5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.583333,
+            "lat": 49.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4e0625ed-1fec-4e92-85e5-1ab60bdd30eb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.578063,
+            "lat": 42.412688
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5398822f-e1e6-4350-9998-3803ba319ca5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3681055a-fd1b-49a3-bb15-877efb95c826",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4565127,
+            "lat": 35.268304
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ae060d7c-ea69-4430-ba09-6bb6d79f285f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.0438,
+            "lat": 42.9634
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a08bac7b-fb8b-4c5a-8aa2-65a855da14af",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.55,
+            "lat": 45.3667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d0bf1c9f-09f5-466f-a0c9-a6fa12edd994",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.85,
+            "lat": 46.3333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d2ab1187-f1fe-40dd-adb8-7357be1d1090",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.0858494,
+            "lat": 33.08954897
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e67ce7f1-4052-4c27-8fd2-022b36283f21",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.082025,
+            "lat": 41.521018
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cc97fb56-cbc7-4604-9426-86acfba86daa",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.4167,
+            "lat": 44.35
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c3fb3fb4-d1bc-406e-b918-e9ae57fedd20",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.459169,
+            "lat": 42.517132
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c4f92d68-1bf6-49cd-a267-9d244b4ba45a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.3327093,
+            "lat": 35.96393964
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f1d5027e-5e9c-4af1-810e-477e8375ec78",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.4167,
+            "lat": 44.35
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "918c8e54-174c-44c3-8a80-60b2641f4382",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.130932,
+            "lat": 41.884915
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d1bb4565-bd19-43ff-bc9a-3d49ed7e13eb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.755893,
+            "lat": 35.454188
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4e6fdd31-adf9-485e-90a8-686423040c93",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.912882,
+            "lat": 39.563031
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5d669010-8e96-40a8-8302-8597e30d639a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.2251319553,
+            "lat": 32.950527
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8bac2759-88f2-4548-891e-3cbf139c2611",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.19102176326724,
+            "lat": 34.959318559172054
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1a1f3dc4-0b1f-4039-9f30-1b86e15f2dd6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.08275,
+            "lat": 39.000747
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d1014ef2-be29-4441-9266-1235da06d63c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.67220265053544,
+            "lat": 46.03989523116191
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4ff7eddb-4db0-4e48-a2db-47846defbcac",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "391ad707-8f84-49fc-b328-9a5659128906",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1113105223,
+            "lat": 34.431291
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1c8293f5-c596-4759-8f82-5be425f50b90",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.570178,
+            "lat": 41.792589
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "53cf32eb-d7ef-4fbc-999e-c74b7bb68605",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.776101,
+            "lat": 36.04139358
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d3a6359a-2e23-4cee-b922-9811598a10b4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.0864,
+            "lat": 47.8163
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d19de662-d63c-4b2d-89b5-9e87c8d6cc56",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.72227,
+            "lat": 47.881511
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d2d73817-749a-4836-841b-71bd708cc2cb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1106,
+            "lat": 43.9956
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bbcea426-2dd0-4131-bfcb-1dceac1b558a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4523486,
+            "lat": 36.54156288
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "91e05d84-4d71-4667-8dc9-86747fc9eea1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.596069,
+            "lat": 43.574915
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b5867c2e-cd43-4d42-8d08-aa9e954ad6b2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.398433,
+            "lat": 41.571013
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ab635026-5351-4f65-8fc5-3e06299932a7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.2570373,
+            "lat": 36.44814835
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f4391315-5057-4d7e-854b-adcc1fc6b8e6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.270627,
+            "lat": 44.713534
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "515bce42-4b1d-4a02-ace3-54a07ae906a5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.583333,
+            "lat": 49.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3f42edaf-d71b-4157-b371-515b7342218f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.8333,
+            "lat": 47.2167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "40324ae0-ba41-4ce2-8e85-7860bdfdaf9d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.7333,
+            "lat": 43.8333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1cdb9396-0833-47ec-bd6d-c95264f822f4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.023447,
+            "lat": 31.205281
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9d2be51d-4d19-446f-b78b-42bcb4d64c01",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.023447,
+            "lat": 31.205281
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "58ae45a3-172d-41af-84b0-bbc5b9af9fd4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.6838013854,
+            "lat": 32.750578
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4dcbb73d-5025-45e2-b062-658f4de75b45",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.449278,
+            "lat": 31.889969
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ec58b1bb-65ab-4a24-be2b-7c5d79d08059",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.0622222,
+            "lat": 34.5336111
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e1907d2c-5dfa-40f0-ad63-21ffe53ddc3e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.05281,
+            "lat": 38.36314
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ef9e6f14-4ad5-42a5-8ffe-8905fd259f73",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.533804,
+            "lat": 48.305481
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b0b8b996-d48d-4162-af4b-03a1554118d4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.6333,
+            "lat": 43.3167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fea55b85-03b5-45be-ad9a-90bc3e79040b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0675816052,
+            "lat": 34.423023
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dfbc2e8e-a50e-4702-844a-8ed226b1ac7c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d4733de6-e343-42f2-b673-8baac4784d22",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.491471,
+            "lat": 32.573609
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b8cb14fc-df3d-4087-8c15-00480df76776",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.3856309,
+            "lat": 31.617434
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ff7febc3-e019-453e-99f0-54e6f45bbccc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.284249,
+            "lat": 41.979667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2398ebe6-6f64-4e39-8211-e90c5a4f0f89",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.333997829,
+            "lat": 31.580295
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ee2bea61-8ea2-4f97-b77a-2e7b90afd2e6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.198354,
+            "lat": 39.546077
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c46b6ff5-6f37-4871-a602-af3057e7845a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.008946,
+            "lat": 32.200082
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "02f6edeb-a514-4d07-8d82-1187d0588091",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.48,
+            "lat": 29.41
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f67815d3-d24e-4233-b14f-21ea30dead74",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.628175,
+            "lat": 32.6931833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cf8d7451-1047-4ffc-ad7a-d48030ce37b2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1387,
+            "lat": 43.4113
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c3f29538-bfbc-4478-acbd-391115074936",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.65251,
+            "lat": 45.32323
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bb95e059-8c24-4572-89ed-82c1423e9322",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.0833,
+            "lat": 47.8333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0f9be454-792c-4fa5-b024-c24495b3ddc0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.2333,
+            "lat": 45.2333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "109508c5-66d5-4976-8b53-62dca5b91286",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "132fc73a-aecb-466e-b04e-8bbc91bea2cd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.945894,
+            "lat": 33.97641368
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3ed608c3-791f-45bc-af70-c7c650dd9726",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5951281,
+            "lat": 35.0441862
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "41a2852a-987f-4590-baa5-20d21fc9e9f1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.350254,
+            "lat": 47.66876
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6b5bf63e-de34-48a6-add2-bc4a3f586804",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.665047,
+            "lat": 42.037548
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "76f9957b-4b33-476a-afde-be4d7a667200",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.7232093,
+            "lat": 33.52234765
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "51b51c4e-27ef-44b7-b363-5436834c47be",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.8242,
+            "lat": 47.5289
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7fdd4efe-8bc4-47c9-b22c-a8d05d1d33f1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.192379,
+            "lat": 33.130491
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "93900a0e-96a0-4cb0-92a7-73c989555a32",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5777671,
+            "lat": 36.66616408
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "832fd93b-7f07-44f0-be27-b8d9b4b6c6f1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.5168438,
+            "lat": 36.7639687
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a6c12522-8856-4ada-ad7a-039f3123f127",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.452461,
+            "lat": 31.887368
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "678606cc-c4ec-4092-96c6-51a220efd507",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.73498213872537,
+            "lat": 39.54246590613516
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7af60aaa-5337-47bf-b778-caf8bb7440c4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2a416111-a768-486d-b62b-61d300f14dd3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.51666,
+            "lat": 2.83333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a70a06b4-ffce-4cf0-897c-a37215b92b88",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.069495,
+            "lat": 50.005021
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7aa93b06-9827-4b54-8f84-4fe56bc99658",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.58412001410656,
+            "lat": 37.10415089492064
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "86b787ca-bc5b-43be-b40e-d446399ba42a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -98.20829859656273,
+            "lat": 23.768450930116682
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e0520828-b09f-4766-a444-7846959e97a4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.498829,
+            "lat": 42.569645
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f7e2107d-39e3-4dc3-b4c5-69abd457f496",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.663485,
+            "lat": 35.078382
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "56d96ad7-5e32-4aac-aff4-3422e2446ba6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.35,
+            "lat": 44.2833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "919db7ca-91fa-4190-82a1-3e9f428febb9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.70963,
+            "lat": 32.72195
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8c8a5db4-1ea1-4759-a125-085b46a85850",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.6670405,
+            "lat": 36.13310831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0ba260c5-5550-456c-aa6a-58cc5e268812",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.883122,
+            "lat": 33.316729
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "06f3bf32-5279-4a01-a778-54bfc0f40d63",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.3903382,
+            "lat": 34.02535024
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "67fbc9e9-9f5f-4d22-8f90-31e572cf57fa",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.523449,
+            "lat": 32.81590709
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6a67d155-1ed9-41b3-bc8f-d59115233902",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.327337,
+            "lat": 41.951187
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6bfdf96b-3f88-4a41-8f78-dad20fb33c57",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.8,
+            "lat": 43.05
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "51a12fc6-4199-475b-a1d3-02f91f5d36b2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.215514,
+            "lat": 41.892425
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "47693a08-16d6-4850-ab3d-5a035e7e08b4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.6913951,
+            "lat": 33.79823614
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "478dad9c-188c-4687-8afa-1c193449dfec",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.3667,
+            "lat": 42.65
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cc916dec-950a-4b0f-8dca-3049f14d7b1a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e6cfd149-910b-4fec-a04f-7940028d19d3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.35,
+            "lat": 44.6667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ef273077-5cef-4fd4-b6ff-4ac6a78aca15",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0561111111,
+            "lat": 34.4580555556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2b7cecb8-2e6f-4e93-ac50-b8706dd09b8f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3814233,
+            "lat": 35.68598484
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2c0ea60f-a5ac-4c40-9544-cdd75dac8af8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.13902,
+            "lat": 33.31705
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ff6e037c-39d4-4148-bf20-03445423de52",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.124407,
+            "lat": 42.42853
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "05cf2eba-6c14-4958-975c-4d3f2d2311ec",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.433644,
+            "lat": 31.474494
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f93cabea-c1c5-448c-9da7-580608a43903",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3283995,
+            "lat": 33.711498
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fef5591b-5714-4728-a57d-6dfb12ae483a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.78699,
+            "lat": 38.2677
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a41a2e0-83d5-472f-82f3-5ccf883668c8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1976118178,
+            "lat": 34.402723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4181ab0b-2d18-424a-a1ba-258eb4705294",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.87143512551576,
+            "lat": 32.70176843296257
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0e005923-680d-4bb2-9d57-cc32fce0a1b8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.3660246433851,
+            "lat": 47.95761062251738
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cb30ad90-632d-43a3-bd89-793a15769f34",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.23673,
+            "lat": 47.88084
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ecde599a-329f-4304-9482-335354f954e7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.4628365,
+            "lat": 32.48072005
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d2274128-76f2-4798-9019-9816214b8daf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.008946,
+            "lat": 32.200082
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2d74af3f-deb7-42aa-a7e8-cd324e2cb63e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.023447,
+            "lat": 31.205281
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a5b6c91b-fcde-4246-9291-21fa5f5c1f92",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.433644,
+            "lat": 31.474494
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6826e2dc-eda9-4629-864a-37650aa4faff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7966250b-9741-4127-9145-d2d9ab91d165",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.03671,
+            "lat": 38.06358
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6f82246b-536f-4875-b44e-59a10de1e8a2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.80645,
+            "lat": 38.15794
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f8267c93-6c57-4d76-9027-fc9c5d600ef6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": 0,
+            "lat": 0
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1351af03-e457-4c0d-b19d-44cca89176aa",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.3086111,
+            "lat": 35.46810594
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1b0ad438-8a8d-4863-9a25-30971a4bbe57",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.905653,
+            "lat": 44.99158
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6e9e5cad-188c-4906-b558-d178111316ad",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.6667,
+            "lat": 46.1
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "73ab0f7c-3eee-4440-90b7-a4ea7abd42a5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.7333,
+            "lat": 46.6167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a31ffa1-2bc2-452b-8d3b-11ed9e5dfca2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.7667,
+            "lat": 42.6
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3c1d8f7c-c625-49e1-80cb-f1b4e73956b5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.2987208,
+            "lat": 36.66342036
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a69ba089-9e76-4618-a734-062234bb23c4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b23b12da-6cf9-44c8-960e-14e189855f9c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a20ef338-124f-43e9-876a-5611268b936b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a42cdbca-9aad-4cd6-9b49-36b8613e8415",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.7,
+            "lat": 42.4667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "962c80ed-ffcf-432a-a0c2-de4ddf9371f8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.927939,
+            "lat": 47.474094
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9d5ff059-1eeb-45c9-a8f2-6f6383f30361",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cf76f847-0dd1-4af3-bdae-2d0c7c323739",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e0369012-f5b9-4152-97ec-4ae95f2ccb85",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.7167,
+            "lat": 41.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "76bb7ee4-094f-4a49-83d3-25f38e61d977",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.51666,
+            "lat": 2.83333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f0e8df36-0b0f-4fb1-b268-52bd9d09ce88",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -126.6166666667,
+            "lat": 49.6
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "125d35bb-aa86-4d51-b416-9ab190ea0c7f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cfefd243-af48-4b57-9417-c7e672e5f1f1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.167,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e6c03f07-0796-444c-9ec7-00b31248855d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1153381192,
+            "lat": 33.405473
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "63cef536-1039-47b9-997f-152cd5138ace",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.05,
+            "lat": 29.22
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2a18e0c2-cc80-402e-8503-6f9227390191",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4177db9c-729f-4f81-ad4f-766f8114d54c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9951395614,
+            "lat": 31.700622
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "54f06f4b-6fdb-42b5-a14e-cffb9eb5f230",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.084478,
+            "lat": 34.434229
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "caae6bf5-d939-4a16-8ffb-bfacba2a1346",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.738111,
+            "lat": 32.686188
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0063683c-e70b-439d-929b-6ebe406c7cbc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.47036,
+            "lat": 38.32988
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7a568a26-e3ff-48b0-9ff8-b691b416ec37",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.23117,
+            "lat": 38.18206
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "27a95921-89a0-4dc9-a593-c5aafd80be7f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4815,
+            "lat": 32.3723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "62b7d65e-add6-43b0-92e3-518b82e44bd2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.75478977878544,
+            "lat": 48.555160343460685
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "36a97481-ce9e-46c5-984f-9403df4f9c73",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.75478977878544,
+            "lat": 48.555160343460685
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "672f85c0-2deb-4453-b401-f1c924502441",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": 0,
+            "lat": 0
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b02f4c7a-7abb-4a0b-8e32-f2efe82739a9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -90.95686068438015,
+            "lat": 16.892293676973885
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "11cace97-95a5-4245-acd0-0d6716bca341",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.284249,
+            "lat": 41.979667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "25b1b39c-2e73-494f-b9cd-cf2736e7a1cf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105,
+            "lat": 36.44222964
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "27571098-f51d-45df-a195-18a554ddb227",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.7,
+            "lat": 48.4167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "302300e2-4f72-4fec-886a-8fc24d258679",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.831828,
+            "lat": 44.855435
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5b9c9017-4689-429b-aed3-f4c10b15ca54",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.75,
+            "lat": 46.1833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6eb5b0eb-77d9-4f93-b5d9-aa5f71520afc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.7086111111,
+            "lat": 32.7141666667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "49b72545-a59d-4088-9f2d-1be932373b7a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.077789,
+            "lat": 41.021037
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3b247269-17cb-4a0b-8042-47a82731dad3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "767ee768-de29-4b7d-8781-7b715c46b86c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.95,
+            "lat": 44.6
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "da559347-c393-468b-b6b3-0d219e8bbe45",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.95,
+            "lat": 42
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c4f4350b-b032-402f-8cfa-47c3a68ead7c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.73318,
+            "lat": 43.016826
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8b146a50-85e1-4724-8896-9463ee0cdb54",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.881715,
+            "lat": 47.154141
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7ef58931-7a45-479d-a3ce-132d907e21f2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45699,
+            "lat": 31.84704
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f3d844fe-853a-414d-bf70-f08cd5ebdebe",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.7176163,
+            "lat": 32.72222581
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f67422ee-157b-4c04-b8fd-dbe8564095fb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.6667,
+            "lat": 43.15
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fdc862f8-a3e5-4378-84e6-136fd409b588",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0600411,
+            "lat": 36.94805121
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a16d0f81-2c1c-4d55-8e76-3367bae392ff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.5526297,
+            "lat": 35.69264625
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a34cc9a4-d633-4608-b292-7451179ccadb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.065821,
+            "lat": 34.41884
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "95c44fb1-379a-4444-96ba-44cc4d62540e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1981,
+            "lat": 43.3967
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9c4b49ae-05a1-412b-965c-97abe0a76a3b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.2327,
+            "lat": 43.5755
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "020a9228-dd1e-409c-91f2-bead30063db6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.5699508,
+            "lat": 36.81438428
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ea2aa0c8-9a33-40df-9840-6499c5874cc7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.70534803117107,
+            "lat": 32.430375237105956
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f933a08b-5af1-4208-84a1-b841538b2419",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.45221513580368,
+            "lat": 37.92968285761966
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d8b89122-6c01-4782-8bff-3a09470ff8c4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.4283,
+            "lat": 44.8749
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9d9fee3a-b4dc-40bc-abc4-827064dbe65a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.9963436042,
+            "lat": 34.171745
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1f836b44-7c3d-48d0-b879-042134a495c0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0ab7f914-bd1a-4d1b-a065-c2bed28cce25",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.185313,
+            "lat": 34.048398
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "54bb8de3-d7d4-4662-84e4-9f8ee54b30f1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "588d3b52-ccc1-493d-844d-3fd8c37bded6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3283995,
+            "lat": 33.711498
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dd0e0522-b527-49cc-a6c3-cd7949bab64d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0758512,
+            "lat": 34.46480911
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d1da45fe-f11a-420f-8437-ced462741fdf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.8626892,
+            "lat": 32.0450028
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cab3b721-f099-4395-9b58-11b081262cd7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.136938,
+            "lat": 42.312137
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ccbc5381-5354-4067-9058-927dc8927b76",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.403972,
+            "lat": 32.593401
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7372448f-ba5a-46dc-9af1-7235a7f11d58",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4689569,
+            "lat": 36.89209616
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "770a8850-5ba4-4678-a474-3b6f46bf41cd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.587784,
+            "lat": 32.934803
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2e871389-ad77-4746-83d5-716a2af6eceb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.203635,
+            "lat": 35.252542
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "acf19b8a-4782-4b84-8650-c264c8ab4127",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.0167,
+            "lat": 45.2333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a1941224-5608-45cc-85d6-a0e3ed55e6d1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.412674,
+            "lat": 47.575193
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "80860a61-093a-4dd0-b84d-0ff2a9ca36e4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.192379,
+            "lat": 33.130491
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bf1b6868-9413-438f-b2c7-980fce1ca395",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.6167,
+            "lat": 46.7833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3ba82aec-9374-44a3-9cf2-689581ad16d2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0567057953,
+            "lat": 34.423206
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "869a71d8-b2fa-4ffb-8be6-72a15b686b58",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5370013617,
+            "lat": 32.744431
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3099a2de-61c6-4a77-a739-8b13b61acb93",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.896972,
+            "lat": 34.155622
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a92d2805-4bfb-4ba6-9e0c-40ca950dca25",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.2432676797999,
+            "lat": 31.14081461087519
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5d7d4976-42e4-4920-b058-52928bcae052",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.5786111,
+            "lat": 34.5086111
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6881e547-2c81-4281-b006-dcff8c6fc89e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -79.7,
+            "lat": 0.9833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "240743b0-e883-489e-a8eb-68092a28e43a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.35,
+            "lat": 43.6333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0eb2c4ab-9d60-46f8-8d45-a12935d93264",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.5667,
+            "lat": 40.95
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "31edff14-6ad3-4a35-92ad-a9e08218b60c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.932916,
+            "lat": 46.495742
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "37b1ec0b-8e59-4cc5-98f8-483020e43b31",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.7818,
+            "lat": 47.4127
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "381e6959-80b3-4802-b0c0-28d759d6c3ab",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.000667,
+            "lat": 42.677419
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "17bfc126-b7f7-4489-b922-ef7c06c379d5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.3,
+            "lat": 43.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "81bd23c6-08e5-4224-915b-827b26242709",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.50098,
+            "lat": 31.84738
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5eaa4a8c-66a7-4c5c-941b-24a14dd0b93e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.284249,
+            "lat": 41.979667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3d51c9a0-eb67-4acd-925a-93b13f2cab96",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.7406253,
+            "lat": 33.36397848
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a6d54246-3411-48fb-bb4e-1cb6f22abe4b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.4,
+            "lat": 44.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a9dbac70-6c05-45f9-9185-5bce17704193",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.2593363,
+            "lat": 37.01567083
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9fe7ef6d-2bfe-47ea-bad4-adaab55ca5e1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.98991,
+            "lat": 32.1258
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9bec6300-c92a-4723-a0ce-ea1124993b61",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.646393,
+            "lat": 33.080833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "91c43161-a002-4d87-9a2b-b4f82f96e58c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.980266,
+            "lat": 42.072418
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b43957de-fc8d-4774-93b7-942df1075fa0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.839157,
+            "lat": 32.064445
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b6cc862c-5cd2-4772-be35-e0ee34caeb63",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.8744464,
+            "lat": 34.78906528
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c11b813c-bbe3-4c4e-a120-4db3ab5a3af7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.164046,
+            "lat": 40.428741
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "83dd869d-68c9-4bfd-abf6-d5f2a1b00d30",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.26,
+            "lat": 27.06
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1465e4aa-aa20-41a6-abdf-55db659d92ea",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.7833333333,
+            "lat": 49.0166666667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8f8ea932-e639-4757-95ea-4c42ba708f11",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.3,
+            "lat": 50.0333333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e5562e44-aa39-4fd6-ac6e-0ceb89d94e3a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0525768,
+            "lat": 36.55387834
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c6b38fe0-5172-479b-a86f-d9a4a386d8d5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.763331,
+            "lat": 42.538962
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d97c5dac-c33e-4e7a-96d5-8759fc51c314",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.9387,
+            "lat": 47.3758
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dc028723-22f3-4c7c-ace3-0684e622d0b3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.3882679,
+            "lat": 33.65525492
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dd78faca-f287-4211-86fe-666f47b17d50",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.65,
+            "lat": 44.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a65f39a-9b0a-46bf-a345-dc6db2681965",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b2493794-8af7-4242-a578-88c7cbf82bbc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.70963,
+            "lat": 32.72195
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "523d215c-63bf-46bd-94f7-8717c6374468",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.22239,
+            "lat": 47.548532
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d3603e77-6f09-43fb-a8ef-e625fcf951e4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.280416,
+            "lat": 45.63822
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4c014243-b866-477f-80ce-e515b9f1b32c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.77113,
+            "lat": 38.27467
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7d28c718-ec56-496f-90f5-781e00ef6dff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.38306,
+            "lat": 38.23842
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "88b5e77f-93f8-43e3-a686-b4c7607dc08a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.51442,
+            "lat": 34.542937
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e0da9acb-6a13-4ea9-899b-17d2523310f2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.031409,
+            "lat": 34.202531
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "60ec4324-ef58-4d9d-abc4-e3cd67753ea3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -88.18333,
+            "lat": 15.88379
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "76e8632f-827e-41cf-bcc2-d0861dd1ac72",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -93.83618140903317,
+            "lat": 32.333157161279885
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b145cb45-ee52-44c2-8b03-b6a351538e27",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.2430860186517,
+            "lat": 50.01652199931778
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6ec3c566-88ab-4e56-890a-f5a598ab3f85",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.27,
+            "lat": 33.227
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "234c2f46-68f5-459a-9d1c-88fe97b94d92",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.5667,
+            "lat": 40.95
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "287e2063-8be6-471a-84b0-8e3e5b7862ea",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5333,
+            "lat": 44.4667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0c75bbcd-f761-49a1-93a3-8c2c7b1d5840",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.65432,
+            "lat": 46.630449
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "423531d0-2eeb-44ea-bdfa-6ed0fb7a3537",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.424304,
+            "lat": 34.176978
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "67ba5a6e-0774-4324-9225-6d061e23fdff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4606399,
+            "lat": 36.38821714
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c35359b8-bb2b-4c5c-a3c0-293be58afc45",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.25,
+            "lat": 44.8333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c94a83be-a3bd-455d-8cda-8f94f3a0124e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.7076477,
+            "lat": 36.99411221
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ba285608-410a-4a84-bcb9-552f0fd5c208",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f09e9d56-c482-4305-abe1-1ee7278fa6e0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.0833,
+            "lat": 47.35
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f27e950a-8473-4bec-b2f7-e47a671b38f7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.35,
+            "lat": 44.6667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f6daa012-36b2-43aa-a72e-50edc8ddc6d9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.6770065,
+            "lat": 33.1247604
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e789bf3e-33d4-49d6-82b6-597fb41ba72d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5167,
+            "lat": 46.8167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "697043ad-c338-45f5-9e27-bc381893c5f6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4191041,
+            "lat": 34.75376904
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "60ee25d7-904e-4024-9c3b-18845b4717f6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.71892,
+            "lat": 48.14095
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "60f9e527-fd8f-4649-a643-451c47840cdb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.0128286,
+            "lat": 32.1030676
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b3d64660-f566-479d-9956-febb23806163",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.3010091,
+            "lat": 36.90671846
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7fa079e4-5a95-4cf4-8e21-9f28fc592de9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.5842,
+            "lat": 48.0619
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "36435d92-d906-4e1f-92d3-e3f0e54d94e0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.646393,
+            "lat": 33.080833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "364c97e1-185a-4c38-ab98-f1580dffc5e6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.600088,
+            "lat": 42.283881
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f18b6679-9776-404a-88f8-d345386c86fe",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9473736858,
+            "lat": 31.952407
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c4bfb105-981c-4e25-814f-a70d7c3ab87a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1603277079,
+            "lat": 32.924612
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fc20adb9-0778-42df-9e9e-027053df873b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4700231874,
+            "lat": 32.564842
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "76499958-76fa-402c-b8be-674348a1d23a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.8736306,
+            "lat": 33.208676
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "57f314ce-e4b7-47fa-8200-85aed1b75797",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1515597874,
+            "lat": 34.374789
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e9e8423e-8722-4c8f-9ac8-691c9150556a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.422543,
+            "lat": 31.721488
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ca9d8023-9a2f-4418-9f78-845305491471",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8d901366-eb51-4505-b9b8-18f8e9282b5b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.083,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6e2cd636-5455-49f3-bdfb-032bd5776404",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -100.4470627740817,
+            "lat": 25.337229522704224
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "75c3f214-70f3-43d9-aa3f-d3483d8fee6f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -90.98302803382234,
+            "lat": 16.882571960435143
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ee871d88-d85f-466e-be33-507dfd4ed320",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.239991,
+            "lat": 47.617351
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e5395e01-a496-4eb6-91eb-1e34d0dfefea",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.50944,
+            "lat": 32.56814
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "da1c3711-affb-4ff7-bc1c-b65e769061a4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.927462,
+            "lat": 43.060473
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ea0ab062-2502-4a48-9172-acfdad7914a6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1783,
+            "lat": 43.207
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "54ad1482-32cc-45e2-a9fa-8eaee669e052",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.116974,
+            "lat": 33.330905
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "55cd2bd3-b6f0-4fe6-897b-bc7726e42265",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.675307,
+            "lat": 45.365255
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7076d43d-5f7b-4604-b8ca-9378540a3372",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.3,
+            "lat": 43.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4659beb7-4259-4fa4-b360-24b4c6441cb5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.280416,
+            "lat": 45.63822
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cc2143a0-f82e-4377-8340-7d1ade616726",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.44,
+            "lat": 33.71
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a1cb86c6-fbf0-4633-9e89-d311729b36f9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.69783,
+            "lat": 45.244969
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bea85053-b338-42c8-b506-aa51e9868b52",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.778337,
+            "lat": 32.312316
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c031b886-3818-4e2f-bb9e-8185da0e59bf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.365749,
+            "lat": 32.841874
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c21fa52b-10e3-4be0-a2a2-5f8c10858954",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.930399,
+            "lat": 34.007188
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "abdce68a-3043-4a42-95a0-70f17dea594d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5075561,
+            "lat": 36.63003589
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8584c378-f888-4d63-8c65-689dc12536b3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.124407,
+            "lat": 42.42853
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0ceb7486-ea58-44c7-b80f-ccd0116e1d8e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.866137,
+            "lat": 34.275965
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "06e66484-121c-4599-8cf5-df442d972cf5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.5459136,
+            "lat": 34.06339024
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "51475d7d-1b73-4bb7-85ef-37ba0239e5f5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.6922222,
+            "lat": 34.8977778
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2d9a257a-3d32-464c-9c7c-c15ea455789d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.083,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1e15d781-1146-441f-92a0-720142c78810",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -60.2666667,
+            "lat": 6.3166667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0c626c5f-7725-483c-88b7-9e6b1b71baee",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "23e432c8-1280-4dc9-8a9c-02367d544110",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "64258c4e-b1fc-4140-836e-d9bc57828514",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.358505,
+            "lat": 43.889692
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7b9fd082-107c-435e-9900-a1531dddb5c8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.73336,
+            "lat": 34.806166
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "72c9fac3-6b15-4b5f-9ecd-06f592268e2e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.310349,
+            "lat": 47.42346
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c957433d-67a1-47dc-ba58-24a74b3ad5a8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1163888889,
+            "lat": 33.3308333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "26a1a4c1-342b-47f2-b951-89aac6273d54",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.433644,
+            "lat": 31.474494
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b26c2d07-fbc6-44aa-9cb3-8129cea75a45",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.198354,
+            "lat": 39.546077
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "63aefb24-c7b9-4a48-90bd-9eaca84bb428",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.40758376889995,
+            "lat": 35.510451198106274
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "006e4357-f5a7-44aa-8690-5dca005e9ce9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.875,
+            "lat": 34.5441667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1401ec8b-dc68-4e21-8bbe-549300bd949e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.6667,
+            "lat": 44.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "555cda54-6482-43a3-ac6a-41719563c039",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.3612304,
+            "lat": 31.6035623
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "799aabf3-75d9-44f2-aee5-13c99ac0b824",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.53927,
+            "lat": 32.62101
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "92a5deef-054a-4f1b-bb27-d9541539be59",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.412674,
+            "lat": 47.575193
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d3a5fb18-f6a4-4cb3-aceb-0c60379c8b88",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.1932,
+            "lat": 47.52371
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d3b6adc8-1eda-4719-bcf7-ddc6247332c4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.469279,
+            "lat": 37.247796
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d405a663-ea87-4ee3-939d-d6da2586da62",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3833,
+            "lat": 45.2167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e5a3c74a-c48a-48af-aec3-22fb3ef1db76",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.8629872,
+            "lat": 32.0380866
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6f359086-23f8-4152-81d1-7a001a5cf15f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.51527,
+            "lat": 32.45342
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0abad35b-4aa5-4d46-80f7-7bfe1a3de3db",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6d218f46-8890-4ed6-83fd-64afaaef4ce8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.2881806,
+            "lat": 29.2395111
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f2c375fe-2a41-4401-a472-7dd93c89baaf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.0652778,
+            "lat": 16.7088889
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2d4577af-eb45-4f77-8123-27324ff4aeb6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9096287344,
+            "lat": 33.347905
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6ecfa595-a6eb-45f8-a4f5-2726c93433c6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.439355,
+            "lat": 36.895431
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "27e7f020-2987-4546-87ba-cd931c11053d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "192636c3-4adc-45cd-aaad-75f02657ae05",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.37646,
+            "lat": 38.26476
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1413b32e-8390-4619-a933-117ca9ca0c07",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.03023,
+            "lat": 48.982402
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c251e83c-cc03-4e43-aa4a-0792e8721b44",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.75478977878544,
+            "lat": 48.555160343460685
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1a5d5532-53b7-463d-b987-ea9d2e416d52",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.654419,
+            "lat": 41.778534
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e0d72a74-5ddf-41bb-9350-1ba68593ef7d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.51782,
+            "lat": 32.46335
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d903bc0e-a367-421a-a942-3f31f90e95a7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4320983,
+            "lat": 33.6151996
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a32d4396-f753-4cc2-b6b8-ddf6bc1a218f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.6897481,
+            "lat": 35.65947114
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b884cc33-ff60-4428-86c5-9c2e75ee2aea",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.7389316,
+            "lat": 33.30992135
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a4ee3c85-4bcf-4516-bc83-937d9a96cf3b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7fa43205-f893-40c9-bd51-a205e1e5ba93",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1113105223,
+            "lat": 34.431291
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f84a0cc8-93fe-45a2-a0b7-1d60d079ba3b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.14,
+            "lat": 33.85
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ce5b3f72-055b-4992-9348-f0724165c20e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.0372,
+            "lat": 43.0123
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "702e8f8d-a525-4f25-9f13-8f8dbdbba04f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.433644,
+            "lat": 31.474494
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2fbbbb2d-3901-47f4-b536-8e81dc0e1840",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.3922,
+            "lat": 38.45099
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "18aa0dfe-822a-418e-a2dd-fbeb69bbe827",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3481e2c7-16b2-4107-b054-2e24441b006e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.51666,
+            "lat": 2.83333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "606ff421-dc1d-4087-846a-9b2a2b98e7dd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -126.75,
+            "lat": 49.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3f1738e2-9dee-4d9e-b678-266715d4cfd4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.726685,
+            "lat": 32.459236
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e6719235-0cba-4fea-ab6b-279c5c4b607d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0242955349,
+            "lat": 32.584192
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3c4d0de7-12c0-4991-b532-316af4672f56",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3946151,
+            "lat": 34.522723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dc3b4de6-7fba-40f4-adee-f525fd5249b7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.5,
+            "lat": 49.45
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a1c38ecf-2bfc-4399-b374-6a00d900f120",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.43,
+            "lat": 25.57
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2d83325c-79ee-468a-8baa-bc948f73dccf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.167,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "61c4ce44-a4ce-4391-a9ce-41bcb68110c3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.57306,
+            "lat": 28.51528
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "05d5accc-35ee-4d47-9db7-e88c2bd59c2c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.00895,
+            "lat": 32.20008
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "09dea49e-a36c-46a4-a3d7-8c11f279a06e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.5667,
+            "lat": 47.85
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "42348b59-45bb-4f79-b968-915f0fccbec9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.70671,
+            "lat": 32.73231
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "72199de4-a896-418f-a27c-fcc8aa4ffc1a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.67491,
+            "lat": 39.853797
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6d52f33c-29e1-44b2-9ef2-06a613bf1581",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.825508,
+            "lat": 32.114555
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8f1c4654-6315-424f-9426-2c65396e4cf3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.4,
+            "lat": 47
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "93012582-9456-4a56-852c-03b6a83a0e5c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.565284,
+            "lat": 42.484354
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "80a125ff-e50f-43da-a32d-3d83f9d5d30f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.932916,
+            "lat": 46.495742
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "00913971-0f25-4ed9-9120-03fe570db0e9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5669444444,
+            "lat": 32.7830555556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7afd0d9d-4967-46c2-bf9a-710cecbeb54a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.39433536871483,
+            "lat": 36.29748102582919
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "38bd4937-707f-4c12-906d-6fc746c40d7f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.99149672648753,
+            "lat": 47.20429803474714
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9585b844-4b3b-497c-b7a6-c640b11d46b3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.904944,
+            "lat": 31.401806
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1a55469f-9f10-4bc4-9006-b5a240110c3e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.70963,
+            "lat": 32.72195
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0c3f1521-f8ff-42f7-8746-ba643463f1e6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.5350553,
+            "lat": 33.68392792
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "07c120f9-bd74-4906-a922-c09e5f7b9141",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.9833,
+            "lat": 42.2333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cd61f674-4574-40bc-aa5c-d56ef7899b02",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.36365,
+            "lat": 31.61538
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bed1113f-92de-4004-beae-6a5f250d92ff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.453883,
+            "lat": 44.889588
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "56fce736-60da-4f42-ac72-ec3ab5a0ca10",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.52972,
+            "lat": 32.62675
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2e4ca3eb-2993-4a7f-b58a-0e1f7c50ccd6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.89822,
+            "lat": 46.92156
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ae0400ee-c11d-4fb3-ba2b-9729a4e15231",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.420118,
+            "lat": 32.58101222
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9f9efe9c-4b6c-40b4-99b5-e371ecb42761",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.078847,
+            "lat": 42.081867
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9777b47c-0692-4781-83e6-432101b2d341",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.25524,
+            "lat": 41.972701
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d9ca5d2b-9e80-4f37-afcc-15d3eada18c0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.85,
+            "lat": 47.55
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f4dffc93-b87b-4d72-befb-f229a3c15c8f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.25323,
+            "lat": 47.200723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f1013d2d-6b6e-41fd-bcb4-962083dc865e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3833,
+            "lat": 47.2833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f179071d-f1f4-428d-94fc-87e95a55aabb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.00901,
+            "lat": 31.73518
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b1a5ddf1-41e5-422e-80dc-d3155fbabd0d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0777883964,
+            "lat": 34.395801
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "628c4aff-3c84-4e63-b778-51eb3344488d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "94d1b078-3f2f-403e-9600-70b03f79e937",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.999116,
+            "lat": 34.110751
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ecc9eb51-d299-487d-9307-9667416fdc5c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4815,
+            "lat": 32.3723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6b55b4e8-dcde-451d-be06-b63135a09104",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.0786562,
+            "lat": 38.0242904
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9bbe536f-c841-4224-a562-d151397dc58e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.48428,
+            "lat": 38.48878
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "99c94f85-8861-47fb-9b0c-ef5226e51880",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "95dd1c91-51ad-4f04-9e1a-85140010fae5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0049895199,
+            "lat": 34.107036
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "17bd90e0-bf15-4b2f-b162-691a391ad254",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -88.18333,
+            "lat": 15.88379
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8cbf4d51-d96e-4821-a6d6-c8b52c5e2b26",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -101.11635635181848,
+            "lat": 21.841533217999967
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6bd64686-0a03-484c-ac56-32e7b0f03ece",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.3333,
+            "lat": 42.5333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "eaa59fb6-de18-4d72-a7b8-9e873c2ec498",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.510465,
+            "lat": 47.787685
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "004fec34-b1eb-4f0c-b2ac-9d52c27cf4d2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4889985,
+            "lat": 33.3007011
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "04bbbb36-9fc4-4b50-94b4-3f92f22fe731",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.6530903,
+            "lat": 33.36796269
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5a7da387-8fbb-4811-9885-25c7639c4f65",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -97.145248,
+            "lat": 25.956192
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6e707b3c-21c4-4e62-bbb0-9b605d7f9c3b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8892102,
+            "lat": 36.12980468
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "72cd862a-f521-4149-a576-4559da9db014",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.578063,
+            "lat": 42.412688
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "17ed7c9a-3fc5-4258-8d9a-35480d998a27",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.207183,
+            "lat": 41.975479
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1af703e9-2c89-4f0b-92fd-ef699eb85e43",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.9333,
+            "lat": 42.3833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a680361-c2bb-4913-8451-c8f47eac3441",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.6833,
+            "lat": 38.1
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a3b50ba9-49e2-4ada-8be5-77167890b699",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.7230936,
+            "lat": 32.63665025
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aaba3f9e-4f9f-47be-884a-8680d1faa900",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.6983398,
+            "lat": 33.32017397
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9939d966-4d1b-4fb5-b166-4e54d8440ae8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -133.4308333333,
+            "lat": 56.4688888889
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3ca9b452-1282-41be-ac54-ce73f3aefb99",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.034706,
+            "lat": 49.023421
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e0bf0a1e-5494-4d09-9961-28c16e8c316b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.00895,
+            "lat": 32.20008
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fe9f40eb-680b-4334-aa77-ccb9c97c1d68",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fb6d0912-e57a-4685-9f40-d8747c000742",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.05,
+            "lat": 49.6833333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f2c4bc04-81b9-432e-9ffe-91f60c746b1e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.46,
+            "lat": 29.42
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b2fc118e-07c3-498b-a070-a6ba24a8ccd1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.26,
+            "lat": 27.06
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f9b7f5dd-a857-4f74-abd7-14bce785b360",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.7667,
+            "lat": 47.2167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bba14292-8f24-4dcf-92a5-3aa262754dd6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.510465,
+            "lat": 47.787685
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2d60c831-49e4-4f06-9eff-ab0c2c609bbd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.412674,
+            "lat": 47.575193
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6e238c00-4210-4071-9b3d-d09f93c1ae6b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1976118178,
+            "lat": 34.402723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "72efa99d-44c7-4122-9e17-2dbf53918b9d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.82347,
+            "lat": 27.03037
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "16c5e8d3-ff27-4767-ba09-64f867bd71d1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.9452072805286,
+            "lat": 35.8427289587811
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2ec5104d-4406-4c62-9313-31d6d9aa303c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.19463967646945,
+            "lat": 35.22880280194262
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9faa4b4d-a262-443b-bfc4-b432172a3042",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.40018538933144,
+            "lat": 47.39232589102222
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f6bc0e19-3ede-4e3f-b562-adbbbee3f160",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5454953311,
+            "lat": 32.618054
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1f92915a-7407-42bf-bd10-ca071513bd19",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9412125584,
+            "lat": 31.75388
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bd2423f6-218a-4e77-9873-57b5a0be0640",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.00895,
+            "lat": 32.20008
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a71667ae-8e71-4566-b801-4b953e145e80",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3fda62e7-fcb4-4633-9975-861149deb8dd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0397b86b-7003-4054-be89-63f1d42fb746",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.51666,
+            "lat": 2.83333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4ff9ba24-8fa8-4116-9a17-a0ac37670c8c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.417,
+            "lat": 52.3333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "eb2c2e49-4aaf-4a2c-99ee-4d33404fc079",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.418566,
+            "lat": 45.182989
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fb34a8cc-eb28-41c2-b49e-9a79dba23999",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.1981,
+            "lat": 43.3967
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2059e4d4-d99f-4eca-97a9-156ace24bf31",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.4,
+            "lat": 44.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "095d6419-e7d1-41e9-80b7-464fa9015a90",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.7,
+            "lat": 46.25
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "099e4996-09a3-4d8d-8749-48a74cbe2e6a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2b830c71-9187-45bd-bb4a-1c65de4b8adf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4606399,
+            "lat": 36.38821714
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "62a278ba-2e95-4562-861b-f54387499f9a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.270627,
+            "lat": 44.713534
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "53ed4d81-3372-4e2f-b6a4-9d357238531a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5828831,
+            "lat": 36.36862917
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e1fe71fa-2675-4f61-bfd1-544d29db17da",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.15,
+            "lat": 44.1167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "be51aa3b-0985-483e-a0de-3f4d8c7e1310",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.771556,
+            "lat": 44.967243
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7f91c416-9626-4a7f-98b6-548a32a81b95",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.52751,
+            "lat": 32.62054
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "88776a09-52f3-4176-8326-9c252d746359",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.765570825,
+            "lat": 36.886564128
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bed23781-736b-44f2-a3df-8b0582f77658",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4815,
+            "lat": 32.3723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9d1ea493-3c13-4718-ba66-0834d8d831ef",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.730672,
+            "lat": 42.833014
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e147d20c-56f7-4381-bac4-61aa67f4e9ef",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.198684,
+            "lat": 34.406259
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "10a03b0a-c9ac-42bb-95b1-f0de80824452",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.83322773499071,
+            "lat": 45.55931441052632
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b219fa12-1e1d-46cb-be76-3894996b9cff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.3538889,
+            "lat": 34.5394444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6f991fcb-e931-47fa-807f-c71d87c47551",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a1b1d4b7-7864-4d2d-b2e1-55c0f32b7428",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.26079,
+            "lat": 3.09061
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "00c0cf9d-80f1-48be-ab1f-adac6d35c6be",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.6539656,
+            "lat": 34.0420392
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "01aba6fa-4f4d-4a6a-b2cc-ef001f96dd18",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.245407,
+            "lat": 44.008779
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ca17ca85-eec1-4236-a41d-a0d042ca0072",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.6167,
+            "lat": 45.95
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d46959fd-fa66-4e47-852a-518f1fa423d2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5a54881e-5a05-4dc3-bb50-3d72568eed7d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.25,
+            "lat": 48.1333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2af7d42d-5887-4e3f-bc33-3ece95ce19e9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.7167,
+            "lat": 41.9333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3e3b74fc-d9d2-49e5-a8ed-54b693496258",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.837393,
+            "lat": 47.240458
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6cafd866-5e28-4925-823f-8c73e7d7ac14",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0336111111,
+            "lat": 34.4172222222
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "38eb53ee-5925-471b-87ad-e765235bb023",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.646393,
+            "lat": 33.080833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "91b3732c-d91a-4b43-98ab-552afa1faf01",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.25,
+            "lat": 44.8333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b0371791-a856-4dd6-bb48-c7e76da9bdb8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.084478,
+            "lat": 34.434229
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a40236b0-cfab-4cff-bce6-226a50106b8a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4298f133-ebc2-43b2-b12a-47bf1985a0dd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "58c3dafc-7364-41e4-b462-f775cc3d55f5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 32.759892
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8fee9de5-f4da-453c-9d87-dd02ea2434db",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.6266667,
+            "lat": 19.5294444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fd012d38-b181-4f5a-b600-3dd738488027",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -73.7834,
+            "lat": 44.328
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d380436b-ef09-4392-9e09-8e476193c101",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.14,
+            "lat": 33.85
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "11eff5d1-5e00-4346-96b6-e3a400eab50b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.82477,
+            "lat": 38.2245
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ef974d9c-cfba-4811-ab93-386034ef19b4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.89839,
+            "lat": 38.41026
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ce436044-2ce0-45c6-bc8d-5cf96d03b307",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.53,
+            "lat": 27.4
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "450d74e2-ff09-4d3c-85a9-a84ded2fce00",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.24090689809088,
+            "lat": 34.04001250669102
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "28729140-81bc-4acc-97e7-46bebac4a60f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.485,
+            "lat": 47.488
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "13b77bad-7b47-462c-8d8a-050fd2e25b41",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.83999,
+            "lat": 42.591858
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1d01dcd5-f347-4ed1-a88a-cbb2c6b28a2a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.239805,
+            "lat": 45.427139
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1d76020a-bdb4-4398-8f23-f74064724781",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.65,
+            "lat": 45.2333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e3293acf-eaaf-42f4-a330-1d95d40da5e6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.8998,
+            "lat": 47.337
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d645ac74-5bee-477e-bcef-7632a5758150",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.1833,
+            "lat": 44.2833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "da187485-6268-4bfb-8f44-3f024776a033",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.825508,
+            "lat": 32.114555
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "669ecde5-6fdd-4c61-b6c7-28cd046cdb73",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.2333,
+            "lat": 42.5833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "68739eb0-7023-4c28-8841-6f45c64a1c26",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.4,
+            "lat": 37.3667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "70bcc0d4-3a40-4559-8284-dfc996185965",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.771556,
+            "lat": 44.967243
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a8487ec4-1b67-453d-891c-43fcd53f0bc3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.890907,
+            "lat": 45.501586
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4c88ea5b-734c-4b27-bc99-f50b0a81c848",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.51527,
+            "lat": 32.45342
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "448b6f07-dd1e-402f-9598-4996d77c140b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3940806,
+            "lat": 36.40704246
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "37841b77-59a0-4bb3-82e1-577af7170014",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.7886392,
+            "lat": 33.86299525
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "391b681a-96ee-43f5-b35a-d7dee511d3c8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.7161509,
+            "lat": 34.34135796
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "74f65ab7-9494-46d2-9032-4aa45c283bde",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.991976,
+            "lat": 34.393953
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "94878f43-b271-40d1-92e4-deb36aa7a4a5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8727938,
+            "lat": 36.37344375
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "03a4d66b-a161-47fa-8e19-304e235753d4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.000667,
+            "lat": 42.677419
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d21c7257-2d1f-40c5-b609-0666470a338b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.3776405,
+            "lat": 33.69136513
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fed3c6e7-4de3-42ac-9553-76298733a82b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5167,
+            "lat": 46.9167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a07891c4-6d0b-4b36-9d73-6c0ca6e8ebf9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.75478977878544,
+            "lat": 48.555160343460685
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "459351a8-4891-4df9-beac-29d7e7e4acd6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -84.7482186,
+            "lat": 49.2678238
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "70a16040-14df-4778-a6b0-180262e0aad7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.8,
+            "lat": 46.0667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a37f9a94-208f-4a7d-a3b0-946802246546",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.412674,
+            "lat": 47.575193
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a3f74eb1-5d8b-42d4-9e74-90516e69bec1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.198354,
+            "lat": 39.546077
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dd22ae5c-b8c3-4bc6-8cbe-a56287c32a54",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0678549435,
+            "lat": 34.4372098533
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ff092ac7-a90a-49c4-8ce5-8885efa9e811",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.498829,
+            "lat": 42.569645
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5639fabc-8b75-4b56-8ec6-003cf6bc0590",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.53659,
+            "lat": 38.27014
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3765ab00-dc14-4ff8-a1d5-60d7ca575b78",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.4270163778,
+            "lat": 31.922716
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cf5e8200-233e-41fd-b7bc-6ebeb1ed7f24",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.183253,
+            "lat": 39.327962
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2a2be65f-a511-4319-bd52-f0b8e5dce62c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.73498213872537,
+            "lat": 39.54246590613516
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "205250c2-025a-45d7-a78f-91e2f5a6526d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1163888889,
+            "lat": 33.3308333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "04ff4725-19c5-4055-a5dc-a09ee1fe7404",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4393758,
+            "lat": 36.81953754
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "07256534-9814-4656-8066-dd389f786687",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.5505582,
+            "lat": 36.30810222
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2aeb71e1-636b-48de-9e1a-4fedd273152e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.7532982,
+            "lat": 33.46416479
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2e515573-dd85-40ab-9649-dfd5c85ccdae",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.638757,
+            "lat": 47.812111
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "63b34700-f708-48a5-913a-cdeeaa9820bf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.273631,
+            "lat": 41.667696
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "69e59d55-6f94-47c4-89d1-06a782acb3f5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.8333,
+            "lat": 47.2167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7883c8ba-f70d-4b59-90e9-f4d1bfb28550",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.231731,
+            "lat": 44.504644
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8338dbaf-a6f4-4e65-bb67-ea7811402fe7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3496374,
+            "lat": 36.41656808
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "afb9c80f-83b6-483f-8ed6-7b63834b3de7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.825158,
+            "lat": 47.430762
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f8572d54-6059-48db-b781-09dd33edff8b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f9add2e8-da82-455f-a97b-9cfb047120be",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3283995,
+            "lat": 33.711498
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "df9a5a97-9742-4001-ad1d-1f1af55f8d42",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.124407,
+            "lat": 42.42853
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "adb96e83-b7f9-4d16-b396-4458a24b5d97",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.3167,
+            "lat": 42.6833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d24760fb-6e3d-465b-bb36-6c5cda14032c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.949196,
+            "lat": 43.287405
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "41eb7c18-23c2-4462-bf9d-b440667eb29d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.65861,
+            "lat": 37.461354
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2df8efc7-5b97-4b39-884d-26c2e7c26202",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.2028078296838,
+            "lat": 48.86600632064929
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a855723a-c12f-462d-9ae0-234da6b645d5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.9711111,
+            "lat": 34.4455556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3bee7b26-0633-456a-8d45-7cb36ff4aa58",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.083,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "01f526cf-c706-4804-bfe0-75a1acb9e2fb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.083,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ba4cf6d2-8719-48e2-873f-7e9c0bc639bc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.514,
+            "lat": 38.94021
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7492bb26-eb24-4a4a-a206-ae4dbc39dbb8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c11ba700-e914-4f68-bc52-374f57dd06dc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.9172211,
+            "lat": 34.3991661
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f5c7e6be-6fec-4fd5-8589-86338808130c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -75.02184,
+            "lat": 44.479677
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ca3f0017-3339-4ae1-ae3e-8eefe9dfc43c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -93.1,
+            "lat": 16.7269444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9541031a-46ca-4e5c-b83e-ed10aa296b82",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.670051,
+            "lat": 32.880785
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "36f25435-9d14-4edb-9714-da860dbba687",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.8563163341,
+            "lat": 33.367591
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9dba9494-7719-4184-9434-6f69296d0409",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0567057953,
+            "lat": 34.423206
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "77a07df0-aa9b-44fc-af1c-614c52d53837",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.99482,
+            "lat": 34.243781
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "21337767-ad37-4c9c-9f3b-23f6c623e892",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.24090689809088,
+            "lat": 34.04001250669102
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "db86092f-1382-4122-9afd-416c323258a8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0bbdf384-b006-467c-9b1d-1ed41a9ee626",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.0824109,
+            "lat": 27.0541522
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "eea004c2-60b0-4e9d-a8f0-a4ffe3dfe7d7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.10468,
+            "lat": 33.42485
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ddb888d4-256d-446d-971b-df08d14f1f56",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.89822,
+            "lat": 46.92156
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "df1e0d4c-a92d-458d-8a6d-1ef3df997674",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.111577,
+            "lat": 42.098688
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d9161366-571f-4089-adc4-554862f9f5cd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.4511091,
+            "lat": 33.00036666
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "db7ae43e-0112-460b-964d-2a87a274cfec",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.9114251,
+            "lat": 36.12945157
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4b946c13-6589-4e37-b158-ddcab9694a85",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.4566805,
+            "lat": 36.30612669
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a097e77-d7f7-4a80-940e-838a1b6badc8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.646393,
+            "lat": 33.080833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a4907321-e3bd-4ead-b845-601223fba3a9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.8333,
+            "lat": 45.5167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "af60ecaa-fa9d-467c-9fa7-8c0ca9982c5d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "17f328c8-ad0e-44f8-a86c-db1bf4cf2213",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.663485,
+            "lat": 35.078382
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6eaadfc8-91ce-4886-8a8e-f2cc486dfa1f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.893402,
+            "lat": 45.24242
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7150de5b-f0be-4aee-9bf5-71c50977bd6a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.5910931,
+            "lat": 36.37400298
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "94195471-4d68-4427-a8db-9226163afe5c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.1833,
+            "lat": 42.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9436e8ce-69cd-4062-8496-46f462855ac5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.7667,
+            "lat": 42.6
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b6e43c52-aac6-4bc0-9209-9c71abd11a88",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.708352,
+            "lat": 48.0097
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "16dbbb3e-586c-4431-8d9a-60f12d660aed",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.155519,
+            "lat": 40.884235
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "261bb151-adb3-4ab8-8862-fec0d758349e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.023447,
+            "lat": 31.205281
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "975a1a03-a728-4a19-88cc-c3c5b2c9178e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.19284763681591,
+            "lat": 47.870705824169896
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7781a4aa-1518-4bb5-9d41-b3786811b60a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.6971257966153,
+            "lat": 33.22812018644003
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0430b4cd-6357-4e20-9d52-b3d63468b03f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.5786111,
+            "lat": 34.5086111
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ce04a61d-ec06-4639-a1ff-b438dd971558",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.1666666667,
+            "lat": 33.0333333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f1bd6c61-b029-438b-a827-e4cab4ab6620",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.54599,
+            "lat": 46.848509
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "640d12f3-0559-4572-86d8-ad1a49f10148",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.350254,
+            "lat": 47.66876
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "676d9915-5e04-4ec3-b70e-ee4f6a3bb715",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.36983,
+            "lat": 31.59696
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "51124b4b-95ef-4687-a893-2b3943fd2a54",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.879841,
+            "lat": 48.610556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "52a45d04-de87-4d1d-8372-6b939ca7fd6b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.600088,
+            "lat": 42.283881
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "606f6947-dc32-4b21-a2d6-7247523ef97c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.510465,
+            "lat": 47.787685
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "47b95342-54d9-4715-ac64-0fa0866060b6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.587784,
+            "lat": 32.934803
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8511ac1b-e65a-477c-99dc-7e0b77766099",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.1221332,
+            "lat": 36.05449795
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9c2659e3-8a2a-4a7f-871d-472b8bda8f0c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.220508,
+            "lat": 36.66490827
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9f04dbfd-63cf-429a-a55d-e161284bb023",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.26856,
+            "lat": 39.983892
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a0e5eb61-538c-41ae-b137-c6514c41fd08",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.5951281,
+            "lat": 35.0441862
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "aa8b3616-5ba6-480d-98a9-3c112ae1e948",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -123.2575,
+            "lat": 43.3821
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "11139993-7f96-4fce-a776-078b5373d06f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.71306,
+            "lat": 32.73621
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e4fe74c1-2ef4-4207-bc04-811ed6a8023a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.4166666667,
+            "lat": 52.3333333333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "02a4a1ba-3665-4198-b28e-b914342bbbdc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.23,
+            "lat": 47.62
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7344b864-7af0-49f4-aebd-c09876679c79",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2e06beff-375b-4f04-b16e-30e3eefafd38",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.986655,
+            "lat": 38.075006
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ffeac222-5261-4165-ac01-f0ce08829461",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.270627,
+            "lat": 44.713534
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5ec494ee-bda9-446b-96d3-d4b6e033efa1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.04598,
+            "lat": 38.11669
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4ea4703b-65f4-4981-85fc-dacd0a11e67f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9076726868,
+            "lat": 33.21434
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "94b260ef-8efd-4e8e-989b-1abac6e35ad0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.071944,
+            "lat": 52.116944
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a69f2dd2-e8c5-4b26-b1b1-d2e4c6d62787",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.682766,
+            "lat": 46.187649
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5769112d-3a0a-4755-846a-5faa6610c363",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.02394436384505,
+            "lat": 33.364254310375294
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ba7fcea7-bcfb-48cb-a476-960da6010b44",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.82422348578524,
+            "lat": 34.4369250201946
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2df0801d-6447-45bb-8d10-d06219dbfbda",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.23673,
+            "lat": 47.88084
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1ad25a3b-a633-4404-ae14-56c1e5b1c4b8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.6369941,
+            "lat": 35.75489861
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0ad20910-109b-4586-b2ce-6df04331ed4f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.350254,
+            "lat": 47.66876
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0f0ea85a-acfb-479b-a1b8-842232d78ed4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.215514,
+            "lat": 41.892425
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "021a81ef-12dc-4223-952a-cb4e6c780ca7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.646393,
+            "lat": 33.080833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a4e4d459-2d9e-46ea-85da-72adfa69adfd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.426067,
+            "lat": 37.277133
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "88489836-0a8e-42b4-8341-d894a762d1bf",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.980266,
+            "lat": 42.072418
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "97e66fb4-c57c-4877-9c50-2cd46c6afe53",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.26856,
+            "lat": 39.983892
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "99003ebd-ec29-444d-8ef4-f77ca68d4ab2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bb0ccd2d-052f-4120-b99f-7aef9922dda8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.9409,
+            "lat": 47.7385
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bb625ef0-bd32-4348-8c66-e9d02274cd75",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.663485,
+            "lat": 35.078382
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "beb15036-3247-474f-becc-88abcb5397c6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.324733,
+            "lat": 41.284424
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9ecc2f15-4178-4a7d-859e-ae8ca2138153",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.8590515,
+            "lat": 32.0150703
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b0d50c37-73f4-4a00-b1a6-183a7c02b73d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.9167,
+            "lat": 46.6833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "40ba1153-e8f3-42fb-93cc-40e997ef6be1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4815,
+            "lat": 32.3723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "756c5884-8788-4511-8974-33f16610f2d0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4815,
+            "lat": 32.3723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "51a03897-6ff6-4fb7-b4e2-a2ce45df2e2a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.78,
+            "lat": 31.59
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0c906b71-f42a-476e-8f56-2f6b7c136bf2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9076726868,
+            "lat": 33.21434
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a2128579-b7ca-478c-b833-3a3553336216",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.12123,
+            "lat": 48.83251
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5ee056c0-77ef-48f9-b919-53c52642e0cd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.66,
+            "lat": 29.28
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "346d925f-4deb-4d58-8c6a-0fe392cf3139",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.15,
+            "lat": 43.05
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fb041a89-d403-45be-b9cf-9514acf51a06",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.404754,
+            "lat": 36.059742
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a7bdcf07-4865-4d85-afc8-e3651a529fff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.00171,
+            "lat": 38.39718
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "708e4ec7-8bc6-41f4-a83d-3830a1e28015",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.22933,
+            "lat": 38.5072
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c8e7073a-3f0c-4730-9bb3-2cb29feceeb1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0569444444,
+            "lat": 34.4575
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "93e8bb96-4a26-4822-a892-74340ce948f7",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.94517417960488,
+            "lat": 35.842732158964004
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "90cad20a-91b3-4f02-8e12-f48fdf4e88a6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.9586111,
+            "lat": 34.5730556
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2fe8912e-ce63-4895-afd4-5a170a1ff491",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.2028078296838,
+            "lat": 48.86600632064929
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4767686d-f005-483d-b508-e0fd86cce19b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.43607643608719,
+            "lat": 45.57039959394705
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1d898733-9d2e-4991-8e8e-015fb514b13a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.3435895,
+            "lat": 34.13612141
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "baf31429-45cd-40f6-9bf8-168a5fe68f08",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.5592865,
+            "lat": 33.77358509
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "771e63dc-030f-497e-b0c9-0f52d876b861",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.7276593,
+            "lat": 32.96823056
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9118283e-988e-45df-9348-2f962b4909b6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.062077,
+            "lat": 44.49517
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f7008861-ede4-408e-b581-7977a852562f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.7798,
+            "lat": 47.4114
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ebfd8ffd-4018-4bb7-a084-f384482729d6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.761654,
+            "lat": 33.70846
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6d5cae49-6fac-49e7-a5a8-5f0d2296d8b0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.124407,
+            "lat": 42.42853
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "667531c1-9e4b-45e9-817f-0d34a418592b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.401033,
+            "lat": 48.656324
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "50217576-49b4-4c3a-a54c-74e7485b436e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.9167,
+            "lat": 46.6833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "570c0344-a33a-4d78-8aea-71322372263f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.3833,
+            "lat": 45.35
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "873ae180-6c31-469d-8e07-b9bed86f3465",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.6323069,
+            "lat": 36.06460715
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9021bfd8-eef2-44b1-b755-a1ffb21a7197",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1329136,
+            "lat": 32.6725591
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2cbdaa1b-580d-4f18-8a1d-22e1baf8b2fe",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9833,
+            "lat": 31.77838
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3c96c31b-05c8-475c-aa84-dad129b39961",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.044246,
+            "lat": 43.893791
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "318ee504-d968-482c-a925-ca63ecba08b1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.6167,
+            "lat": 44.4833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2c0d6ec8-0d74-4a7a-87be-4dcc15537711",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "709a7d62-f787-4530-86f2-331f11199989",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "606dfa99-f7e8-42a2-a3d2-15d75f7a6421",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.43,
+            "lat": 25.57
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f0b2e570-6208-4600-a9ab-7d58af6df1ff",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.92151,
+            "lat": 48.942913
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "38168fcd-a0ac-4b30-8c27-52db5c7907eb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -93.1,
+            "lat": 16.7269444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "57e045a4-5826-4b56-b505-437ea5071535",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -93.1,
+            "lat": 16.7269444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "69fb80cd-ece3-4c3d-b03a-d04be29a14ba",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.69043585143505,
+            "lat": 34.41272378698258
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2dae6610-7c63-4c8f-9103-3674e1e0cf19",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.95012934843614,
+            "lat": 19.444813451237142
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "19e9ae46-6b30-4ab8-ab6a-4ddadd2020df",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.63787776171154,
+            "lat": 48.26280969118889
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2b0c0d6e-6842-4447-8720-5c76675284fd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.73498213872537,
+            "lat": 39.54246590613516
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "33fe7584-5091-4bed-a263-f3947b670fcb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -126.5666666667,
+            "lat": 49.6
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "824c0e0c-e0d7-4953-b6c3-8d2bade75dae",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4691222526,
+            "lat": 34.422661
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "18ea92ea-e225-4b70-b9d1-5d61cf74ed77",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.35,
+            "lat": 31.6
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "997870b1-d456-4d3d-8b85-6e5cc43440ca",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "49e7fea4-4814-42c4-8887-05e901e27382",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.8,
+            "lat": 46.0667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2a1c6863-2718-4a9e-bacc-d3dfd375c634",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "23d383c0-ab69-4758-b642-8c42d1be24fb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.949196,
+            "lat": 43.287405
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2abb64ce-ef8f-485d-b80c-4fa61a6b96c4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.077878,
+            "lat": 42.54795
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "06b5f5f5-1a58-4c3f-9f04-b48bfae3853e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.375808,
+            "lat": 42.802514
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2ed37c4b-0ed7-4ba2-a823-d595bc668b33",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.7667,
+            "lat": 47.2167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6ce1cee5-71a3-461c-b7c0-8ca526024e37",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "56af5d09-fb9a-4b21-9897-b06c68577e37",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.6031162,
+            "lat": 33.40033066
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "74bfa810-324f-4aad-9bb7-0430aa041fda",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.412674,
+            "lat": 47.575193
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6e31b349-b637-4a51-bc72-f4913d48257f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.663485,
+            "lat": 35.078382
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "490b3062-fc48-445c-842f-cfdfb2cc85d8",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "33c1e43c-d90e-4f4f-b611-90be88801fbd",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.654419,
+            "lat": 41.778534
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d5b112c6-743f-4621-8d1c-c40bb822348b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8738301,
+            "lat": 36.87818886
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ac7010f1-8988-48c2-9ce2-40e68f36803e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.839157,
+            "lat": 32.064445
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7b70a2d9-2337-472b-b91c-76f8198dbb59",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.2,
+            "lat": 45.4167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "827dbc45-a7f9-46e8-b266-08e02a81d230",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3667,
+            "lat": 46.65
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f9af5b55-209b-4df3-bbb6-4689b0634bac",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.588315,
+            "lat": 42.624914
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "842a02b8-e101-4ed4-8658-9c505fbf646f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.9631704979,
+            "lat": 33.134101
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0ab6c85d-1b11-4700-ba1e-e91094a4bb6d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6b2cddd2-cbd1-4243-9abd-782882afc2ca",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.133538,
+            "lat": 40.448657
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a88676eb-2fac-45fa-be1f-81ccb0f3ed04",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1153381192,
+            "lat": 33.405473
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "84277c57-182e-46fa-97fb-ee2c81a38bfb",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.433644,
+            "lat": 31.474494
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9d982f3c-434e-4f86-932e-59b66fbfbd84",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4815,
+            "lat": 32.3723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2587133b-65a4-4cca-9b63-8ac8bb1227ec",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.117111,
+            "lat": 47.543256
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2dc58331-820c-4745-8dd9-19e3259e6d85",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.812797,
+            "lat": 33.87438261
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2f7cb916-74ff-4d22-9c69-d0927489f0c0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.3387405,
+            "lat": 36.67165176
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "36a2cbf1-8901-472a-a849-de288a93fc4d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.5476967,
+            "lat": 33.02069445
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "370b744e-5348-4c93-85fb-9ac5c30a3ab6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.7106238,
+            "lat": 33.50951381
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "19246392-3430-4674-a495-d288b0b52a2c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3333,
+            "lat": 44.5
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1943f221-19d4-43d0-88a6-17e18db71add",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.0167,
+            "lat": 44.55
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1f934623-e700-44fb-9bf2-ff4780f8d432",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.55,
+            "lat": 45.3667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1fefff6d-59b1-4c56-b83d-cd0b1ddda866",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.843887,
+            "lat": 32.019165
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "103be7c9-c077-47a2-b109-e5120fd2e2a5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.45699,
+            "lat": 31.84704
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "12a0ac63-9743-4c06-8d66-511b5047d49a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.3612304,
+            "lat": 31.6035623
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d12267dc-b9d1-47f4-83f9-c69afc9d0b16",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d58b5765-64d2-4495-9808-fd0b8da8abf5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -111.1833,
+            "lat": 42.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b9b6523a-2b97-424f-9772-174100a01c9b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.426067,
+            "lat": 37.277133
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e06cf918-bf83-490b-8e10-62d238492645",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.458487,
+            "lat": 46.772398
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "93222516-bf93-4459-8ea9-69ee0866686b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.1327776,
+            "lat": 34.306118
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c36daac5-8cdb-44be-be49-384844ac9b38",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.0253796,
+            "lat": 34.1656598
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b3b9c55e-e7de-4031-8c6c-27a70987fcf9",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5167,
+            "lat": 46.9167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bf1662d4-4989-4105-81cb-2a844985bff5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.3,
+            "lat": 47.7667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "40cd7dd6-dd6e-4857-af1b-d5a64919ec47",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.2754062,
+            "lat": 33.40210799
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "17295a66-eb1f-470b-8a7a-014b16d2038d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -59.51666,
+            "lat": 2.83333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5555f841-ff87-4981-9792-b97f91c200df",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -124.36306,
+            "lat": 48.285
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1ec7dcc7-1e73-4bb2-a425-56c9013d5d5c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -132.25,
+            "lat": 56.4166666667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "29e5772a-52f8-4efd-8290-84117d38f2c1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -103.9470905,
+            "lat": 35.91470284
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "0105abf9-7ed8-4b40-be21-e6ee646108f2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.357701,
+            "lat": 41.145783
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "20b4b02d-cf06-4203-9678-b289b1e2fe64",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.612653,
+            "lat": 44.709328
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "97bc8635-a311-4915-8bc2-144d4ca09f4a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.608717,
+            "lat": 43.985452
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a8bae4d6-dc4c-4f6d-8e2d-4f5f476fa4e4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.905653,
+            "lat": 44.99158
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dbaaf299-238a-49b8-8be5-bfca64ac7839",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.8357727,
+            "lat": 36.22077975
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e66998f6-5382-4f81-8102-8cc7207135ba",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.0667,
+            "lat": 40.9833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ca8c675e-8679-4f52-859b-bfaf7eb36d05",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.70614,
+            "lat": 32.91702
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cce50188-4f20-4c3a-a1a3-c65d8a919fc5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.3283997,
+            "lat": 33.7977993
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bd7d4cfd-cefb-4176-acb3-ecf779b31668",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.608717,
+            "lat": 43.985452
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "6e896033-a23d-485c-a1e5-faef2f6ea1b3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.5,
+            "lat": 43.8667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "863a2496-d2d3-4b98-a5bb-939f69de91e0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.7708315,
+            "lat": 34.22163936
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2e6fd1ff-ae17-4323-988e-49c00b0a740a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.0927777778,
+            "lat": 40.0094444444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "41bffb07-3a12-4c29-adb4-2c51a69151d6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.9333,
+            "lat": 47.6167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fa469176-f879-40b5-a7a2-7ddafd5a080a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.295649,
+            "lat": 48.3098987
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bf478cd6-cff3-4a94-9da6-f3026ca7572c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.840656,
+            "lat": 42.693656
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b3001abb-119b-4b7f-8465-29c096f5fe59",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.36365,
+            "lat": 31.61538
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4869d84d-fa73-4f74-a19f-b4354a615c90",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.10718,
+            "lat": 38.35372
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5e816ee9-309c-4812-b31e-4de409f4163b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.612491,
+            "lat": 41.454838
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "783a8a85-6034-434b-b3f7-84cb30863c0d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.730672,
+            "lat": 42.833014
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ac2ab6e1-6687-404a-9c7a-fe6fe6ba36d6",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -119.82422348578524,
+            "lat": 34.4369250201946
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "055f71ec-3c6e-452c-9249-776da207ce3b",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -121.69259670879347,
+            "lat": 47.154031312747314
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2cda3033-ccd8-4fe1-ad9f-ec9e736620d5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -120.2427778,
+            "lat": 34.875
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1061f394-c1e1-4f67-a036-9de994e2c17f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -110.402,
+            "lat": 40.16329
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3bf126f0-8c60-402e-b876-75a9360d0aba",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -60.2666667,
+            "lat": 6.3166667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cf263780-f4c6-4bb5-ba83-6e6505dfa0fc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.496714,
+            "lat": 31.898705
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dd611cfa-ae49-4272-ad6f-afe013a7401d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -90.98302803382234,
+            "lat": 16.882571960435143
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2f0ab7ce-f1b4-4178-9385-222e50558573",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.715258,
+            "lat": 41.943831
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a07bc9f-cd9f-4b35-8385-a50c1d4852cc",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.35,
+            "lat": 44.2833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e2bc6ad8-ec80-459d-8f66-bc0361d0fe54",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.728206,
+            "lat": 44.942853
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e790139e-3cb2-41c0-9a8f-c9f3cee607d5",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -113.5833,
+            "lat": 44.0167
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cbdd5b69-041d-49b4-a19c-9e65cf8fa8a0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.4320983,
+            "lat": 33.5285997
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cdae998a-f006-4db7-a58e-b9f69af7e1ba",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.215514,
+            "lat": 41.892425
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "724957cc-f0e5-4de7-add4-0341fc64ad32",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.276012,
+            "lat": 47.803527
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "53a5163d-ab6c-4822-bc13-081c30eb9699",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.8557818,
+            "lat": 32.69942049
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4ca07116-b695-4425-98a7-b03eed446a82",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -105.8451115,
+            "lat": 33.195911
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "4d37c20c-ea82-442f-8eb6-17202b4fef15",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.1381464,
+            "lat": 36.9235171
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "88d53b35-0a3b-4cf4-a37d-353e3932ca1c",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -117.3199,
+            "lat": 45.4343
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "983d4304-5436-4439-b1ee-69d1aa1d51a4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.8497003,
+            "lat": 36.84600531
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cfc68794-0336-415b-b9cc-c3091676d1d3",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.1153381192,
+            "lat": 33.405473
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d15f9ed9-85f4-4bdc-a160-c0591bc0d946",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.0675816052,
+            "lat": 34.423023
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e5487eab-6389-4fbe-b0f3-eb7ed877dcf0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.433644,
+            "lat": 31.474494
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "d1b776e3-e00d-4ed8-830d-93f94dfd282a",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.89839,
+            "lat": 38.41026
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "af7e7b80-c145-4068-95d6-7bf96674aa12",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -107.2042309659,
+            "lat": 32.910372
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3917f6a3-6302-4d6f-952d-3cbbae54f020",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -122.122,
+            "lat": 46.7578
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "cecbfd32-86ab-4d2e-ab50-31b91af768a1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -115.5667,
+            "lat": 43.6333
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9b116659-edbd-494e-b177-d0a83c437a9f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -106.465376,
+            "lat": 31.813188
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e01de566-9e14-4277-b1d5-f0000f33417f",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -93.1,
+            "lat": 16.7269444
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "86179189-d89c-4f93-bf3e-8a4a88d48005",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -91.1625,
+            "lat": 16.8125
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9b21b92d-1ddc-4f65-a7c0-904e32162866",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -74.448633,
+            "lat": 42.057137
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5039448d-126f-4bf7-8865-790b66f19811",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -118.083,
+            "lat": 52.8833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "7325caa5-e250-47f1-9441-72d6f4b41d0d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -80.31,
+            "lat": 25.61
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "302e283b-1ff2-4673-9cf4-f07b56a9d641",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -82.21,
+            "lat": 29.41
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "16e70b6c-d547-4a51-be85-128a70db1d99",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -125.583333,
+            "lat": 49.75
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "c87f6859-0fe5-4ad7-b747-6f12a0cd4b28",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.65,
+            "lat": 47.85
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ddc72f73-f807-4c16-9d58-41b582de7dd0",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.124407,
+            "lat": 42.42853
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "ae192194-b8b9-43ac-853e-941f7391f736",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "66231d3a-4ffb-4c80-93bb-cbd9ac599d45",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.4,
+            "lat": 37.3667
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8b4cbf71-d554-4ed9-963d-7e9a78c42c38",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.1765382,
+            "lat": 34.92388008
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "760c6d02-59c4-4691-a40f-34a724efdda1",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.45,
+            "lat": 47.6833
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "24f4389e-f949-4bd2-a4b2-7a81e6d3c193",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.867493,
+            "lat": 34.82395
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "3a84970a-74d6-4b18-b1a7-6f47351b6eea",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.799562,
+            "lat": 46.65603
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9dc0ae7b-b6ca-4924-b390-1a7e1a98c03d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -112.840656,
+            "lat": 42.693656
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "f365f4f7-f4f7-4a37-b120-6398f2538b5e",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -109.240617,
+            "lat": 31.592321
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "fa228820-032c-4453-b84d-40328bb6937d",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.15973,
+            "lat": 33.03485
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "b55d45c1-1f96-4742-88ad-145079603126",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -114.950044,
+            "lat": 40.96048
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "1c84fae2-43ea-477a-93d9-4aa23b2a52ab",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.70963,
+            "lat": 32.72195
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "43ea233e-075a-4a18-9382-6502c5550de2",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -104.4815,
+            "lat": 32.3723
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "2566a9b8-9aed-4a7c-9e5f-bac6193b5178",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -116.412674,
+            "lat": 47.575193
+          },
+          "scientificname": "puma concolor"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "122b2672-1282-4016-99ce-4c3b3c709ea4",
+        "_score": 1,
+        "_source": {
+          "geopoint": {
+            "lon": -108.994714,
+            "lat": 31.694212
+          },
+          "scientificname": "puma concolor"
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "rs": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "09b18522-5643-478f-86e9-d2e34440d43e",
+          "doc_count": 872
+        },
+        {
+          "key": "21ea1ef6-4a2a-4ff2-a18b-5c0f297fc1cf",
+          "doc_count": 62
+        },
+        {
+          "key": "0e2f3962-e905-48f2-a1c6-19d16e2bd5ba",
+          "doc_count": 61
+        },
+        {
+          "key": "f9a33279-d6ba-41c7-a511-ef6adfcb6e20",
+          "doc_count": 45
+        },
+        {
+          "key": "e6d3c1da-a02f-43a2-a5ef-6a035298b933",
+          "doc_count": 35
+        },
+        {
+          "key": "2d853a6d-50ec-4931-8e91-48fc2491fdee",
+          "doc_count": 31
+        },
+        {
+          "key": "b7a79601-c07b-46d5-bd09-d4472b0d9431",
+          "doc_count": 30
+        },
+        {
+          "key": "9d8ced48-62c5-4ce0-99e7-a03550c674c0",
+          "doc_count": 25
+        },
+        {
+          "key": "ec359278-df8e-4766-a1d3-4b55fd822704",
+          "doc_count": 23
+        },
+        {
+          "key": "f18d38a1-19c2-4b33-b79a-d44ab356b01c",
+          "doc_count": 16
+        },
+        {
+          "key": "a4c4e0ee-38dd-47fd-9b06-ce4cc011e111",
+          "doc_count": 11
+        },
+        {
+          "key": "c6969e30-ca21-4576-954d-9c0e052bdde9",
+          "doc_count": 10
+        },
+        {
+          "key": "c2dcb184-6c90-4aa3-9ebb-33b2d53837b9",
+          "doc_count": 9
+        },
+        {
+          "key": "e165b318-d5f7-40d5-a0d9-82ba3c31060f",
+          "doc_count": 8
+        },
+        {
+          "key": "5c861676-8285-4a04-b1c5-94ce73342320",
+          "doc_count": 7
+        },
+        {
+          "key": "50cfe20a-9100-4710-89f9-a97bc3aa53d7",
+          "doc_count": 6
+        },
+        {
+          "key": "b4d4e884-a2ef-4967-b4cb-2072fc465eaf",
+          "doc_count": 6
+        },
+        {
+          "key": "f3d1fbbb-93d5-432e-8808-ebc08c42ef6d",
+          "doc_count": 5
+        },
+        {
+          "key": "0a0f5c81-bf4d-492b-b459-08bd987a0c9a",
+          "doc_count": 4
+        },
+        {
+          "key": "62c35d43-f15c-451d-a8be-1b9c6928b8bd",
+          "doc_count": 4
+        },
+        {
+          "key": "9dce915b-3de4-4a7d-a68d-e4c4c15809ce",
+          "doc_count": 4
+        },
+        {
+          "key": "059b7cd4-03d9-4ed5-acac-a4cc41ab5c1d",
+          "doc_count": 3
+        },
+        {
+          "key": "311c3a01-c824-4a85-8771-fcc3f353619b",
+          "doc_count": 3
+        },
+        {
+          "key": "433646ab-571a-44f5-820e-25e0736b1113",
+          "doc_count": 3
+        },
+        {
+          "key": "48e1b8c1-91aa-4b87-8ca0-de1f81232eaf",
+          "doc_count": 3
+        },
+        {
+          "key": "d1c20e8e-d875-473b-bfbf-fecf35ed00d0",
+          "doc_count": 3
+        },
+        {
+          "key": "f1512610-8631-475c-875a-a634191a9715",
+          "doc_count": 3
+        },
+        {
+          "key": "f77daa20-545c-4fce-812c-cdb4d658dfa5",
+          "doc_count": 3
+        },
+        {
+          "key": "0f3f26e2-cc13-47a3-a268-4c321b621586",
+          "doc_count": 2
+        },
+        {
+          "key": "929bf047-9ad7-48bd-88fa-c2630d423e8a",
+          "doc_count": 2
+        },
+        {
+          "key": "d0105f1d-a9a0-4cd4-817d-aebfb5512923",
+          "doc_count": 2
+        },
+        {
+          "key": "f8944362-0f02-4ccb-bbaf-3149b2de8e22",
+          "doc_count": 2
+        },
+        {
+          "key": "14a8f79f-eab7-48da-ad50-bda142703820",
+          "doc_count": 1
+        },
+        {
+          "key": "16e722d1-cf07-4bb9-a4ff-3c38ab0bcebf",
+          "doc_count": 1
+        },
+        {
+          "key": "2ee6534e-46ab-4233-98c4-d13c4262ce2e",
+          "doc_count": 1
+        },
+        {
+          "key": "319636db-c2da-493c-beac-1194949e95b4",
+          "doc_count": 1
+        },
+        {
+          "key": "86b1f54d-ac01-4c5e-8ed8-09da2689c7a9",
+          "doc_count": 1
+        },
+        {
+          "key": "a6eee223-cf3b-4079-8bb2-b77dad8cae9d",
+          "doc_count": 1
+        },
+        {
+          "key": "f4f833ea-0abf-4059-948e-132c64dda1be",
+          "doc_count": 1
+        }
+      ]
+    },
+    "gstyle": {
+      "doc_count": 137283704,
+      "f": {
+        "doc_count": 1322,
+        "style": {
+          "doc_count_error_upper_bound": 0,
+          "sum_other_doc_count": 0,
+          "buckets": [
+            {
+              "key": "puma concolor",
+              "doc_count": 1322
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/__tests__/mock/search-eb08700461885651d0d6711d111e91e1.json
+++ b/__tests__/mock/search-eb08700461885651d0d6711d111e91e1.json
@@ -1,0 +1,820 @@
+{
+  "timed_out": false,
+  "_shards": {
+    "total": 48,
+    "successful": 48,
+    "failed": 0
+  },
+  "hits": {
+    "total": 83108,
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "06155592-f333-4612-a841-c8b25e6249dd",
+        "_score": 1,
+        "_routing": "17c0326e-7984-4654-a6d8-1fd2568578fa",
+        "_parent": "17c0326e-7984-4654-a6d8-1fd2568578fa",
+        "_source": {
+          "licenselogourl": "https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+          "uuid": "06155592-f333-4612-a841-c8b25e6249dd",
+          "format": "image/jpeg",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.45454545454545453,
+          "rights": "BY-NC-SA",
+          "mediatype": "images",
+          "hasSpecimen": true,
+          "records": [
+            "17c0326e-7984-4654-a6d8-1fd2568578fa"
+          ],
+          "etag": "f0fb67b7cac772b30f43b0380209bfa556d05ddf",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "idigbio:uuid": "06155592-f333-4612-a841-c8b25e6249dd",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00032251.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00032251",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00032251",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00032251"
+            ],
+            "idigbio:siblings": {
+              "record": [
+                "17c0326e-7984-4654-a6d8-1fd2568578fa"
+              ]
+            },
+            "dcterms:rights": "© University of Connecticut",
+            "idigbio:dateModified": "2014-09-09T01:38:49.314000",
+            "idigbio:etag": "f0fb67b7cac772b30f43b0380209bfa556d05ddf",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "webstatement": "http://creativecommons.org/licenses/by-nc-sa/4.0/",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00032251"
+          ],
+          "data": {
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00032251.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00032251",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00032251",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "dcterms:rights": "© University of Connecticut",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "datemodified": "2014-09-09T01:38:49.314000+00:00",
+          "accessuri": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00032251.JPG"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "097aa502-6c48-4011-89d3-ffa295b46cf3",
+        "_score": 1,
+        "_routing": "3c7fa3f8-01c3-4e91-9f9a-75c550381ff3",
+        "_parent": "3c7fa3f8-01c3-4e91-9f9a-75c550381ff3",
+        "_source": {
+          "licenselogourl": "https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+          "uuid": "097aa502-6c48-4011-89d3-ffa295b46cf3",
+          "format": "image/jpeg",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.45454545454545453,
+          "rights": "BY-NC-SA",
+          "mediatype": "images",
+          "hasSpecimen": true,
+          "records": [
+            "3c7fa3f8-01c3-4e91-9f9a-75c550381ff3"
+          ],
+          "etag": "ba5b48d755fc106ada509260bf732101149bbd8a",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "idigbio:uuid": "097aa502-6c48-4011-89d3-ffa295b46cf3",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00021995.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00021995",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00021995",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00021995"
+            ],
+            "idigbio:siblings": {
+              "record": [
+                "3c7fa3f8-01c3-4e91-9f9a-75c550381ff3"
+              ]
+            },
+            "dcterms:rights": "© University of Connecticut",
+            "idigbio:dateModified": "2014-09-12T19:39:15.755000",
+            "idigbio:etag": "ba5b48d755fc106ada509260bf732101149bbd8a",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "webstatement": "http://creativecommons.org/licenses/by-nc-sa/4.0/",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00021995"
+          ],
+          "data": {
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00021995.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00021995",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00021995",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "dcterms:rights": "© University of Connecticut",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "datemodified": "2014-09-12T19:39:15.755000+00:00",
+          "accessuri": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00021995.JPG"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0b2fc030-1294-421b-9b9d-a3b1ed22bc37",
+        "_score": 1,
+        "_routing": "18cafbe5-3412-4620-890a-9ffe10a7e633",
+        "_parent": "18cafbe5-3412-4620-890a-9ffe10a7e633",
+        "_source": {
+          "licenselogourl": "https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+          "uuid": "0b2fc030-1294-421b-9b9d-a3b1ed22bc37",
+          "format": "image/jpeg",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.45454545454545453,
+          "rights": "BY-NC-SA",
+          "mediatype": "images",
+          "hasSpecimen": true,
+          "records": [
+            "18cafbe5-3412-4620-890a-9ffe10a7e633"
+          ],
+          "etag": "0f35a52f4da103f6e13b7cf6381d5d5d4a6dc2e9",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "idigbio:uuid": "0b2fc030-1294-421b-9b9d-a3b1ed22bc37",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00078840.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00078840",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00078840",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00078840"
+            ],
+            "idigbio:siblings": {
+              "record": [
+                "18cafbe5-3412-4620-890a-9ffe10a7e633"
+              ]
+            },
+            "dcterms:rights": "© University of Connecticut",
+            "idigbio:dateModified": "2014-09-09T02:40:37.515000",
+            "idigbio:etag": "0f35a52f4da103f6e13b7cf6381d5d5d4a6dc2e9",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "webstatement": "http://creativecommons.org/licenses/by-nc-sa/4.0/",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00078840"
+          ],
+          "data": {
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00078840.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00078840",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00078840",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "dcterms:rights": "© University of Connecticut",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "datemodified": "2014-09-09T02:40:37.515000+00:00",
+          "accessuri": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00078840.JPG"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "0b72a8c0-bcb5-40a6-8abf-a4e5a30b4e49",
+        "_score": 1,
+        "_routing": "0bc984e9-4e03-441b-94a8-75f433c26e70",
+        "_parent": "0bc984e9-4e03-441b-94a8-75f433c26e70",
+        "_source": {
+          "licenselogourl": "https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+          "uuid": "0b72a8c0-bcb5-40a6-8abf-a4e5a30b4e49",
+          "format": "image/jpeg",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.45454545454545453,
+          "rights": "BY-NC-SA",
+          "mediatype": "images",
+          "hasSpecimen": true,
+          "records": [
+            "0bc984e9-4e03-441b-94a8-75f433c26e70"
+          ],
+          "etag": "2ff675afd19846d40b50d7d36965bbb4c90c6a2c",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "idigbio:uuid": "0b72a8c0-bcb5-40a6-8abf-a4e5a30b4e49",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00078518.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00078518",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00078518",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00078518"
+            ],
+            "idigbio:siblings": {
+              "record": [
+                "0bc984e9-4e03-441b-94a8-75f433c26e70"
+              ]
+            },
+            "dcterms:rights": "© University of Connecticut",
+            "idigbio:dateModified": "2014-09-09T01:28:25.004000",
+            "idigbio:etag": "2ff675afd19846d40b50d7d36965bbb4c90c6a2c",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "webstatement": "http://creativecommons.org/licenses/by-nc-sa/4.0/",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00078518"
+          ],
+          "data": {
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00078518.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00078518",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00078518",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "dcterms:rights": "© University of Connecticut",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "datemodified": "2014-09-09T01:28:25.004000+00:00",
+          "accessuri": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00078518.JPG"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "120c9d5a-5faa-41c6-93f4-4b680e0ca311",
+        "_score": 1,
+        "_routing": "f7506eff-4f5c-4ede-b06a-b18753373c8a",
+        "_parent": "f7506eff-4f5c-4ede-b06a-b18753373c8a",
+        "_source": {
+          "hasSpecimen": true,
+          "uuid": "120c9d5a-5faa-41c6-93f4-4b680e0ca311",
+          "format": "image/jpeg",
+          "recordset": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "dqs": 0.2727272727272727,
+          "rights": "Public Domain",
+          "mediatype": "images",
+          "records": [
+            "f7506eff-4f5c-4ede-b06a-b18753373c8a"
+          ],
+          "etag": "040004a97d744908f6d1b8ce705a712265ee53ef",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "ac:comments": "http://creativecommons.org/publicdomain/mark/1.0/",
+            "idigbio:parent": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+            "xmpRights:UsageTerms": "Public Domain",
+            "ac:thumbnailAccessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-SDnv8PCUXTU3breruiboRG?resize=1250&format=jpeg",
+            "ac:goodQualityAccessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-SDnv8PCUXTU3breruiboRG?resize=1250&format=jpeg",
+            "coreid": "807963",
+            "dcterms:identifier": "http://bisque.iplantcollaborative.org/image_service/image/00-SDnv8PCUXTU3breruiboRG?resize=1250&format=jpeg",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "idigbio:dateModified": "2016-04-21T13:40:35.966214",
+            "ac:metadataLanguage": "en",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807963",
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:5b42d543-b5e6-43c8-b68a-9bb97b086f47",
+            "ac:subtype": "Photograph",
+            "idigbio:etag": "040004a97d744908f6d1b8ce705a712265ee53ef",
+            "dcterms:format": "image/jpeg",
+            "idigbio:siblings": {
+              "record": [
+                "f7506eff-4f5c-4ede-b06a-b18753373c8a"
+              ]
+            },
+            "ac:caption": "YU YU.076242 Acer spicatum Lam.",
+            "idigbio:recordIds": [
+              "urn:uuid:5b42d543-b5e6-43c8-b68a-9bb97b086f47",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\media\\http://bovary.iplantcollaborative.org/image_service/image/00-sdnv8pcuxtu3breruiborg",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\media\\http://bisque.iplantcollaborative.org/image_service/image/00-sdnv8pcuxtu3breruiborg?resize=1250&format=jpeg"
+            ],
+            "ac:accessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-SDnv8PCUXTU3breruiboRG?resize=1250&format=jpeg",
+            "xmp:MetadataDate": "2015-02-04 18:09:11",
+            "idigbio:uuid": "120c9d5a-5faa-41c6-93f4-4b680e0ca311"
+          },
+          "recordids": [
+            "urn:uuid:5b42d543-b5e6-43c8-b68a-9bb97b086f47",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\media\\http://bovary.iplantcollaborative.org/image_service/image/00-sdnv8pcuxtu3breruiborg",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\media\\http://bisque.iplantcollaborative.org/image_service/image/00-sdnv8pcuxtu3breruiborg?resize=1250&format=jpeg"
+          ],
+          "data": {
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:5b42d543-b5e6-43c8-b68a-9bb97b086f47",
+            "ac:subtype": "Photograph",
+            "ac:metadataLanguage": "en",
+            "xmpRights:UsageTerms": "Public Domain",
+            "ac:comments": "http://creativecommons.org/publicdomain/mark/1.0/",
+            "dcterms:format": "image/jpeg",
+            "ac:goodQualityAccessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-SDnv8PCUXTU3breruiboRG?resize=1250&format=jpeg",
+            "coreid": "807963",
+            "dcterms:identifier": "http://bisque.iplantcollaborative.org/image_service/image/00-SDnv8PCUXTU3breruiboRG?resize=1250&format=jpeg",
+            "ac:caption": "YU YU.076242 Acer spicatum Lam.",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "ac:thumbnailAccessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-SDnv8PCUXTU3breruiboRG?resize=1250&format=jpeg",
+            "ac:accessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-SDnv8PCUXTU3breruiboRG?resize=1250&format=jpeg",
+            "xmp:MetadataDate": "2015-02-04 18:09:11",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807963"
+          },
+          "datemodified": "2016-04-21T13:40:35.966214+00:00",
+          "accessuri": "http://bisque.iplantcollaborative.org/image_service/image/00-SDnv8PCUXTU3breruiboRG?resize=1250&format=jpeg"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "16201bed-b9cc-4065-813b-78a9938b3d1c",
+        "_score": 1,
+        "_routing": "8b34495c-42ae-4ba2-8377-0a5b034397e0",
+        "_parent": "8b34495c-42ae-4ba2-8377-0a5b034397e0",
+        "_source": {
+          "licenselogourl": "https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png",
+          "uuid": "16201bed-b9cc-4065-813b-78a9938b3d1c",
+          "format": "image/jpeg",
+          "recordset": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "dqs": 0.45454545454545453,
+          "rights": "BY-NC-SA",
+          "mediatype": "images",
+          "hasSpecimen": true,
+          "records": [
+            "8b34495c-42ae-4ba2-8377-0a5b034397e0"
+          ],
+          "etag": "0d72beeac600bca7a7cdf18ca518afdee6745eef",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "idigbio:parent": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "idigbio:uuid": "16201bed-b9cc-4065-813b-78a9938b3d1c",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00078650.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00078650",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00078650",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "idigbio:recordIds": [
+              "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00078650"
+            ],
+            "idigbio:siblings": {
+              "record": [
+                "8b34495c-42ae-4ba2-8377-0a5b034397e0"
+              ]
+            },
+            "dcterms:rights": "© University of Connecticut",
+            "idigbio:dateModified": "2014-09-09T05:02:47.586000",
+            "idigbio:etag": "0d72beeac600bca7a7cdf18ca518afdee6745eef",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "webstatement": "http://creativecommons.org/licenses/by-nc-sa/4.0/",
+          "recordids": [
+            "e70af26a-fb9e-43ab-96a0-d62a2df37e6d\\media\\urn:catalog:uconn:conn:image:conn00078650"
+          ],
+          "data": {
+            "dcterms:type": "StillImage",
+            "xmpRights:WebStatement": "URL: http://creativecommons.org/licenses/by-nc-sa/4.0/",
+            "dcterms:title": "specimen image",
+            "ac:bestQualityFormat": "image/jpeg",
+            "ac:licenseLogoURL": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by-nc-sa.png",
+            "ac:bestQualityAccessURI": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00078650.JPG",
+            "coreid": "urn:catalog:UConn:CONN:CONN00078650",
+            "dcterms:identifier": "urn:catalog:UConn:CONN:Image:CONN00078650",
+            "xmpRights:Owner": "G. S. Torrey Herbarium, University of Connecticut",
+            "dcterms:rights": "© University of Connecticut",
+            "ac:metadataLanguage": "eng",
+            "dcterms:creator": "CONN"
+          },
+          "datemodified": "2014-09-09T05:02:47.586000+00:00",
+          "accessuri": "http://bgbaseserver.eeb.uconn.edu/DATABASEIMAGES/CONN00078650.JPG"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "eefcd5db-9ac1-4b74-9cb2-529152eef6a6",
+        "_score": 1,
+        "_routing": "22984faf-06f3-43bf-8dc9-db30d4a06e6f",
+        "_parent": "22984faf-06f3-43bf-8dc9-db30d4a06e6f",
+        "_source": {
+          "licenselogourl": "http://i.creativecommons.org/p/zero/1.0/88x31.png",
+          "uuid": "eefcd5db-9ac1-4b74-9cb2-529152eef6a6",
+          "format": "image/jpeg",
+          "recordset": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "dqs": 0.45454545454545453,
+          "rights": "CC0",
+          "mediatype": "images",
+          "hasSpecimen": true,
+          "records": [
+            "22984faf-06f3-43bf-8dc9-db30d4a06e6f"
+          ],
+          "etag": "3f7598c51ab9110d57da01649ac1199ac064a68f",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "idigbio:parent": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:adc1cf49-83f0-4228-be67-181cf7469f49",
+            "ac:subtype": "Photograph",
+            "xmp:MetadataDate": "2012-10-08 20:53:21",
+            "xmpRights:UsageTerms": "Yale Peabody Museum of Natural History",
+            "ac:thumbnailAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204999/format/1",
+            "idigbio:etag": "3f7598c51ab9110d57da01649ac1199ac064a68f",
+            "dcterms:format": "image/jpeg",
+            "idigbio:recordIds": [
+              "urn:uuid:adc1cf49-83f0-4228-be67-181cf7469f49",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\media\\http://deliver.odai.yale.edu/content/repository/ypm/id/204999/format/3"
+            ],
+            "ac:goodQualityAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204999/format/3",
+            "coreid": "269794",
+            "dcterms:identifier": "http://deliver.odai.yale.edu/content/repository/YPM/id/204999/format/3",
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "idigbio:siblings": {
+              "record": [
+                "22984faf-06f3-43bf-8dc9-db30d4a06e6f"
+              ]
+            },
+            "idigbio:dateModified": "2016-04-21T13:40:34.206773",
+            "ac:accessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204999/format/3",
+            "ac:metadataLanguage": "en",
+            "idigbio:uuid": "eefcd5db-9ac1-4b74-9cb2-529152eef6a6",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=269794"
+          },
+          "webstatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+          "recordids": [
+            "urn:uuid:adc1cf49-83f0-4228-be67-181cf7469f49",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\media\\http://deliver.odai.yale.edu/content/repository/ypm/id/204999/format/3"
+          ],
+          "data": {
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:adc1cf49-83f0-4228-be67-181cf7469f49",
+            "ac:subtype": "Photograph",
+            "ac:metadataLanguage": "en",
+            "xmpRights:UsageTerms": "Yale Peabody Museum of Natural History",
+            "ac:thumbnailAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204999/format/1",
+            "dcterms:format": "image/jpeg",
+            "ac:goodQualityAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204999/format/3",
+            "coreid": "269794",
+            "dcterms:identifier": "http://deliver.odai.yale.edu/content/repository/YPM/id/204999/format/3",
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "ac:accessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204999/format/3",
+            "xmp:MetadataDate": "2012-10-08 20:53:21",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=269794"
+          },
+          "datemodified": "2016-04-21T13:40:34.206773+00:00",
+          "accessuri": "http://deliver.odai.yale.edu/content/repository/YPM/id/204999/format/3"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "ef158cc6-2f94-48e5-92be-e608631f990f",
+        "_score": 1,
+        "_routing": "df6e800e-e2e1-4fcf-9940-fb738b70e7ed",
+        "_parent": "df6e800e-e2e1-4fcf-9940-fb738b70e7ed",
+        "_source": {
+          "hasSpecimen": true,
+          "uuid": "ef158cc6-2f94-48e5-92be-e608631f990f",
+          "format": "image/jpeg",
+          "recordset": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "dqs": 0.2727272727272727,
+          "rights": "Public Domain",
+          "mediatype": "images",
+          "records": [
+            "df6e800e-e2e1-4fcf-9940-fb738b70e7ed"
+          ],
+          "etag": "e94e1b945eb0bbe0af87a790d7fd36f5e8eb13c4",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "ac:comments": "http://creativecommons.org/publicdomain/mark/1.0/",
+            "idigbio:parent": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+            "xmpRights:UsageTerms": "Public Domain",
+            "ac:thumbnailAccessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-aetigLi3e4EjEhpFQFyddL?resize=1250&format=jpeg",
+            "ac:goodQualityAccessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-aetigLi3e4EjEhpFQFyddL?resize=1250&format=jpeg",
+            "coreid": "807945",
+            "dcterms:identifier": "http://bisque.iplantcollaborative.org/image_service/image/00-aetigLi3e4EjEhpFQFyddL?resize=1250&format=jpeg",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "idigbio:dateModified": "2016-04-21T13:40:35.966214",
+            "ac:metadataLanguage": "en",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807945",
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:7705ca3c-df7a-40c4-9ff9-270b091a3f5f",
+            "ac:subtype": "Photograph",
+            "idigbio:etag": "e94e1b945eb0bbe0af87a790d7fd36f5e8eb13c4",
+            "dcterms:format": "image/jpeg",
+            "idigbio:siblings": {
+              "record": [
+                "df6e800e-e2e1-4fcf-9940-fb738b70e7ed"
+              ]
+            },
+            "ac:caption": "YU YU.076227 Acer saccharum Marsh.",
+            "idigbio:recordIds": [
+              "urn:uuid:7705ca3c-df7a-40c4-9ff9-270b091a3f5f",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\media\\http://bovary.iplantcollaborative.org/image_service/image/00-aetigli3e4ejehpfqfyddl",
+              "7a8d946d-083f-4d2a-9cc9-cd590398194f\\media\\http://bisque.iplantcollaborative.org/image_service/image/00-aetigli3e4ejehpfqfyddl?resize=1250&format=jpeg"
+            ],
+            "ac:accessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-aetigLi3e4EjEhpFQFyddL?resize=1250&format=jpeg",
+            "xmp:MetadataDate": "2015-02-04 18:08:03",
+            "idigbio:uuid": "ef158cc6-2f94-48e5-92be-e608631f990f"
+          },
+          "recordids": [
+            "urn:uuid:7705ca3c-df7a-40c4-9ff9-270b091a3f5f",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\media\\http://bovary.iplantcollaborative.org/image_service/image/00-aetigli3e4ejehpfqfyddl",
+            "7a8d946d-083f-4d2a-9cc9-cd590398194f\\media\\http://bisque.iplantcollaborative.org/image_service/image/00-aetigli3e4ejehpfqfyddl?resize=1250&format=jpeg"
+          ],
+          "data": {
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:7705ca3c-df7a-40c4-9ff9-270b091a3f5f",
+            "ac:subtype": "Photograph",
+            "ac:metadataLanguage": "en",
+            "xmpRights:UsageTerms": "Public Domain",
+            "ac:comments": "http://creativecommons.org/publicdomain/mark/1.0/",
+            "dcterms:format": "image/jpeg",
+            "ac:goodQualityAccessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-aetigLi3e4EjEhpFQFyddL?resize=1250&format=jpeg",
+            "coreid": "807945",
+            "dcterms:identifier": "http://bisque.iplantcollaborative.org/image_service/image/00-aetigLi3e4EjEhpFQFyddL?resize=1250&format=jpeg",
+            "ac:caption": "YU YU.076227 Acer saccharum Marsh.",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "ac:thumbnailAccessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-aetigLi3e4EjEhpFQFyddL?resize=1250&format=jpeg",
+            "ac:accessURI": "http://bisque.iplantcollaborative.org/image_service/image/00-aetigLi3e4EjEhpFQFyddL?resize=1250&format=jpeg",
+            "xmp:MetadataDate": "2015-02-04 18:08:03",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=807945"
+          },
+          "datemodified": "2016-04-21T13:40:35.966214+00:00",
+          "accessuri": "http://bisque.iplantcollaborative.org/image_service/image/00-aetigLi3e4EjEhpFQFyddL?resize=1250&format=jpeg"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "eff82e1c-8962-4673-9885-0172c4c38ae1",
+        "_score": 1,
+        "_routing": "07d81427-448e-43aa-841a-8191b8bed86b",
+        "_parent": "07d81427-448e-43aa-841a-8191b8bed86b",
+        "_source": {
+          "licenselogourl": "http://i.creativecommons.org/p/zero/1.0/88x31.png",
+          "uuid": "eff82e1c-8962-4673-9885-0172c4c38ae1",
+          "format": "image/jpeg",
+          "recordset": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "dqs": 0.45454545454545453,
+          "rights": "CC0",
+          "mediatype": "images",
+          "hasSpecimen": true,
+          "records": [
+            "07d81427-448e-43aa-841a-8191b8bed86b"
+          ],
+          "etag": "50481b54c26c47888b4fa6b3eef92e546d6c2df3",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "idigbio:parent": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:e3f6005d-fd20-4924-a77f-5adc32da8481",
+            "ac:subtype": "Photograph",
+            "xmp:MetadataDate": "2012-10-08 20:53:21",
+            "xmpRights:UsageTerms": "Yale Peabody Museum of Natural History",
+            "ac:thumbnailAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204975/format/1",
+            "idigbio:etag": "50481b54c26c47888b4fa6b3eef92e546d6c2df3",
+            "dcterms:format": "image/jpeg",
+            "idigbio:recordIds": [
+              "urn:uuid:e3f6005d-fd20-4924-a77f-5adc32da8481",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\media\\http://deliver.odai.yale.edu/content/repository/ypm/id/204975/format/3"
+            ],
+            "ac:goodQualityAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204975/format/3",
+            "coreid": "110466",
+            "dcterms:identifier": "http://deliver.odai.yale.edu/content/repository/YPM/id/204975/format/3",
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "idigbio:siblings": {
+              "record": [
+                "07d81427-448e-43aa-841a-8191b8bed86b"
+              ]
+            },
+            "idigbio:dateModified": "2016-04-21T13:40:34.206773",
+            "ac:accessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204975/format/3",
+            "ac:metadataLanguage": "en",
+            "idigbio:uuid": "eff82e1c-8962-4673-9885-0172c4c38ae1",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110466"
+          },
+          "webstatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+          "recordids": [
+            "urn:uuid:e3f6005d-fd20-4924-a77f-5adc32da8481",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\media\\http://deliver.odai.yale.edu/content/repository/ypm/id/204975/format/3"
+          ],
+          "data": {
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:e3f6005d-fd20-4924-a77f-5adc32da8481",
+            "ac:subtype": "Photograph",
+            "ac:metadataLanguage": "en",
+            "xmpRights:UsageTerms": "Yale Peabody Museum of Natural History",
+            "ac:thumbnailAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204975/format/1",
+            "dcterms:format": "image/jpeg",
+            "ac:goodQualityAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204975/format/3",
+            "coreid": "110466",
+            "dcterms:identifier": "http://deliver.odai.yale.edu/content/repository/YPM/id/204975/format/3",
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "ac:accessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/204975/format/3",
+            "xmp:MetadataDate": "2012-10-08 20:53:21",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110466"
+          },
+          "datemodified": "2016-04-21T13:40:34.206773+00:00",
+          "accessuri": "http://deliver.odai.yale.edu/content/repository/YPM/id/204975/format/3"
+        }
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "mediarecords",
+        "_id": "f0caf08c-a500-4327-9012-e839d62017ea",
+        "_score": 1,
+        "_routing": "9a8fb7bd-de66-499f-a229-366f76d4c08d",
+        "_parent": "9a8fb7bd-de66-499f-a229-366f76d4c08d",
+        "_source": {
+          "licenselogourl": "http://i.creativecommons.org/p/zero/1.0/88x31.png",
+          "uuid": "f0caf08c-a500-4327-9012-e839d62017ea",
+          "format": "image/jpeg",
+          "recordset": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "dqs": 0.45454545454545453,
+          "rights": "CC0",
+          "mediatype": "images",
+          "hasSpecimen": true,
+          "records": [
+            "9a8fb7bd-de66-499f-a229-366f76d4c08d"
+          ],
+          "etag": "1fbdecaca33b319aa26bb9a6192ff0ed38cfe230",
+          "flags": [
+            "dwc_basisofrecord_invalid"
+          ],
+          "indexData": {
+            "idigbio:parent": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:ff3d1719-b933-4008-b5d6-d64da618ed65",
+            "ac:subtype": "Photograph",
+            "xmp:MetadataDate": "2012-10-08 20:53:21",
+            "xmpRights:UsageTerms": "Yale Peabody Museum of Natural History",
+            "ac:thumbnailAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/205022/format/1",
+            "idigbio:etag": "1fbdecaca33b319aa26bb9a6192ff0ed38cfe230",
+            "dcterms:format": "image/jpeg",
+            "idigbio:recordIds": [
+              "urn:uuid:ff3d1719-b933-4008-b5d6-d64da618ed65",
+              "09edf7d2-e68e-4a42-93da-762f86bb814f\\media\\http://deliver.odai.yale.edu/content/repository/ypm/id/205022/format/3"
+            ],
+            "ac:goodQualityAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/205022/format/3",
+            "coreid": "110498",
+            "dcterms:identifier": "http://deliver.odai.yale.edu/content/repository/YPM/id/205022/format/3",
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "idigbio:siblings": {
+              "record": [
+                "9a8fb7bd-de66-499f-a229-366f76d4c08d"
+              ]
+            },
+            "idigbio:dateModified": "2016-04-21T13:40:34.206773",
+            "ac:accessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/205022/format/3",
+            "ac:metadataLanguage": "en",
+            "idigbio:uuid": "f0caf08c-a500-4327-9012-e839d62017ea",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110498"
+          },
+          "webstatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+          "recordids": [
+            "urn:uuid:ff3d1719-b933-4008-b5d6-d64da618ed65",
+            "09edf7d2-e68e-4a42-93da-762f86bb814f\\media\\http://deliver.odai.yale.edu/content/repository/ypm/id/205022/format/3"
+          ],
+          "data": {
+            "dcterms:type": "StillImage",
+            "ac:providerManagedID": "urn:uuid:ff3d1719-b933-4008-b5d6-d64da618ed65",
+            "ac:subtype": "Photograph",
+            "ac:metadataLanguage": "en",
+            "xmpRights:UsageTerms": "Yale Peabody Museum of Natural History",
+            "ac:thumbnailAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/205022/format/1",
+            "dcterms:format": "image/jpeg",
+            "ac:goodQualityAccessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/205022/format/3",
+            "coreid": "110498",
+            "dcterms:identifier": "http://deliver.odai.yale.edu/content/repository/YPM/id/205022/format/3",
+            "xmpRights:Owner": "Yale Peabody Museum of Natural History",
+            "xmpRights:WebStatement": "http://creativecommons.org/publicdomain/zero/1.0/",
+            "ac:accessURI": "http://deliver.odai.yale.edu/content/repository/YPM/id/205022/format/3",
+            "xmp:MetadataDate": "2012-10-08 20:53:21",
+            "ac:associatedSpecimenReference": "http://portal.neherbaria.org/portal/collections/individual/index.php?occid=110498"
+          },
+          "datemodified": "2016-04-21T13:40:34.206773+00:00",
+          "accessuri": "http://deliver.odai.yale.edu/content/repository/YPM/id/205022/format/3"
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "top_flags": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 35746,
+      "buckets": [
+        {
+          "key": "dwc_basisofrecord_invalid",
+          "doc_count": 83108
+        },
+        {
+          "key": "dwc_class_added",
+          "doc_count": 3664
+        },
+        {
+          "key": "dwc_datasetid_added",
+          "doc_count": 3664
+        },
+        {
+          "key": "dwc_family_added",
+          "doc_count": 3664
+        },
+        {
+          "key": "dwc_genus_added",
+          "doc_count": 3664
+        },
+        {
+          "key": "dwc_kingdom_added",
+          "doc_count": 3664
+        },
+        {
+          "key": "dwc_order_added",
+          "doc_count": 3664
+        },
+        {
+          "key": "dwc_parentnameusageid_added",
+          "doc_count": 3664
+        },
+        {
+          "key": "dwc_phylum_added",
+          "doc_count": 3664
+        },
+        {
+          "key": "dwc_taxonid_added",
+          "doc_count": 3664
+        }
+      ]
+    }
+  }
+}

--- a/__tests__/mock/search-f3ce4be5eae8176e0a6c666305997c72.json
+++ b/__tests__/mock/search-f3ce4be5eae8176e0a6c666305997c72.json
@@ -1,0 +1,1802 @@
+{
+  "timed_out": false,
+  "_shards": {
+    "total": 48,
+    "successful": 48,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1283468,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "522d0f2d-2287-42e9-89ad-75a0816c0efe",
+        "_score": null,
+        "_source": {
+          "scientificname": "carex graceii"
+        },
+        "sort": [
+          0.4057971
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "e193324c-279e-4b78-b918-fd9ef83729b7",
+        "_score": null,
+        "_source": {
+          "scientificname": "carex vizarronensis"
+        },
+        "sort": [
+          0.3768116
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "decf64ec-f417-4952-a260-72aaeb7bffc8",
+        "_score": null,
+        "_source": {
+          "scientificname": "carex curviculmis"
+        },
+        "sort": [
+          0.3768116
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "58fa6db9-a238-4eee-80fb-4624b677b113",
+        "_score": null,
+        "_source": {
+          "scientificname": "carex asynchrona"
+        },
+        "sort": [
+          0.3768116
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "dfb3de27-0f1e-4e52-8371-b1265bdf810f",
+        "_score": null,
+        "_source": {
+          "scientificname": "carex curviculmis"
+        },
+        "sort": [
+          0.3768116
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "eb5ebb4c-40a3-49d7-8d92-b53461072991",
+        "_score": null,
+        "_source": {
+          "scientificname": "carex longicaulis"
+        },
+        "sort": [
+          0.3768116
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "365c83b4-62c8-4454-b620-c0482089a141",
+        "_score": null,
+        "_source": {
+          "scientificname": "carex rzedowskii"
+        },
+        "sort": [
+          0.3768116
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "19881784-64b4-4afd-a9cb-83303430c5d3",
+        "_score": null,
+        "_source": {
+          "scientificname": "carex gypsophila"
+        },
+        "sort": [
+          0.3768116
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a75890c7-30e7-486b-ae5a-36eae30c06f9",
+        "_score": null,
+        "_source": {
+          "scientificname": "carex schiedeana"
+        },
+        "sort": [
+          0.3768116
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "5449876a-3f11-428a-9024-125f503e7273",
+        "_score": null,
+        "_source": {
+          "scientificname": "carex echinata subsp. townsendii"
+        },
+        "sort": [
+          0.3768116
+        ]
+      }
+    ]
+  },
+  "aggregations": {
+    "rs": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "e6ccc2bd-9451-4802-8a51-8640d9f09793",
+          "doc_count": 73097
+        },
+        {
+          "key": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+          "doc_count": 69285
+        },
+        {
+          "key": "36d35b23-113e-4633-90ec-19d265a3b5f6",
+          "doc_count": 65451
+        },
+        {
+          "key": "fabcdc12-9d29-4bd2-912b-176e71818144",
+          "doc_count": 59903
+        },
+        {
+          "key": "a6eee223-cf3b-4079-8bb2-b77dad8cae9d",
+          "doc_count": 57778
+        },
+        {
+          "key": "5386d272-06c6-4027-b5d5-d588c2afe5e5",
+          "doc_count": 53504
+        },
+        {
+          "key": "0583609b-202f-40d0-8021-4c019635d4c9",
+          "doc_count": 53432
+        },
+        {
+          "key": "fc014977-92f7-47fd-92d7-b609c39d8212",
+          "doc_count": 46880
+        },
+        {
+          "key": "7450a9e3-ef95-4f9e-8260-09b498d2c5e6",
+          "doc_count": 42223
+        },
+        {
+          "key": "f778ecc0-8371-49d5-9ab1-9d75f0b76fad",
+          "doc_count": 40725
+        },
+        {
+          "key": "9e5aede6-bee5-4a3d-a255-513771b20035",
+          "doc_count": 32376
+        },
+        {
+          "key": "65536dcd-7bb2-44e5-af3f-4a13f08e53d0",
+          "doc_count": 29471
+        },
+        {
+          "key": "e2def7e2-1455-4856-9823-6d3738417d24",
+          "doc_count": 23803
+        },
+        {
+          "key": "db6c3db9-1e6d-4def-af29-33aa0339bfa9",
+          "doc_count": 19825
+        },
+        {
+          "key": "3c9420c9-c4a8-47dc-88b7-b5638ca5e716",
+          "doc_count": 18792
+        },
+        {
+          "key": "205fa34c-2fcb-4492-b992-972b18560f6f",
+          "doc_count": 16975
+        },
+        {
+          "key": "b6ec6203-09db-4d6e-8cba-ee4bebd2934c",
+          "doc_count": 16377
+        },
+        {
+          "key": "207b6c64-7b58-4d6a-816d-bc759c27eafc",
+          "doc_count": 14570
+        },
+        {
+          "key": "72d4c3c7-3413-4588-a803-e1a63e0d7c6c",
+          "doc_count": 14540
+        },
+        {
+          "key": "a4e6033a-d1eb-46d3-869d-7c0328f09aa7",
+          "doc_count": 13897
+        },
+        {
+          "key": "f0174bc9-0cca-450e-a941-655d80040139",
+          "doc_count": 13109
+        },
+        {
+          "key": "26f7cbde-fbcb-4500-80a9-a99daa0ead9d",
+          "doc_count": 12870
+        },
+        {
+          "key": "d53132e6-7997-4850-8607-4fec5a3f9c3f",
+          "doc_count": 12624
+        },
+        {
+          "key": "8057906f-17c9-4e25-b173-4e7fb938078b",
+          "doc_count": 12265
+        },
+        {
+          "key": "1e798b2d-7f97-49b0-a864-79c968af91d3",
+          "doc_count": 12098
+        },
+        {
+          "key": "d38fd1e8-bc15-46b2-92d5-5f3df98cff53",
+          "doc_count": 11460
+        },
+        {
+          "key": "703b5bdc-4581-47e3-b4b6-e6f32d0eec54",
+          "doc_count": 11181
+        },
+        {
+          "key": "4e3043a6-d48a-4a35-b5fb-f67d50cbc158",
+          "doc_count": 10037
+        },
+        {
+          "key": "09a3fcf2-55a1-488f-aa42-f103bdce0536",
+          "doc_count": 9895
+        },
+        {
+          "key": "23a47a5f-2ac1-4f81-acd3-21d5b82ed22a",
+          "doc_count": 9861
+        },
+        {
+          "key": "62a36329-6b82-48bc-94d8-1cb9adb91ab5",
+          "doc_count": 9620
+        },
+        {
+          "key": "3027c437-cdb3-4072-9410-5a46ec3b1fd5",
+          "doc_count": 9402
+        },
+        {
+          "key": "8b0c1f4b-9de7-4521-98c2-983e0bfd33c7",
+          "doc_count": 9329
+        },
+        {
+          "key": "d7b285d4-2643-45ee-9302-b0c3d51dda5c",
+          "doc_count": 9220
+        },
+        {
+          "key": "a2b36fdf-50bc-44ef-a6a4-ca6dc1dc148a",
+          "doc_count": 9198
+        },
+        {
+          "key": "1527b668-b797-42be-94d3-0058e1393e94",
+          "doc_count": 8796
+        },
+        {
+          "key": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "doc_count": 8552
+        },
+        {
+          "key": "beab5209-9628-4d4d-851e-2bc9bb1a0105",
+          "doc_count": 8366
+        },
+        {
+          "key": "237d30ca-7675-4840-b4fd-96771fabf518",
+          "doc_count": 8078
+        },
+        {
+          "key": "d2217bca-3a93-4407-bb56-087afa000cbc",
+          "doc_count": 8047
+        },
+        {
+          "key": "d78d13a7-3852-4244-ba34-86ef5765fa99",
+          "doc_count": 7996
+        },
+        {
+          "key": "14f8f83f-7a0c-458c-b6d5-6da7dc8eaa0a",
+          "doc_count": 7898
+        },
+        {
+          "key": "0fd6e726-6828-4f62-ba8d-6ec316fe0b52",
+          "doc_count": 6898
+        },
+        {
+          "key": "0dab1fc7-ca99-456b-9985-76edbac003e0",
+          "doc_count": 6855
+        },
+        {
+          "key": "3998ec8d-4aae-46db-9370-179c19b69356",
+          "doc_count": 6845
+        },
+        {
+          "key": "7f497d81-4c7e-4e06-b166-a459968b14e3",
+          "doc_count": 6660
+        },
+        {
+          "key": "e5f57bb0-07ec-4405-90b6-dc89647a1cb5",
+          "doc_count": 6336
+        },
+        {
+          "key": "7c1a1d78-aeaa-4501-87e1-83eceb8ca8ea",
+          "doc_count": 6292
+        },
+        {
+          "key": "7644703a-ce24-4f7b-b800-66ddf8812f86",
+          "doc_count": 6052
+        },
+        {
+          "key": "4523e216-ee13-4b15-a3f7-a6fd56431604",
+          "doc_count": 5888
+        },
+        {
+          "key": "05c029de-734c-450a-a41a-56061b7ebb18",
+          "doc_count": 5577
+        },
+        {
+          "key": "4ac45d7e-c6e5-45ea-a0e0-aea6ebe2afcf",
+          "doc_count": 5337
+        },
+        {
+          "key": "f1cf8457-237e-487a-9d13-5de7d81b9de4",
+          "doc_count": 5297
+        },
+        {
+          "key": "46c11153-2154-495d-89d2-7cdef6425cdb",
+          "doc_count": 5197
+        },
+        {
+          "key": "531537fc-6349-4a20-ae42-540d61797086",
+          "doc_count": 4920
+        },
+        {
+          "key": "71bf994a-3af5-484d-983b-b146aa1512d1",
+          "doc_count": 4790
+        },
+        {
+          "key": "83ad8494-136b-485a-87d4-8ce01dd6a8de",
+          "doc_count": 4769
+        },
+        {
+          "key": "844875a9-9927-48a5-90b4-76c5f227f145",
+          "doc_count": 4514
+        },
+        {
+          "key": "c2767dde-1315-4d78-abf9-8e098dd588ab",
+          "doc_count": 4476
+        },
+        {
+          "key": "ba54ba45-caac-4708-a389-ac94642976f8",
+          "doc_count": 4394
+        },
+        {
+          "key": "910eadc8-8131-428c-b28a-91d0e2890f1d",
+          "doc_count": 4392
+        },
+        {
+          "key": "5a660a44-afdd-45ac-8c48-1a6c570ce0b5",
+          "doc_count": 4336
+        },
+        {
+          "key": "76fd34da-4892-4821-858d-98fe9e28ba8b",
+          "doc_count": 3919
+        },
+        {
+          "key": "0bc60df1-a162-4173-9a73-c51e09031843",
+          "doc_count": 3893
+        },
+        {
+          "key": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "doc_count": 3843
+        },
+        {
+          "key": "005ac06a-3d9a-46ad-ac3c-062aaa5b7059",
+          "doc_count": 3797
+        },
+        {
+          "key": "b531ea59-025d-4c29-9d23-99ae75bcd55f",
+          "doc_count": 3619
+        },
+        {
+          "key": "471835cc-feb6-4d05-a8d1-62ce71399326",
+          "doc_count": 3362
+        },
+        {
+          "key": "5835f642-2560-4e3e-9c25-741a12cc3fe8",
+          "doc_count": 3210
+        },
+        {
+          "key": "6258d160-a7aa-4937-bce3-3538eebd374f",
+          "doc_count": 3183
+        },
+        {
+          "key": "c55ac6d0-180d-41be-829a-e82898c5ca54",
+          "doc_count": 3138
+        },
+        {
+          "key": "20360fae-574a-4d63-b9f6-47b1cc07fd22",
+          "doc_count": 3134
+        },
+        {
+          "key": "ff89320d-e232-4edd-9cdd-4b6acc672ad3",
+          "doc_count": 3121
+        },
+        {
+          "key": "a16dc8d8-ff4a-4d62-a684-2937fb292b8d",
+          "doc_count": 3010
+        },
+        {
+          "key": "aca26f37-3ec8-4e9e-b927-50b4944a0096",
+          "doc_count": 2967
+        },
+        {
+          "key": "0ed8a17e-149b-4cbe-8383-7676da92ea1c",
+          "doc_count": 2949
+        },
+        {
+          "key": "40250f4d-7aa6-4fcc-ac38-2868fa4846bd",
+          "doc_count": 2939
+        },
+        {
+          "key": "215eeaf0-0a88-409e-a75d-aec98b7c41eb",
+          "doc_count": 2732
+        },
+        {
+          "key": "781fd581-7b93-471e-a025-413e4bcd8491",
+          "doc_count": 2730
+        },
+        {
+          "key": "70abba3e-5f2a-4276-87f3-261706e24453",
+          "doc_count": 2697
+        },
+        {
+          "key": "e6eba8cd-fa2c-4ba2-bec0-6841e7633695",
+          "doc_count": 2675
+        },
+        {
+          "key": "ddef79ec-043c-4027-9876-c4a298feff6d",
+          "doc_count": 2655
+        },
+        {
+          "key": "264c48ec-8636-451f-a7e0-74131bc6f84c",
+          "doc_count": 2563
+        },
+        {
+          "key": "0f19f6d6-79a4-434e-ba0b-a4f49f334078",
+          "doc_count": 2487
+        },
+        {
+          "key": "b9ab58cf-785e-44a7-a873-1966e14a6715",
+          "doc_count": 2351
+        },
+        {
+          "key": "2c00c297-9ebd-498a-b701-d3ebde4b49f3",
+          "doc_count": 2316
+        },
+        {
+          "key": "8f689b8b-5b65-4638-9555-f2a5d237a624",
+          "doc_count": 2285
+        },
+        {
+          "key": "3c6f1ea5-f2e7-4203-9cfe-74ec2fb1b035",
+          "doc_count": 2261
+        },
+        {
+          "key": "5e29dbcc-ce45-4f05-9bb0-212baffa8932",
+          "doc_count": 2177
+        },
+        {
+          "key": "e794b292-4a94-471e-ab84-6aaef1fea1b3",
+          "doc_count": 2109
+        },
+        {
+          "key": "2d7910d9-7f63-4bde-918a-9e0265f1c245",
+          "doc_count": 2102
+        },
+        {
+          "key": "59efaf7d-60b5-4295-abb3-27ba42eb5231",
+          "doc_count": 2072
+        },
+        {
+          "key": "ba042ffa-8175-4a47-8eb1-08b4d6319ccf",
+          "doc_count": 2052
+        },
+        {
+          "key": "f08c31ea-0e90-4cc1-b471-dfd0584ae7cf",
+          "doc_count": 2048
+        },
+        {
+          "key": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "doc_count": 2010
+        },
+        {
+          "key": "108cca70-4d1c-4882-843b-2d31ba8d6763",
+          "doc_count": 1983
+        },
+        {
+          "key": "765aa536-b79e-4794-a0d2-40a160233922",
+          "doc_count": 1976
+        },
+        {
+          "key": "e4ff51ba-5007-4c40-9a86-e8c6f4db77b7",
+          "doc_count": 1956
+        },
+        {
+          "key": "21b563bc-70c2-46d5-bce8-2489db2db3d8",
+          "doc_count": 1911
+        },
+        {
+          "key": "953b0329-c3e4-4816-a038-7afbd2bb2547",
+          "doc_count": 1831
+        },
+        {
+          "key": "244ee82a-438c-4e77-a2ce-4e2af9ddbe4d",
+          "doc_count": 1794
+        },
+        {
+          "key": "b2b294ed-1742-4479-b0c8-a8891fccd7eb",
+          "doc_count": 1780
+        },
+        {
+          "key": "d478c23a-1993-443d-85ea-308870606626",
+          "doc_count": 1779
+        },
+        {
+          "key": "dd232f5c-7f53-48ec-9bb7-7205702c3dc8",
+          "doc_count": 1769
+        },
+        {
+          "key": "5baa1d0c-cfc0-4c89-8e3e-7a49359b0caa",
+          "doc_count": 1736
+        },
+        {
+          "key": "6b2c3ca9-69ad-4316-a2d1-33399e9f547e",
+          "doc_count": 1710
+        },
+        {
+          "key": "ec4acc26-ff1b-4131-a1df-a950fe31bb0e",
+          "doc_count": 1708
+        },
+        {
+          "key": "96662fa9-ff60-495b-912a-284f3b98ed72",
+          "doc_count": 1701
+        },
+        {
+          "key": "a6e02b78-6fc6-4cb6-bb87-8d5a443f2c2a",
+          "doc_count": 1700
+        },
+        {
+          "key": "f84d528a-7d08-467e-b532-ace707316f1d",
+          "doc_count": 1617
+        },
+        {
+          "key": "9b725e43-93c9-423b-adf8-a11d08a83d13",
+          "doc_count": 1589
+        },
+        {
+          "key": "8ec76c75-a673-4682-bfde-00a18bc12794",
+          "doc_count": 1566
+        },
+        {
+          "key": "c569e530-7322-40b8-9b66-1e0ed96fefcb",
+          "doc_count": 1477
+        },
+        {
+          "key": "2941b767-e90b-41b9-9627-6e589e0c0c85",
+          "doc_count": 1458
+        },
+        {
+          "key": "c49bc91d-0a50-497b-8b17-d77808745cf9",
+          "doc_count": 1450
+        },
+        {
+          "key": "120d557c-c5be-474d-98f0-1ba00ae16b40",
+          "doc_count": 1432
+        },
+        {
+          "key": "b88033dd-5dbb-4377-b374-2210f32ece16",
+          "doc_count": 1419
+        },
+        {
+          "key": "6cc31636-c3e5-4887-bbee-2e56621771c4",
+          "doc_count": 1406
+        },
+        {
+          "key": "570dcca6-a84f-43aa-8053-1a2ac60d9ead",
+          "doc_count": 1330
+        },
+        {
+          "key": "88595487-6d33-4980-ba54-bcf427c9466e",
+          "doc_count": 1299
+        },
+        {
+          "key": "be31dfd1-c721-4697-8ee0-f7043c070810",
+          "doc_count": 1264
+        },
+        {
+          "key": "43aa1339-67e4-4298-b7c5-3d0f201266ef",
+          "doc_count": 1246
+        },
+        {
+          "key": "3c367a2d-eec0-4ef1-b3bc-4cbebb320c5a",
+          "doc_count": 1241
+        },
+        {
+          "key": "bf1fee2d-f760-4068-b8e6-d1db63ce434c",
+          "doc_count": 1223
+        },
+        {
+          "key": "e34cf41b-196c-4199-85d5-4d2ca5954b09",
+          "doc_count": 1217
+        },
+        {
+          "key": "d82fa49b-915e-4aa8-acc6-51df3d431884",
+          "doc_count": 1207
+        },
+        {
+          "key": "9e1958fb-1dc4-4375-ae35-67ba7f9c7afe",
+          "doc_count": 1202
+        },
+        {
+          "key": "b667cef4-96fe-42e8-a9fa-6298aa80bb14",
+          "doc_count": 1068
+        },
+        {
+          "key": "3056112e-97c6-4d0d-b6c2-3c0a9adaca24",
+          "doc_count": 1041
+        },
+        {
+          "key": "e185415c-15c4-4612-89f3-27cfebbca0d9",
+          "doc_count": 1039
+        },
+        {
+          "key": "a69decc7-76ba-496a-a66e-f91049c02cf0",
+          "doc_count": 1038
+        },
+        {
+          "key": "79aa7602-a963-44f3-82dd-e141a387adb8",
+          "doc_count": 1007
+        },
+        {
+          "key": "2f740a87-8049-435d-9d06-1c393c9c11b7",
+          "doc_count": 1001
+        },
+        {
+          "key": "ef59f7cc-ed42-45fc-9abc-5edfb2c8caec",
+          "doc_count": 987
+        },
+        {
+          "key": "667a12e7-c6d8-4de0-933f-ce2f07cb7a92",
+          "doc_count": 965
+        },
+        {
+          "key": "364b1f8d-5975-48d9-bba1-c97ab172986c",
+          "doc_count": 949
+        },
+        {
+          "key": "d7540872-1c53-48ac-a617-2d0739eadcbd",
+          "doc_count": 939
+        },
+        {
+          "key": "e36691ec-c4f8-4bec-b331-b48ffa82ff49",
+          "doc_count": 915
+        },
+        {
+          "key": "364a24d9-d4a8-4e0b-8e50-07b90f844548",
+          "doc_count": 901
+        },
+        {
+          "key": "664bd710-8791-4dba-a3b6-000a1b140951",
+          "doc_count": 895
+        },
+        {
+          "key": "7026b70a-7245-42bd-8162-81ae9a6cfbcb",
+          "doc_count": 882
+        },
+        {
+          "key": "e23109b4-e143-437c-b329-3dff7cb35488",
+          "doc_count": 799
+        },
+        {
+          "key": "cb33cf97-2a7b-4b45-9b73-5aca568332a6",
+          "doc_count": 795
+        },
+        {
+          "key": "f8866892-56a0-4f46-9583-6719d42d81de",
+          "doc_count": 791
+        },
+        {
+          "key": "9151bc4c-8505-4b22-a16b-9dbf337535fa",
+          "doc_count": 784
+        },
+        {
+          "key": "f3ee2661-268a-48dc-b931-b9429d5674f4",
+          "doc_count": 765
+        },
+        {
+          "key": "12018be6-3795-43a3-a073-a2b9d60c0af3",
+          "doc_count": 758
+        },
+        {
+          "key": "8295ea14-c4fd-499b-bc68-2907ed36badc",
+          "doc_count": 717
+        },
+        {
+          "key": "c1e2b821-96a2-422f-a1fe-7a53aaa2e9bf",
+          "doc_count": 690
+        },
+        {
+          "key": "4db72a36-c08b-4a6b-8c68-ab45ebb0efce",
+          "doc_count": 674
+        },
+        {
+          "key": "b5b79eb9-c270-4427-9cd6-43bd6c4b73ab",
+          "doc_count": 636
+        },
+        {
+          "key": "6d09cfc1-a17c-4067-b1a0-557b8e5334ea",
+          "doc_count": 618
+        },
+        {
+          "key": "de5203b1-5a44-4010-948c-b7d33f46397a",
+          "doc_count": 613
+        },
+        {
+          "key": "c3134980-bf5c-49b8-a289-790d45f02c86",
+          "doc_count": 589
+        },
+        {
+          "key": "98ece30d-bf85-4122-b872-7786031b457f",
+          "doc_count": 587
+        },
+        {
+          "key": "c5b7dae8-b483-4742-9954-d7f9226daa34",
+          "doc_count": 576
+        },
+        {
+          "key": "204fbebc-37cc-4331-a2be-11f38949561c",
+          "doc_count": 572
+        },
+        {
+          "key": "a7228b3f-982a-4518-a761-b19b00e14844",
+          "doc_count": 570
+        },
+        {
+          "key": "93e97f6c-0ab6-41a7-9b58-7e230a80ec1e",
+          "doc_count": 559
+        },
+        {
+          "key": "1d17fdad-d338-4ae0-9232-dbf18eaf9f66",
+          "doc_count": 547
+        },
+        {
+          "key": "c5eeb223-0515-423a-a51a-151426c8f60d",
+          "doc_count": 544
+        },
+        {
+          "key": "7e4aacd3-0a24-49ab-b019-518b7069b682",
+          "doc_count": 531
+        },
+        {
+          "key": "2cebadf7-6d52-49b2-b3a7-d4969a36aa12",
+          "doc_count": 520
+        },
+        {
+          "key": "710a8a54-783c-41aa-ad9a-05544cdb4c55",
+          "doc_count": 515
+        },
+        {
+          "key": "37213da3-a1c7-4644-917e-8f8440e1c4d4",
+          "doc_count": 498
+        },
+        {
+          "key": "bf9066a2-2c5f-4cf2-821a-1a68b4df5b1b",
+          "doc_count": 488
+        },
+        {
+          "key": "2532cbd0-2752-4211-b249-4a9811a280f2",
+          "doc_count": 458
+        },
+        {
+          "key": "a77b7747-8a1e-40ff-8c63-fb9087cc099d",
+          "doc_count": 458
+        },
+        {
+          "key": "042dbdba-a449-4291-8777-577a5a4045de",
+          "doc_count": 444
+        },
+        {
+          "key": "58afd7df-a696-4dd6-a765-540f8b31c07d",
+          "doc_count": 433
+        },
+        {
+          "key": "50b0bbe4-f075-4427-8dfc-fcc469dd3e78",
+          "doc_count": 385
+        },
+        {
+          "key": "aac5fd7f-8043-4aa8-811f-e50de70d96f3",
+          "doc_count": 383
+        },
+        {
+          "key": "275a8cea-1c34-4580-a030-4f58e680605c",
+          "doc_count": 373
+        },
+        {
+          "key": "82672123-feef-4b1c-9ee3-9a681204ae76",
+          "doc_count": 373
+        },
+        {
+          "key": "1bfc0147-2df1-4488-bcf7-d140e24dda51",
+          "doc_count": 368
+        },
+        {
+          "key": "4960f30c-c1c7-490e-966a-61ad02969e38",
+          "doc_count": 363
+        },
+        {
+          "key": "1f5a1b81-e361-4d65-ab1c-6fb7e30c9910",
+          "doc_count": 359
+        },
+        {
+          "key": "9f3bbc7b-c682-4f66-88b3-48eef3a38f38",
+          "doc_count": 359
+        },
+        {
+          "key": "d14d21fe-da24-47e5-81fb-4bfe962ce828",
+          "doc_count": 357
+        },
+        {
+          "key": "0038ce2e-43bb-4f70-8dd6-dca34efd3fca",
+          "doc_count": 352
+        },
+        {
+          "key": "5277e72c-9e53-4c98-85f1-ee413bc473cd",
+          "doc_count": 343
+        },
+        {
+          "key": "d8862887-ff5c-4caa-9d61-f1958887ebc1",
+          "doc_count": 330
+        },
+        {
+          "key": "f31a5f98-efd3-476a-9627-de3add582acd",
+          "doc_count": 313
+        },
+        {
+          "key": "3ac8f738-bc3e-43e4-8358-00a32594954d",
+          "doc_count": 311
+        },
+        {
+          "key": "7fbf76b1-6bd6-4217-a5bc-1d89e45f6a68",
+          "doc_count": 310
+        },
+        {
+          "key": "662b1aa5-9c19-4eb9-9766-1da78a117456",
+          "doc_count": 307
+        },
+        {
+          "key": "1e054b9b-0193-4ff3-b623-9264cf982d4d",
+          "doc_count": 302
+        },
+        {
+          "key": "a0546df1-b727-402f-b9b8-570e65e58026",
+          "doc_count": 299
+        },
+        {
+          "key": "341611f4-8b65-4655-b244-9be91a1109cd",
+          "doc_count": 282
+        },
+        {
+          "key": "8bcb95b2-ab5c-4368-8ead-14588eeb9c98",
+          "doc_count": 275
+        },
+        {
+          "key": "e7016bd5-cb10-45b9-8959-0f5750f7a5db",
+          "doc_count": 272
+        },
+        {
+          "key": "e60301d9-9b40-483f-92de-065769b9d3dd",
+          "doc_count": 264
+        },
+        {
+          "key": "1549b662-ec36-436a-8593-76f7642ec9e4",
+          "doc_count": 263
+        },
+        {
+          "key": "d5c32031-231f-4213-b0f1-2dc4bbf711a0",
+          "doc_count": 251
+        },
+        {
+          "key": "5663707e-1f94-40a1-97f3-aaeff1d41d20",
+          "doc_count": 249
+        },
+        {
+          "key": "74ba1d92-d9a5-486e-8e52-bb44d51e1788",
+          "doc_count": 249
+        },
+        {
+          "key": "06c35934-1b75-4196-838d-29d509951bf9",
+          "doc_count": 228
+        },
+        {
+          "key": "92e4e092-6dcb-46bc-85a0-dea8310aba45",
+          "doc_count": 212
+        },
+        {
+          "key": "67893f3c-c409-41c6-a8f2-47956739a911",
+          "doc_count": 211
+        },
+        {
+          "key": "de67ccab-7d04-43b9-8083-81e45f628505",
+          "doc_count": 207
+        },
+        {
+          "key": "2e4ccf50-bb7d-43a6-9640-088b248c2c5a",
+          "doc_count": 205
+        },
+        {
+          "key": "b30a7dd2-d974-4073-bdd0-cb4ea5402bae",
+          "doc_count": 203
+        },
+        {
+          "key": "4fed055b-3c46-4ec4-b76d-84d43df9258b",
+          "doc_count": 187
+        },
+        {
+          "key": "e701ecce-f9ab-445f-afcb-24f279efbc9c",
+          "doc_count": 186
+        },
+        {
+          "key": "414a5bf5-061e-4e47-8410-0f76a04f7d1d",
+          "doc_count": 183
+        },
+        {
+          "key": "d1983d53-434a-436e-a698-3a2745eb61dc",
+          "doc_count": 183
+        },
+        {
+          "key": "48f5d475-7381-4d06-88eb-119796b9d189",
+          "doc_count": 180
+        },
+        {
+          "key": "22436fe4-5049-4266-9849-335dd3f161aa",
+          "doc_count": 176
+        },
+        {
+          "key": "dbb2acdc-a808-4deb-9dc2-542d70368a3f",
+          "doc_count": 171
+        },
+        {
+          "key": "38c75faa-67df-46ae-bce8-331f46d46140",
+          "doc_count": 167
+        },
+        {
+          "key": "17fc477d-727e-4dde-99d6-ac440e937d14",
+          "doc_count": 159
+        },
+        {
+          "key": "6ae7221e-2085-46cf-9ad0-353269e95bc8",
+          "doc_count": 158
+        },
+        {
+          "key": "7cb4bbe6-d9b7-4cdb-b3bf-97a971487f75",
+          "doc_count": 154
+        },
+        {
+          "key": "d5b9fb39-d233-4cd0-8682-c4deff1e337b",
+          "doc_count": 148
+        },
+        {
+          "key": "ea9de87b-7231-4a05-809f-4b658ea4173d",
+          "doc_count": 146
+        },
+        {
+          "key": "589ee0cf-456c-4d9c-8e7e-3adc3cec0e09",
+          "doc_count": 142
+        },
+        {
+          "key": "3e5a9f79-297b-497d-84eb-97e0d1e5c2bf",
+          "doc_count": 138
+        },
+        {
+          "key": "954ec5e0-4fcd-414d-8ad2-46b4b75cfc74",
+          "doc_count": 136
+        },
+        {
+          "key": "86b2bfc9-ca99-4250-b93a-f86f3777236d",
+          "doc_count": 134
+        },
+        {
+          "key": "bfb53140-79c1-4625-81aa-3f37de7c0c2f",
+          "doc_count": 130
+        },
+        {
+          "key": "7311c4ac-7cf6-4160-a55c-4a4c7cd0cf89",
+          "doc_count": 124
+        },
+        {
+          "key": "c9dad611-5e60-4456-934e-75b0e0842ddd",
+          "doc_count": 124
+        },
+        {
+          "key": "5ffc8bc6-e366-4157-b1ba-00859f1048a4",
+          "doc_count": 121
+        },
+        {
+          "key": "a2105c9c-b869-4637-8850-eb51ea6b1066",
+          "doc_count": 112
+        },
+        {
+          "key": "5486b66d-2082-433d-9223-bd789ebca29c",
+          "doc_count": 107
+        },
+        {
+          "key": "69d150df-eba4-4ab3-9156-71cb0db41830",
+          "doc_count": 102
+        },
+        {
+          "key": "5f513dff-ccd8-4578-ad0b-5e6cf035e4d1",
+          "doc_count": 100
+        },
+        {
+          "key": "5ee6f92f-c65c-4888-98e3-f152b3ceb184",
+          "doc_count": 97
+        },
+        {
+          "key": "ef77ec72-6537-41ab-a418-17f9a58e6e73",
+          "doc_count": 92
+        },
+        {
+          "key": "678dc436-3370-4992-a361-761dab8c3fda",
+          "doc_count": 91
+        },
+        {
+          "key": "ca4e7ee9-06f5-4f93-830c-507a6598ec25",
+          "doc_count": 87
+        },
+        {
+          "key": "f5d395b8-c3c9-43df-b4ff-63d65c6a971e",
+          "doc_count": 87
+        },
+        {
+          "key": "1c729855-f3dd-439d-b326-54d62f57b0fd",
+          "doc_count": 85
+        },
+        {
+          "key": "282fe9c2-d6cb-4325-b3b5-b70ab1d22bbb",
+          "doc_count": 79
+        },
+        {
+          "key": "0a410c4a-cd4f-4bd8-b6ba-a0c2baa37622",
+          "doc_count": 78
+        },
+        {
+          "key": "b6d0f953-29b4-41da-a255-2ed07c83edf1",
+          "doc_count": 71
+        },
+        {
+          "key": "28a8561d-4699-4c90-823b-686d6207d675",
+          "doc_count": 69
+        },
+        {
+          "key": "aa53dc91-0cf2-4714-a6e0-f00f9139dcd8",
+          "doc_count": 69
+        },
+        {
+          "key": "6f470382-cb0b-4634-a796-2248bfa97fdc",
+          "doc_count": 67
+        },
+        {
+          "key": "91f4f1c9-37e3-430b-8020-f8d65af8e422",
+          "doc_count": 64
+        },
+        {
+          "key": "c96ca51c-908e-41cc-ae10-ac1fb72ca3d9",
+          "doc_count": 64
+        },
+        {
+          "key": "f89ada44-88df-46f0-bc61-cc46d9c84673",
+          "doc_count": 63
+        },
+        {
+          "key": "473400bf-fe83-4bd6-9f69-c4608f4cdf4f",
+          "doc_count": 61
+        },
+        {
+          "key": "50ca2a08-0e76-4f56-9976-d344dd201a9b",
+          "doc_count": 61
+        },
+        {
+          "key": "b12b08da-3d05-4406-a051-0139a33ecf35",
+          "doc_count": 60
+        },
+        {
+          "key": "c7ae0ade-c23e-4fe6-a3d4-79bd973374c2",
+          "doc_count": 60
+        },
+        {
+          "key": "73236de8-c2cc-458c-b0c3-743c7b57db3a",
+          "doc_count": 59
+        },
+        {
+          "key": "ad4e4ea0-2ac9-4030-b4bd-bf4206e79bcc",
+          "doc_count": 59
+        },
+        {
+          "key": "f42a9828-c1d2-47a1-afac-7138e62b3fb1",
+          "doc_count": 59
+        },
+        {
+          "key": "a83151ae-e1db-4166-9dde-438f6544dca9",
+          "doc_count": 58
+        },
+        {
+          "key": "d06a16c6-f540-40a8-9e92-876ad1955d03",
+          "doc_count": 56
+        },
+        {
+          "key": "2d4658e3-0d1a-43fc-97ff-b4813dd1f86e",
+          "doc_count": 54
+        },
+        {
+          "key": "7e44229a-e8fa-4570-ada1-0cd7843a66d7",
+          "doc_count": 53
+        },
+        {
+          "key": "a50e98bd-13e9-41fe-a5cc-aee4f240628b",
+          "doc_count": 53
+        },
+        {
+          "key": "ce98b978-4542-45c6-aecf-79cf3f6979ed",
+          "doc_count": 51
+        },
+        {
+          "key": "f016064e-c9c6-4baf-925c-e68e1190bb6d",
+          "doc_count": 51
+        },
+        {
+          "key": "f3327705-8d69-4d9c-88b7-584a08c74653",
+          "doc_count": 50
+        },
+        {
+          "key": "8400a716-0aef-4131-9e79-c8ad81d244ad",
+          "doc_count": 49
+        },
+        {
+          "key": "a4378725-7967-47bc-aada-0220e02e1f96",
+          "doc_count": 49
+        },
+        {
+          "key": "d08a71aa-fe87-4bf5-ac68-8e7497bf585c",
+          "doc_count": 49
+        },
+        {
+          "key": "ea3c3b03-0ed5-42fc-b192-7328459ea04a",
+          "doc_count": 49
+        },
+        {
+          "key": "945d6d7d-c768-4189-be9d-f693104d590c",
+          "doc_count": 48
+        },
+        {
+          "key": "9a861ebe-f8d7-4eb1-a2c8-3006f07cfec2",
+          "doc_count": 48
+        },
+        {
+          "key": "1fc07b28-43f5-49d1-badf-63005e1c3e9a",
+          "doc_count": 44
+        },
+        {
+          "key": "67174355-6ee7-4a4c-af45-60e848973853",
+          "doc_count": 42
+        },
+        {
+          "key": "bc93e4c6-fd85-4412-987f-52f6fa3bb67d",
+          "doc_count": 42
+        },
+        {
+          "key": "fdf98e60-9feb-4b86-a42e-ae6c7152d02c",
+          "doc_count": 42
+        },
+        {
+          "key": "40d35f62-cf89-488a-bad3-66e66d38c10c",
+          "doc_count": 41
+        },
+        {
+          "key": "64b54f96-91f0-4442-b6de-173aa1a5c31b",
+          "doc_count": 40
+        },
+        {
+          "key": "67b5d248-4a1e-4861-bc2a-3ac7f379acde",
+          "doc_count": 40
+        },
+        {
+          "key": "8dfc3d88-8f6b-4432-b69c-534717906004",
+          "doc_count": 40
+        },
+        {
+          "key": "5af1bae4-35c0-4ab7-9d08-08bbe22ca003",
+          "doc_count": 36
+        },
+        {
+          "key": "30733214-8eb0-4894-b19d-775fe8a617cf",
+          "doc_count": 35
+        },
+        {
+          "key": "a0ec3ce6-fc8a-48b7-9105-cecf27602e37",
+          "doc_count": 35
+        },
+        {
+          "key": "8f3923b5-4802-40ff-bf98-0acba66691ec",
+          "doc_count": 34
+        },
+        {
+          "key": "384a1909-f66c-4551-9b26-ea985cd9ccd8",
+          "doc_count": 33
+        },
+        {
+          "key": "2df867b1-89de-4539-8414-67c47a88f0c8",
+          "doc_count": 32
+        },
+        {
+          "key": "b027383d-6705-4d06-8514-db6ef16efdb5",
+          "doc_count": 32
+        },
+        {
+          "key": "6226705f-4867-464d-9fab-4e81ecee731f",
+          "doc_count": 31
+        },
+        {
+          "key": "b58043bc-9e47-4a8f-9e4b-5d4c510ea0e1",
+          "doc_count": 31
+        },
+        {
+          "key": "11f88400-8e44-4592-88e4-9d2ce4f37716",
+          "doc_count": 30
+        },
+        {
+          "key": "33b5b5e7-f4e6-435c-9e0f-bb264d58581b",
+          "doc_count": 30
+        },
+        {
+          "key": "687efa84-c549-4743-a193-72d198d8e19c",
+          "doc_count": 30
+        },
+        {
+          "key": "7886c689-ed46-47e9-8dba-4c0468212c65",
+          "doc_count": 29
+        },
+        {
+          "key": "e8c034d5-c2c7-4f23-8dc0-7f94f4116306",
+          "doc_count": 28
+        },
+        {
+          "key": "bd211251-f857-4110-89df-ae59772e44c9",
+          "doc_count": 27
+        },
+        {
+          "key": "677f57a9-9a0d-4e69-8622-96aa1e6392c2",
+          "doc_count": 26
+        },
+        {
+          "key": "a4babe52-5740-44e4-9ea2-acef4797f127",
+          "doc_count": 26
+        },
+        {
+          "key": "23b85d9d-4669-40db-901f-aaad686fe0b8",
+          "doc_count": 25
+        },
+        {
+          "key": "41800344-33b3-4201-b9d2-cabbbf564fbc",
+          "doc_count": 25
+        },
+        {
+          "key": "6c6f34ed-58a4-4ba2-b9c7-34524f79a349",
+          "doc_count": 24
+        },
+        {
+          "key": "c13a5966-99a3-4383-b9ef-259cf46800fe",
+          "doc_count": 24
+        },
+        {
+          "key": "361efdf7-9845-411c-90bd-e51ec7991e87",
+          "doc_count": 23
+        },
+        {
+          "key": "6e922c92-b37d-4c46-8982-19d945ff8fd1",
+          "doc_count": 22
+        },
+        {
+          "key": "fd66cee6-5310-4201-9949-0ea04a05b72b",
+          "doc_count": 22
+        },
+        {
+          "key": "3420d3d5-f142-4db6-951c-5d37cb72ce53",
+          "doc_count": 21
+        },
+        {
+          "key": "cb2973af-0d5a-4fbf-80ab-ec96ede33ef0",
+          "doc_count": 21
+        },
+        {
+          "key": "35830c1e-429e-4006-a153-78984a3e0ee2",
+          "doc_count": 19
+        },
+        {
+          "key": "9e89b6af-4bb5-45af-93d8-0112bd20a60d",
+          "doc_count": 19
+        },
+        {
+          "key": "aeed0286-ffe4-45b8-a7b9-bcee18361433",
+          "doc_count": 19
+        },
+        {
+          "key": "43c69d2a-0fd2-4d34-a1ef-50d0f9c01353",
+          "doc_count": 18
+        },
+        {
+          "key": "948a3370-bdb4-46cb-a047-c777a76ae420",
+          "doc_count": 18
+        },
+        {
+          "key": "0ed6268e-7449-414c-a93c-57ea68f8ab3e",
+          "doc_count": 17
+        },
+        {
+          "key": "341da8fa-d049-46ee-9be8-463043f26fa7",
+          "doc_count": 17
+        },
+        {
+          "key": "33bac15d-b1d0-42a1-8801-86149887eeef",
+          "doc_count": 16
+        },
+        {
+          "key": "6f510e69-96b2-4817-bab7-3a36c8250c79",
+          "doc_count": 16
+        },
+        {
+          "key": "826420a8-3d4a-4cee-901c-f0f2ee9e00b4",
+          "doc_count": 16
+        },
+        {
+          "key": "886f3b02-e2f2-4c49-9ace-df25bf5d091a",
+          "doc_count": 16
+        },
+        {
+          "key": "af4f13cd-f1e8-4e18-ac7a-b0aeee90c749",
+          "doc_count": 16
+        },
+        {
+          "key": "fe04dab1-5a3d-4c28-a450-012658e982d8",
+          "doc_count": 16
+        },
+        {
+          "key": "fe52a17a-a7aa-4f95-a3ea-26fe640170fe",
+          "doc_count": 16
+        },
+        {
+          "key": "253f90be-3b94-469c-820c-cb727b85bdd4",
+          "doc_count": 14
+        },
+        {
+          "key": "ceba331e-9da3-44ee-8970-f1eb8d1a68d6",
+          "doc_count": 14
+        },
+        {
+          "key": "b101e53b-8934-42ef-92db-904c226f29a8",
+          "doc_count": 13
+        },
+        {
+          "key": "18cc4ad5-9449-470e-9195-5858b12d822c",
+          "doc_count": 12
+        },
+        {
+          "key": "2c84db50-bab1-40a6-a9ef-405f3ffcec7e",
+          "doc_count": 12
+        },
+        {
+          "key": "9d35f82b-c19b-4dce-b296-808598d1fb6b",
+          "doc_count": 12
+        },
+        {
+          "key": "0c94911f-6f18-40a2-a0c3-95c845bc41d7",
+          "doc_count": 11
+        },
+        {
+          "key": "17ff84d1-e3e9-43d1-a746-745ef8d339d0",
+          "doc_count": 11
+        },
+        {
+          "key": "350ed733-b782-4195-a5dd-e61e5c82d837",
+          "doc_count": 11
+        },
+        {
+          "key": "4c9d08ce-71c1-47b8-a572-2d40e5984c49",
+          "doc_count": 11
+        },
+        {
+          "key": "0fb6618f-f8d6-4361-8b2d-0923d4aa3c09",
+          "doc_count": 10
+        },
+        {
+          "key": "5d0a9aa8-91f2-4fa4-b4df-554a4221dfcb",
+          "doc_count": 9
+        },
+        {
+          "key": "8e2f9392-55ac-49f3-bcc2-131a00122626",
+          "doc_count": 9
+        },
+        {
+          "key": "90739622-5232-4048-8121-9af9ec69604f",
+          "doc_count": 9
+        },
+        {
+          "key": "9ea3f46b-f7b9-4b2e-8d4e-a052fbe69de9",
+          "doc_count": 9
+        },
+        {
+          "key": "0e5201c0-bad2-4e28-9322-5c5dca8862c8",
+          "doc_count": 8
+        },
+        {
+          "key": "23655eb9-7798-4865-9a92-1dbbc609511d",
+          "doc_count": 8
+        },
+        {
+          "key": "3fe3a250-0f48-4a9b-bb71-36d798694912",
+          "doc_count": 8
+        },
+        {
+          "key": "750a80fe-60b9-423b-aca1-dcc7937d2c84",
+          "doc_count": 8
+        },
+        {
+          "key": "964c24a3-cca4-4028-a0d8-b83513d14b7d",
+          "doc_count": 8
+        },
+        {
+          "key": "97e4947d-fce9-4019-9f86-c0d94c820269",
+          "doc_count": 8
+        },
+        {
+          "key": "997c4dda-0465-40c0-af8d-67f8f90dea3b",
+          "doc_count": 8
+        },
+        {
+          "key": "0bffd75c-2c42-4119-bae7-1ca6d8eb4d1a",
+          "doc_count": 7
+        },
+        {
+          "key": "36be338b-cfb2-47e4-a1fc-b3f7a1aaaf22",
+          "doc_count": 7
+        },
+        {
+          "key": "38db50bb-72f3-4416-aeb9-61457e655a6d",
+          "doc_count": 7
+        },
+        {
+          "key": "4efa0623-a625-4949-aea4-7cb60a99b6f8",
+          "doc_count": 7
+        },
+        {
+          "key": "99e84c7d-dd3c-40d9-9526-54f4342cda95",
+          "doc_count": 7
+        },
+        {
+          "key": "c8eeddef-b903-4aa3-a0fb-44344b8bf301",
+          "doc_count": 7
+        },
+        {
+          "key": "e7301984-8b46-4932-b670-21c231ae4c01",
+          "doc_count": 7
+        },
+        {
+          "key": "394dda75-c336-4ca3-acdd-1c2a317d7361",
+          "doc_count": 6
+        },
+        {
+          "key": "94b17bab-a41a-4cb2-8ae4-209e31c5144d",
+          "doc_count": 6
+        },
+        {
+          "key": "fd09683f-efe8-446c-9e43-7d11f62e597c",
+          "doc_count": 6
+        },
+        {
+          "key": "fd62a976-d195-492a-b6f0-f57fef8b6acc",
+          "doc_count": 6
+        },
+        {
+          "key": "50ee2f53-7f79-4808-bceb-3e660fd1e666",
+          "doc_count": 5
+        },
+        {
+          "key": "55ddd3f9-0e9a-40e8-9e8f-d3a3ab871434",
+          "doc_count": 5
+        },
+        {
+          "key": "8ed556b0-b801-4575-ae53-db7cacbfd0c9",
+          "doc_count": 5
+        },
+        {
+          "key": "a89f64ab-8b3b-4267-b18a-3207d25a45ad",
+          "doc_count": 5
+        },
+        {
+          "key": "b0e9fd61-1e0f-408f-b035-d7952614d7f3",
+          "doc_count": 5
+        },
+        {
+          "key": "b26cc2c9-1141-4502-805a-b9dd1d83c321",
+          "doc_count": 5
+        },
+        {
+          "key": "151075fa-f464-4d76-9064-b24aa945b30f",
+          "doc_count": 4
+        },
+        {
+          "key": "3799e4f9-f685-4796-99b5-f78524441b93",
+          "doc_count": 4
+        },
+        {
+          "key": "3a0d8092-c577-4775-a586-1542574edc53",
+          "doc_count": 4
+        },
+        {
+          "key": "53aa69a7-bd66-468b-8ffa-ec6cb06d7d8d",
+          "doc_count": 4
+        },
+        {
+          "key": "9b34b218-efb2-43b9-9b9e-dac3c470a9f9",
+          "doc_count": 4
+        },
+        {
+          "key": "9c4f4765-2d02-452c-9ae9-cdd1d4846d5d",
+          "doc_count": 4
+        },
+        {
+          "key": "a73b61c5-812c-453b-b12b-5c65929e947a",
+          "doc_count": 4
+        },
+        {
+          "key": "ab3c6b74-477b-4f79-8711-0643851021f0",
+          "doc_count": 4
+        },
+        {
+          "key": "b0a3324f-849a-43bf-811a-9dd10f04806b",
+          "doc_count": 4
+        },
+        {
+          "key": "b10b9eb2-3786-4483-8b73-3cfdf1a9eb90",
+          "doc_count": 4
+        },
+        {
+          "key": "b1549ab7-5fc7-4966-a210-0846484fb171",
+          "doc_count": 4
+        },
+        {
+          "key": "be72355e-a5d6-4094-8635-0127dfb510aa",
+          "doc_count": 4
+        },
+        {
+          "key": "c7821624-d246-43b8-9dfd-de470f9dc294",
+          "doc_count": 4
+        },
+        {
+          "key": "f062cb7d-c03e-4762-b1c4-49118fee1a56",
+          "doc_count": 4
+        },
+        {
+          "key": "433d3c37-8dde-42e4-a344-2cb6605c5da2",
+          "doc_count": 3
+        },
+        {
+          "key": "5ab348ab-439a-4697-925c-d6abe0c09b92",
+          "doc_count": 3
+        },
+        {
+          "key": "6d710d01-54f6-448b-bbf9-adee9e46fc3c",
+          "doc_count": 3
+        },
+        {
+          "key": "97c1db9d-b3c1-4c05-9b55-e99c37773a29",
+          "doc_count": 3
+        },
+        {
+          "key": "b4cce5b5-6450-443c-8988-a279b9cefaab",
+          "doc_count": 3
+        },
+        {
+          "key": "b6ebfa9d-fed3-4e0c-8877-47c1190f346c",
+          "doc_count": 3
+        },
+        {
+          "key": "bfa3c276-a3a9-48cd-8d4a-4ac42f4fe10a",
+          "doc_count": 3
+        },
+        {
+          "key": "c57817e7-034c-4796-ac47-2bc2191713b3",
+          "doc_count": 3
+        },
+        {
+          "key": "e647814d-6975-4b34-b8c4-e79b7ca83085",
+          "doc_count": 3
+        },
+        {
+          "key": "f39780bd-7108-4685-8e6a-b340ff5a5965",
+          "doc_count": 3
+        },
+        {
+          "key": "f5c38252-89f1-4753-af3a-da8818fe3a86",
+          "doc_count": 3
+        },
+        {
+          "key": "0e162e0a-bf3e-4710-9357-44258ca12abb",
+          "doc_count": 2
+        },
+        {
+          "key": "15e04168-22cc-4283-9042-247ab053c7ca",
+          "doc_count": 2
+        },
+        {
+          "key": "2d47501f-dbed-43ce-a9c3-9c8542648ce4",
+          "doc_count": 2
+        },
+        {
+          "key": "53a8ce69-d9b9-4ae2-848a-dab0d4d810d1",
+          "doc_count": 2
+        },
+        {
+          "key": "57a6bf5f-cda1-41fd-8c12-804c95f74841",
+          "doc_count": 2
+        },
+        {
+          "key": "5f6fcfc2-598c-42e8-abb3-50ca9c2446e2",
+          "doc_count": 2
+        },
+        {
+          "key": "68abd0b8-cff1-4c84-a2d9-bd4ac6df4fa4",
+          "doc_count": 2
+        },
+        {
+          "key": "781b461a-2788-4fa6-b3df-bbed9447f5a3",
+          "doc_count": 2
+        },
+        {
+          "key": "7ae4d15d-62e2-459b-842a-446f921b9d3f",
+          "doc_count": 2
+        },
+        {
+          "key": "85ae9fb4-de87-41ce-abb3-44fda2fb24a8",
+          "doc_count": 2
+        },
+        {
+          "key": "8a54c5fa-2900-4859-a2d6-1b7faedafac4",
+          "doc_count": 2
+        },
+        {
+          "key": "9d9016ef-a88f-4312-a0bf-638fc4be53ba",
+          "doc_count": 2
+        },
+        {
+          "key": "a8cafd75-ca3b-42c6-8b8e-52aafa15753b",
+          "doc_count": 2
+        },
+        {
+          "key": "b7a5dadd-7429-489b-9b3b-72abcd9518a3",
+          "doc_count": 2
+        },
+        {
+          "key": "d07e7b8a-2222-477f-a7f3-f098bbfdaf54",
+          "doc_count": 2
+        },
+        {
+          "key": "f4573d80-dd92-4337-9005-ba71e8a8563a",
+          "doc_count": 2
+        },
+        {
+          "key": "0ed0b942-198e-4500-8fe0-1d1ef0785454",
+          "doc_count": 1
+        },
+        {
+          "key": "0f65c2e4-fc98-4a2c-bfbe-24de6ab1feb6",
+          "doc_count": 1
+        },
+        {
+          "key": "1da8098a-1e82-4b8b-bf81-d30e423cdaba",
+          "doc_count": 1
+        },
+        {
+          "key": "212dcc45-bf5b-43d8-a804-3351c04c2f7a",
+          "doc_count": 1
+        },
+        {
+          "key": "2cf2843f-567c-45c1-a328-cc210af76fc1",
+          "doc_count": 1
+        },
+        {
+          "key": "41b166d5-ce08-4efe-99fc-6df77d8fe29e",
+          "doc_count": 1
+        },
+        {
+          "key": "4ecc6eb6-5f2f-4b00-8d26-a58bfa0e7f02",
+          "doc_count": 1
+        },
+        {
+          "key": "5e2f4c81-8c8a-45f3-a220-851f85f86b40",
+          "doc_count": 1
+        },
+        {
+          "key": "667c2736-bcd3-4a6a-abf4-db5d2dc815c4",
+          "doc_count": 1
+        },
+        {
+          "key": "6f2cd35e-9ee6-44d5-b182-cdd19d01a4c3",
+          "doc_count": 1
+        },
+        {
+          "key": "751b5d4c-aba7-4c1f-b0a1-dfe2e9346d1b",
+          "doc_count": 1
+        },
+        {
+          "key": "7e43ea77-d2e5-4bdc-a4f7-a4792866f53f",
+          "doc_count": 1
+        },
+        {
+          "key": "9e66257f-21a9-491a-ac23-06b7b62ceeb7",
+          "doc_count": 1
+        },
+        {
+          "key": "ac8c109d-b69c-4359-87f4-8714f8c8a65d",
+          "doc_count": 1
+        },
+        {
+          "key": "b4154ce7-8145-4fd8-92ed-edd124d53730",
+          "doc_count": 1
+        },
+        {
+          "key": "b590be71-5a03-4f29-bcd4-e91c1b876137",
+          "doc_count": 1
+        },
+        {
+          "key": "c22f048c-6f77-4488-a203-865537dddba9",
+          "doc_count": 1
+        },
+        {
+          "key": "cd7b335e-6f5c-4259-ba45-5e334a719464",
+          "doc_count": 1
+        },
+        {
+          "key": "e01f53f2-8e1b-41cb-9e5a-3dfb3ccf44d6",
+          "doc_count": 1
+        },
+        {
+          "key": "e2fda823-8a6e-4bd8-8602-924615373938",
+          "doc_count": 1
+        },
+        {
+          "key": "e5cb850f-de98-45ce-9872-95262732809f",
+          "doc_count": 1
+        },
+        {
+          "key": "f0599190-e5b7-42ed-bec8-810905f50c34",
+          "doc_count": 1
+        },
+        {
+          "key": "f1960cd5-e27a-40f0-b4bd-3ca7157e4bbb",
+          "doc_count": 1
+        }
+      ]
+    },
+    "max_dm": {
+      "value": 1674653744868,
+      "value_as_string": "2023-01-25T13:35:44.868Z"
+    }
+  }
+}

--- a/__tests__/mock/search-fe885dae056de04dd18dbf62a96a453c.json
+++ b/__tests__/mock/search-fe885dae056de04dd18dbf62a96a453c.json
@@ -1,0 +1,2358 @@
+{
+  "timed_out": false,
+  "_shards": {
+    "total": 48,
+    "successful": 48,
+    "failed": 0
+  },
+  "hits": {
+    "total": 5433124,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "8339d0c9-8c91-423c-8f3f-685757c599cf",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          null
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "9ffc659e-0a38-4333-b65f-c8f3f83e3dcc",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          null
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "bb1e4337-b1dd-4a4f-b351-048dfaad2615",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          null
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a031576d-320f-488a-9d0f-35cfa0303459",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          null
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "32357eda-4aa8-4bf7-922c-7d16a90a30a9",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          null
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a0942a00-659b-4545-b60c-a387b9373a85",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          null
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a09bc581-03dc-46a2-b80f-f6652a821c9e",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          null
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a0cbef10-bd68-4b9a-a6cb-97bab843d7e8",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          null
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a0fbbb8e-c850-43e4-ad3a-7117f304b510",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          null
+        ]
+      },
+      {
+        "_index": "idigbio-2.10.22",
+        "_type": "records",
+        "_id": "a1101b11-038c-47af-a201-69be4b1c5bd6",
+        "_score": null,
+        "_source": {},
+        "sort": [
+          null
+        ]
+      }
+    ]
+  },
+  "aggregations": {
+    "rs": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "616857b7-f952-44ef-9b6f-576dc1e65b51",
+          "doc_count": 516260
+        },
+        {
+          "key": "fc014977-92f7-47fd-92d7-b609c39d8212",
+          "doc_count": 388020
+        },
+        {
+          "key": "a6eee223-cf3b-4079-8bb2-b77dad8cae9d",
+          "doc_count": 356755
+        },
+        {
+          "key": "36d35b23-113e-4633-90ec-19d265a3b5f6",
+          "doc_count": 275137
+        },
+        {
+          "key": "5386d272-06c6-4027-b5d5-d588c2afe5e5",
+          "doc_count": 246119
+        },
+        {
+          "key": "fabcdc12-9d29-4bd2-912b-176e71818144",
+          "doc_count": 242650
+        },
+        {
+          "key": "765aa536-b79e-4794-a0d2-40a160233922",
+          "doc_count": 135352
+        },
+        {
+          "key": "f778ecc0-8371-49d5-9ab1-9d75f0b76fad",
+          "doc_count": 122370
+        },
+        {
+          "key": "7450a9e3-ef95-4f9e-8260-09b498d2c5e6",
+          "doc_count": 100046
+        },
+        {
+          "key": "a4e6033a-d1eb-46d3-869d-7c0328f09aa7",
+          "doc_count": 96050
+        },
+        {
+          "key": "70abba3e-5f2a-4276-87f3-261706e24453",
+          "doc_count": 95094
+        },
+        {
+          "key": "26f7cbde-fbcb-4500-80a9-a99daa0ead9d",
+          "doc_count": 91665
+        },
+        {
+          "key": "2d7910d9-7f63-4bde-918a-9e0265f1c245",
+          "doc_count": 85334
+        },
+        {
+          "key": "e6ccc2bd-9451-4802-8a51-8640d9f09793",
+          "doc_count": 76002
+        },
+        {
+          "key": "c55ac6d0-180d-41be-829a-e82898c5ca54",
+          "doc_count": 64928
+        },
+        {
+          "key": "65536dcd-7bb2-44e5-af3f-4a13f08e53d0",
+          "doc_count": 57422
+        },
+        {
+          "key": "db6c3db9-1e6d-4def-af29-33aa0339bfa9",
+          "doc_count": 56748
+        },
+        {
+          "key": "d7b285d4-2643-45ee-9302-b0c3d51dda5c",
+          "doc_count": 56042
+        },
+        {
+          "key": "4e3043a6-d48a-4a35-b5fb-f67d50cbc158",
+          "doc_count": 54246
+        },
+        {
+          "key": "953b0329-c3e4-4816-a038-7afbd2bb2547",
+          "doc_count": 49710
+        },
+        {
+          "key": "4523e216-ee13-4b15-a3f7-a6fd56431604",
+          "doc_count": 44997
+        },
+        {
+          "key": "3c9420c9-c4a8-47dc-88b7-b5638ca5e716",
+          "doc_count": 43660
+        },
+        {
+          "key": "ba042ffa-8175-4a47-8eb1-08b4d6319ccf",
+          "doc_count": 42353
+        },
+        {
+          "key": "a2b36fdf-50bc-44ef-a6a4-ca6dc1dc148a",
+          "doc_count": 41695
+        },
+        {
+          "key": "d82fa49b-915e-4aa8-acc6-51df3d431884",
+          "doc_count": 41348
+        },
+        {
+          "key": "f0174bc9-0cca-450e-a941-655d80040139",
+          "doc_count": 40218
+        },
+        {
+          "key": "72d4c3c7-3413-4588-a803-e1a63e0d7c6c",
+          "doc_count": 38678
+        },
+        {
+          "key": "beab5209-9628-4d4d-851e-2bc9bb1a0105",
+          "doc_count": 38447
+        },
+        {
+          "key": "9e5aede6-bee5-4a3d-a255-513771b20035",
+          "doc_count": 36728
+        },
+        {
+          "key": "40250f4d-7aa6-4fcc-ac38-2868fa4846bd",
+          "doc_count": 33842
+        },
+        {
+          "key": "bf1fee2d-f760-4068-b8e6-d1db63ce434c",
+          "doc_count": 33365
+        },
+        {
+          "key": "205fa34c-2fcb-4492-b992-972b18560f6f",
+          "doc_count": 31488
+        },
+        {
+          "key": "e2def7e2-1455-4856-9823-6d3738417d24",
+          "doc_count": 31078
+        },
+        {
+          "key": "d53132e6-7997-4850-8607-4fec5a3f9c3f",
+          "doc_count": 30487
+        },
+        {
+          "key": "3027c437-cdb3-4072-9410-5a46ec3b1fd5",
+          "doc_count": 28797
+        },
+        {
+          "key": "e60301d9-9b40-483f-92de-065769b9d3dd",
+          "doc_count": 27843
+        },
+        {
+          "key": "8b0c1f4b-9de7-4521-98c2-983e0bfd33c7",
+          "doc_count": 27754
+        },
+        {
+          "key": "7c1a1d78-aeaa-4501-87e1-83eceb8ca8ea",
+          "doc_count": 27253
+        },
+        {
+          "key": "6cc31636-c3e5-4887-bbee-2e56621771c4",
+          "doc_count": 25372
+        },
+        {
+          "key": "0dab1fc7-ca99-456b-9985-76edbac003e0",
+          "doc_count": 25129
+        },
+        {
+          "key": "e5cb850f-de98-45ce-9872-95262732809f",
+          "doc_count": 24733
+        },
+        {
+          "key": "0fd6e726-6828-4f62-ba8d-6ec316fe0b52",
+          "doc_count": 24533
+        },
+        {
+          "key": "275a8cea-1c34-4580-a030-4f58e680605c",
+          "doc_count": 23487
+        },
+        {
+          "key": "781fd581-7b93-471e-a025-413e4bcd8491",
+          "doc_count": 23297
+        },
+        {
+          "key": "96662fa9-ff60-495b-912a-284f3b98ed72",
+          "doc_count": 23092
+        },
+        {
+          "key": "d7540872-1c53-48ac-a617-2d0739eadcbd",
+          "doc_count": 22720
+        },
+        {
+          "key": "215eeaf0-0a88-409e-a75d-aec98b7c41eb",
+          "doc_count": 22469
+        },
+        {
+          "key": "0583609b-202f-40d0-8021-4c019635d4c9",
+          "doc_count": 21297
+        },
+        {
+          "key": "d06a16c6-f540-40a8-9e92-876ad1955d03",
+          "doc_count": 21105
+        },
+        {
+          "key": "f1cf8457-237e-487a-9d13-5de7d81b9de4",
+          "doc_count": 20960
+        },
+        {
+          "key": "9151bc4c-8505-4b22-a16b-9dbf337535fa",
+          "doc_count": 20439
+        },
+        {
+          "key": "e4ff51ba-5007-4c40-9a86-e8c6f4db77b7",
+          "doc_count": 18984
+        },
+        {
+          "key": "b531ea59-025d-4c29-9d23-99ae75bcd55f",
+          "doc_count": 18742
+        },
+        {
+          "key": "b667cef4-96fe-42e8-a9fa-6298aa80bb14",
+          "doc_count": 18652
+        },
+        {
+          "key": "f8866892-56a0-4f46-9583-6719d42d81de",
+          "doc_count": 18520
+        },
+        {
+          "key": "0ed8a17e-149b-4cbe-8383-7676da92ea1c",
+          "doc_count": 18281
+        },
+        {
+          "key": "b6ec6203-09db-4d6e-8cba-ee4bebd2934c",
+          "doc_count": 18186
+        },
+        {
+          "key": "a7228b3f-982a-4518-a761-b19b00e14844",
+          "doc_count": 17854
+        },
+        {
+          "key": "2c00c297-9ebd-498a-b701-d3ebde4b49f3",
+          "doc_count": 17590
+        },
+        {
+          "key": "a6e02b78-6fc6-4cb6-bb87-8d5a443f2c2a",
+          "doc_count": 17095
+        },
+        {
+          "key": "e7301984-8b46-4932-b670-21c231ae4c01",
+          "doc_count": 16972
+        },
+        {
+          "key": "62a36329-6b82-48bc-94d8-1cb9adb91ab5",
+          "doc_count": 16809
+        },
+        {
+          "key": "59efaf7d-60b5-4295-abb3-27ba42eb5231",
+          "doc_count": 16560
+        },
+        {
+          "key": "6258d160-a7aa-4937-bce3-3538eebd374f",
+          "doc_count": 16329
+        },
+        {
+          "key": "e70af26a-fb9e-43ab-96a0-d62a2df37e6d",
+          "doc_count": 16206
+        },
+        {
+          "key": "8057906f-17c9-4e25-b173-4e7fb938078b",
+          "doc_count": 15580
+        },
+        {
+          "key": "710a8a54-783c-41aa-ad9a-05544cdb4c55",
+          "doc_count": 15577
+        },
+        {
+          "key": "b9ab58cf-785e-44a7-a873-1966e14a6715",
+          "doc_count": 15491
+        },
+        {
+          "key": "253f90be-3b94-469c-820c-cb727b85bdd4",
+          "doc_count": 15483
+        },
+        {
+          "key": "5e29dbcc-ce45-4f05-9bb0-212baffa8932",
+          "doc_count": 15033
+        },
+        {
+          "key": "c2767dde-1315-4d78-abf9-8e098dd588ab",
+          "doc_count": 15022
+        },
+        {
+          "key": "83ad8494-136b-485a-87d4-8ce01dd6a8de",
+          "doc_count": 14920
+        },
+        {
+          "key": "c569e530-7322-40b8-9b66-1e0ed96fefcb",
+          "doc_count": 14024
+        },
+        {
+          "key": "aca26f37-3ec8-4e9e-b927-50b4944a0096",
+          "doc_count": 13734
+        },
+        {
+          "key": "8ec76c75-a673-4682-bfde-00a18bc12794",
+          "doc_count": 13342
+        },
+        {
+          "key": "0bc60df1-a162-4173-9a73-c51e09031843",
+          "doc_count": 13257
+        },
+        {
+          "key": "71bf994a-3af5-484d-983b-b146aa1512d1",
+          "doc_count": 12913
+        },
+        {
+          "key": "b2b294ed-1742-4479-b0c8-a8891fccd7eb",
+          "doc_count": 12649
+        },
+        {
+          "key": "4ac45d7e-c6e5-45ea-a0e0-aea6ebe2afcf",
+          "doc_count": 12581
+        },
+        {
+          "key": "f3ee2661-268a-48dc-b931-b9429d5674f4",
+          "doc_count": 12106
+        },
+        {
+          "key": "844875a9-9927-48a5-90b4-76c5f227f145",
+          "doc_count": 11977
+        },
+        {
+          "key": "5835f642-2560-4e3e-9c25-741a12cc3fe8",
+          "doc_count": 11871
+        },
+        {
+          "key": "b88033dd-5dbb-4377-b374-2210f32ece16",
+          "doc_count": 11838
+        },
+        {
+          "key": "dd232f5c-7f53-48ec-9bb7-7205702c3dc8",
+          "doc_count": 11818
+        },
+        {
+          "key": "e36691ec-c4f8-4bec-b331-b48ffa82ff49",
+          "doc_count": 11776
+        },
+        {
+          "key": "ddef79ec-043c-4027-9876-c4a298feff6d",
+          "doc_count": 11688
+        },
+        {
+          "key": "237d30ca-7675-4840-b4fd-96771fabf518",
+          "doc_count": 11666
+        },
+        {
+          "key": "e185415c-15c4-4612-89f3-27cfebbca0d9",
+          "doc_count": 11472
+        },
+        {
+          "key": "ff89320d-e232-4edd-9cdd-4b6acc672ad3",
+          "doc_count": 11140
+        },
+        {
+          "key": "d78d13a7-3852-4244-ba34-86ef5765fa99",
+          "doc_count": 10816
+        },
+        {
+          "key": "341da8fa-d049-46ee-9be8-463043f26fa7",
+          "doc_count": 10470
+        },
+        {
+          "key": "f84d528a-7d08-467e-b532-ace707316f1d",
+          "doc_count": 10208
+        },
+        {
+          "key": "3e5a9f79-297b-497d-84eb-97e0d1e5c2bf",
+          "doc_count": 9981
+        },
+        {
+          "key": "20360fae-574a-4d63-b9f6-47b1cc07fd22",
+          "doc_count": 9785
+        },
+        {
+          "key": "3998ec8d-4aae-46db-9370-179c19b69356",
+          "doc_count": 9418
+        },
+        {
+          "key": "264c48ec-8636-451f-a7e0-74131bc6f84c",
+          "doc_count": 9297
+        },
+        {
+          "key": "b5b79eb9-c270-4427-9cd6-43bd6c4b73ab",
+          "doc_count": 9263
+        },
+        {
+          "key": "ec4acc26-ff1b-4131-a1df-a950fe31bb0e",
+          "doc_count": 9171
+        },
+        {
+          "key": "948a3370-bdb4-46cb-a047-c777a76ae420",
+          "doc_count": 9164
+        },
+        {
+          "key": "9b725e43-93c9-423b-adf8-a11d08a83d13",
+          "doc_count": 9149
+        },
+        {
+          "key": "207b6c64-7b58-4d6a-816d-bc759c27eafc",
+          "doc_count": 8950
+        },
+        {
+          "key": "05c029de-734c-450a-a41a-56061b7ebb18",
+          "doc_count": 8897
+        },
+        {
+          "key": "d8862887-ff5c-4caa-9d61-f1958887ebc1",
+          "doc_count": 8837
+        },
+        {
+          "key": "d2217bca-3a93-4407-bb56-087afa000cbc",
+          "doc_count": 8638
+        },
+        {
+          "key": "c5b7dae8-b483-4742-9954-d7f9226daa34",
+          "doc_count": 8347
+        },
+        {
+          "key": "471835cc-feb6-4d05-a8d1-62ce71399326",
+          "doc_count": 8342
+        },
+        {
+          "key": "364a24d9-d4a8-4e0b-8e50-07b90f844548",
+          "doc_count": 7935
+        },
+        {
+          "key": "46c11153-2154-495d-89d2-7cdef6425cdb",
+          "doc_count": 7741
+        },
+        {
+          "key": "7cb4bbe6-d9b7-4cdb-b3bf-97a971487f75",
+          "doc_count": 7718
+        },
+        {
+          "key": "ba54ba45-caac-4708-a389-ac94642976f8",
+          "doc_count": 7515
+        },
+        {
+          "key": "76fd34da-4892-4821-858d-98fe9e28ba8b",
+          "doc_count": 7344
+        },
+        {
+          "key": "e5f57bb0-07ec-4405-90b6-dc89647a1cb5",
+          "doc_count": 7323
+        },
+        {
+          "key": "1527b668-b797-42be-94d3-0058e1393e94",
+          "doc_count": 7280
+        },
+        {
+          "key": "244ee82a-438c-4e77-a2ce-4e2af9ddbe4d",
+          "doc_count": 7140
+        },
+        {
+          "key": "de5203b1-5a44-4010-948c-b7d33f46397a",
+          "doc_count": 6992
+        },
+        {
+          "key": "f31a5f98-efd3-476a-9627-de3add582acd",
+          "doc_count": 6736
+        },
+        {
+          "key": "ca8f64d0-40d2-452a-b1b8-713a3861fe69",
+          "doc_count": 6731
+        },
+        {
+          "key": "7644703a-ce24-4f7b-b800-66ddf8812f86",
+          "doc_count": 6644
+        },
+        {
+          "key": "14f8f83f-7a0c-458c-b6d5-6da7dc8eaa0a",
+          "doc_count": 6561
+        },
+        {
+          "key": "82672123-feef-4b1c-9ee3-9a681204ae76",
+          "doc_count": 6517
+        },
+        {
+          "key": "664bd710-8791-4dba-a3b6-000a1b140951",
+          "doc_count": 6515
+        },
+        {
+          "key": "703b5bdc-4581-47e3-b4b6-e6f32d0eec54",
+          "doc_count": 6479
+        },
+        {
+          "key": "be31dfd1-c721-4697-8ee0-f7043c070810",
+          "doc_count": 6350
+        },
+        {
+          "key": "5baa1d0c-cfc0-4c89-8e3e-7a49359b0caa",
+          "doc_count": 6285
+        },
+        {
+          "key": "09a3fcf2-55a1-488f-aa42-f103bdce0536",
+          "doc_count": 6111
+        },
+        {
+          "key": "910eadc8-8131-428c-b28a-91d0e2890f1d",
+          "doc_count": 5923
+        },
+        {
+          "key": "0c94911f-6f18-40a2-a0c3-95c845bc41d7",
+          "doc_count": 5877
+        },
+        {
+          "key": "005ac06a-3d9a-46ad-ac3c-062aaa5b7059",
+          "doc_count": 5784
+        },
+        {
+          "key": "120d557c-c5be-474d-98f0-1ba00ae16b40",
+          "doc_count": 5773
+        },
+        {
+          "key": "e794b292-4a94-471e-ab84-6aaef1fea1b3",
+          "doc_count": 5620
+        },
+        {
+          "key": "a16dc8d8-ff4a-4d62-a684-2937fb292b8d",
+          "doc_count": 5580
+        },
+        {
+          "key": "1e798b2d-7f97-49b0-a864-79c968af91d3",
+          "doc_count": 5508
+        },
+        {
+          "key": "17ff84d1-e3e9-43d1-a746-745ef8d339d0",
+          "doc_count": 5424
+        },
+        {
+          "key": "38db50bb-72f3-4416-aeb9-61457e655a6d",
+          "doc_count": 5364
+        },
+        {
+          "key": "5ee6f92f-c65c-4888-98e3-f152b3ceb184",
+          "doc_count": 5309
+        },
+        {
+          "key": "43aa1339-67e4-4298-b7c5-3d0f201266ef",
+          "doc_count": 5248
+        },
+        {
+          "key": "67b5d248-4a1e-4861-bc2a-3ac7f379acde",
+          "doc_count": 5219
+        },
+        {
+          "key": "35830c1e-429e-4006-a153-78984a3e0ee2",
+          "doc_count": 5085
+        },
+        {
+          "key": "4db72a36-c08b-4a6b-8c68-ab45ebb0efce",
+          "doc_count": 5034
+        },
+        {
+          "key": "d478c23a-1993-443d-85ea-308870606626",
+          "doc_count": 4968
+        },
+        {
+          "key": "7a8d946d-083f-4d2a-9cc9-cd590398194f",
+          "doc_count": 4937
+        },
+        {
+          "key": "21b563bc-70c2-46d5-bce8-2489db2db3d8",
+          "doc_count": 4907
+        },
+        {
+          "key": "1549b662-ec36-436a-8593-76f7642ec9e4",
+          "doc_count": 4609
+        },
+        {
+          "key": "e6eba8cd-fa2c-4ba2-bec0-6841e7633695",
+          "doc_count": 4561
+        },
+        {
+          "key": "ef77ec72-6537-41ab-a418-17f9a58e6e73",
+          "doc_count": 4532
+        },
+        {
+          "key": "17fc477d-727e-4dde-99d6-ac440e937d14",
+          "doc_count": 4513
+        },
+        {
+          "key": "7311c4ac-7cf6-4160-a55c-4a4c7cd0cf89",
+          "doc_count": 4453
+        },
+        {
+          "key": "cd7b335e-6f5c-4259-ba45-5e334a719464",
+          "doc_count": 4293
+        },
+        {
+          "key": "98ece30d-bf85-4122-b872-7786031b457f",
+          "doc_count": 4149
+        },
+        {
+          "key": "09edf7d2-e68e-4a42-93da-762f86bb814f",
+          "doc_count": 4058
+        },
+        {
+          "key": "8f689b8b-5b65-4638-9555-f2a5d237a624",
+          "doc_count": 4038
+        },
+        {
+          "key": "ea3c3b03-0ed5-42fc-b192-7328459ea04a",
+          "doc_count": 4034
+        },
+        {
+          "key": "0f19f6d6-79a4-434e-ba0b-a4f49f334078",
+          "doc_count": 4008
+        },
+        {
+          "key": "9e89b6af-4bb5-45af-93d8-0112bd20a60d",
+          "doc_count": 3958
+        },
+        {
+          "key": "678dc436-3370-4992-a361-761dab8c3fda",
+          "doc_count": 3912
+        },
+        {
+          "key": "5f513dff-ccd8-4578-ad0b-5e6cf035e4d1",
+          "doc_count": 3898
+        },
+        {
+          "key": "ceba331e-9da3-44ee-8970-f1eb8d1a68d6",
+          "doc_count": 3777
+        },
+        {
+          "key": "48f5d475-7381-4d06-88eb-119796b9d189",
+          "doc_count": 3752
+        },
+        {
+          "key": "3420d3d5-f142-4db6-951c-5d37cb72ce53",
+          "doc_count": 3687
+        },
+        {
+          "key": "c57817e7-034c-4796-ac47-2bc2191713b3",
+          "doc_count": 3643
+        },
+        {
+          "key": "e647814d-6975-4b34-b8c4-e79b7ca83085",
+          "doc_count": 3601
+        },
+        {
+          "key": "9ea3f46b-f7b9-4b2e-8d4e-a052fbe69de9",
+          "doc_count": 3490
+        },
+        {
+          "key": "33b5b5e7-f4e6-435c-9e0f-bb264d58581b",
+          "doc_count": 3442
+        },
+        {
+          "key": "91f4f1c9-37e3-430b-8020-f8d65af8e422",
+          "doc_count": 3430
+        },
+        {
+          "key": "97e4947d-fce9-4019-9f86-c0d94c820269",
+          "doc_count": 3401
+        },
+        {
+          "key": "30733214-8eb0-4894-b19d-775fe8a617cf",
+          "doc_count": 3360
+        },
+        {
+          "key": "22436fe4-5049-4266-9849-335dd3f161aa",
+          "doc_count": 3244
+        },
+        {
+          "key": "37213da3-a1c7-4644-917e-8f8440e1c4d4",
+          "doc_count": 3214
+        },
+        {
+          "key": "1f5a1b81-e361-4d65-ab1c-6fb7e30c9910",
+          "doc_count": 3182
+        },
+        {
+          "key": "2e4ccf50-bb7d-43a6-9640-088b248c2c5a",
+          "doc_count": 3164
+        },
+        {
+          "key": "0e5201c0-bad2-4e28-9322-5c5dca8862c8",
+          "doc_count": 3154
+        },
+        {
+          "key": "23a47a5f-2ac1-4f81-acd3-21d5b82ed22a",
+          "doc_count": 3135
+        },
+        {
+          "key": "ef59f7cc-ed42-45fc-9abc-5edfb2c8caec",
+          "doc_count": 3089
+        },
+        {
+          "key": "570dcca6-a84f-43aa-8053-1a2ac60d9ead",
+          "doc_count": 3059
+        },
+        {
+          "key": "fd66cee6-5310-4201-9949-0ea04a05b72b",
+          "doc_count": 2995
+        },
+        {
+          "key": "3056112e-97c6-4d0d-b6c2-3c0a9adaca24",
+          "doc_count": 2953
+        },
+        {
+          "key": "1c729855-f3dd-439d-b326-54d62f57b0fd",
+          "doc_count": 2940
+        },
+        {
+          "key": "b4cce5b5-6450-443c-8988-a279b9cefaab",
+          "doc_count": 2937
+        },
+        {
+          "key": "687efa84-c549-4743-a193-72d198d8e19c",
+          "doc_count": 2929
+        },
+        {
+          "key": "5277e72c-9e53-4c98-85f1-ee413bc473cd",
+          "doc_count": 2865
+        },
+        {
+          "key": "57a6bf5f-cda1-41fd-8c12-804c95f74841",
+          "doc_count": 2723
+        },
+        {
+          "key": "e7016bd5-cb10-45b9-8959-0f5750f7a5db",
+          "doc_count": 2704
+        },
+        {
+          "key": "05498053-5a06-45d5-bf6c-dbea1c42cb2b",
+          "doc_count": 2662
+        },
+        {
+          "key": "cb33cf97-2a7b-4b45-9b73-5aca568332a6",
+          "doc_count": 2628
+        },
+        {
+          "key": "04fe30b4-c1e5-4482-addb-67a4c2cd39ef",
+          "doc_count": 2622
+        },
+        {
+          "key": "c1e2b821-96a2-422f-a1fe-7a53aaa2e9bf",
+          "doc_count": 2576
+        },
+        {
+          "key": "1e054b9b-0193-4ff3-b623-9264cf982d4d",
+          "doc_count": 2539
+        },
+        {
+          "key": "8400a716-0aef-4131-9e79-c8ad81d244ad",
+          "doc_count": 2482
+        },
+        {
+          "key": "fd09683f-efe8-446c-9e43-7d11f62e597c",
+          "doc_count": 2480
+        },
+        {
+          "key": "b58043bc-9e47-4a8f-9e4b-5d4c510ea0e1",
+          "doc_count": 2427
+        },
+        {
+          "key": "8295ea14-c4fd-499b-bc68-2907ed36badc",
+          "doc_count": 2414
+        },
+        {
+          "key": "50b0bbe4-f075-4427-8dfc-fcc469dd3e78",
+          "doc_count": 2342
+        },
+        {
+          "key": "361efdf7-9845-411c-90bd-e51ec7991e87",
+          "doc_count": 2322
+        },
+        {
+          "key": "7e4aacd3-0a24-49ab-b019-518b7069b682",
+          "doc_count": 2304
+        },
+        {
+          "key": "d5a1b706-c624-43df-afcf-9cea7094e75b",
+          "doc_count": 2298
+        },
+        {
+          "key": "b590be71-5a03-4f29-bcd4-e91c1b876137",
+          "doc_count": 2225
+        },
+        {
+          "key": "364b1f8d-5975-48d9-bba1-c97ab172986c",
+          "doc_count": 2223
+        },
+        {
+          "key": "ca4e7ee9-06f5-4f93-830c-507a6598ec25",
+          "doc_count": 2221
+        },
+        {
+          "key": "1d17fdad-d338-4ae0-9232-dbf18eaf9f66",
+          "doc_count": 2204
+        },
+        {
+          "key": "042dbdba-a449-4291-8777-577a5a4045de",
+          "doc_count": 2197
+        },
+        {
+          "key": "3c6f1ea5-f2e7-4203-9cfe-74ec2fb1b035",
+          "doc_count": 2189
+        },
+        {
+          "key": "9e1958fb-1dc4-4375-ae35-67ba7f9c7afe",
+          "doc_count": 2140
+        },
+        {
+          "key": "4fed055b-3c46-4ec4-b76d-84d43df9258b",
+          "doc_count": 2138
+        },
+        {
+          "key": "2df867b1-89de-4539-8414-67c47a88f0c8",
+          "doc_count": 2130
+        },
+        {
+          "key": "18cc4ad5-9449-470e-9195-5858b12d822c",
+          "doc_count": 2118
+        },
+        {
+          "key": "92e4e092-6dcb-46bc-85a0-dea8310aba45",
+          "doc_count": 2074
+        },
+        {
+          "key": "12018be6-3795-43a3-a073-a2b9d60c0af3",
+          "doc_count": 2058
+        },
+        {
+          "key": "bf9066a2-2c5f-4cf2-821a-1a68b4df5b1b",
+          "doc_count": 2037
+        },
+        {
+          "key": "0582c7d8-f9f8-4f1b-acab-9bb5598c10c4",
+          "doc_count": 1999
+        },
+        {
+          "key": "b1549ab7-5fc7-4966-a210-0846484fb171",
+          "doc_count": 1959
+        },
+        {
+          "key": "b30a7dd2-d974-4073-bdd0-cb4ea5402bae",
+          "doc_count": 1957
+        },
+        {
+          "key": "341611f4-8b65-4655-b244-9be91a1109cd",
+          "doc_count": 1953
+        },
+        {
+          "key": "0ed6268e-7449-414c-a93c-57ea68f8ab3e",
+          "doc_count": 1941
+        },
+        {
+          "key": "5e2f4c81-8c8a-45f3-a220-851f85f86b40",
+          "doc_count": 1906
+        },
+        {
+          "key": "c7821624-d246-43b8-9dfd-de470f9dc294",
+          "doc_count": 1901
+        },
+        {
+          "key": "50ee2f53-7f79-4808-bceb-3e660fd1e666",
+          "doc_count": 1898
+        },
+        {
+          "key": "3ac8f738-bc3e-43e4-8358-00a32594954d",
+          "doc_count": 1870
+        },
+        {
+          "key": "ad4e4ea0-2ac9-4030-b4bd-bf4206e79bcc",
+          "doc_count": 1870
+        },
+        {
+          "key": "4cd8e87c-93b6-41cc-9189-50585cdb0518",
+          "doc_count": 1868
+        },
+        {
+          "key": "0038ce2e-43bb-4f70-8dd6-dca34efd3fca",
+          "doc_count": 1864
+        },
+        {
+          "key": "c5eeb223-0515-423a-a51a-151426c8f60d",
+          "doc_count": 1862
+        },
+        {
+          "key": "aac5fd7f-8043-4aa8-811f-e50de70d96f3",
+          "doc_count": 1857
+        },
+        {
+          "key": "e23109b4-e143-437c-b329-3dff7cb35488",
+          "doc_count": 1808
+        },
+        {
+          "key": "f016064e-c9c6-4baf-925c-e68e1190bb6d",
+          "doc_count": 1781
+        },
+        {
+          "key": "c3134980-bf5c-49b8-a289-790d45f02c86",
+          "doc_count": 1755
+        },
+        {
+          "key": "f0599190-e5b7-42ed-bec8-810905f50c34",
+          "doc_count": 1733
+        },
+        {
+          "key": "41b166d5-ce08-4efe-99fc-6df77d8fe29e",
+          "doc_count": 1711
+        },
+        {
+          "key": "750a80fe-60b9-423b-aca1-dcc7937d2c84",
+          "doc_count": 1708
+        },
+        {
+          "key": "667a12e7-c6d8-4de0-933f-ce2f07cb7a92",
+          "doc_count": 1686
+        },
+        {
+          "key": "d5b9fb39-d233-4cd0-8682-c4deff1e337b",
+          "doc_count": 1665
+        },
+        {
+          "key": "8f3923b5-4802-40ff-bf98-0acba66691ec",
+          "doc_count": 1650
+        },
+        {
+          "key": "3c367a2d-eec0-4ef1-b3bc-4cbebb320c5a",
+          "doc_count": 1621
+        },
+        {
+          "key": "a4378725-7967-47bc-aada-0220e02e1f96",
+          "doc_count": 1614
+        },
+        {
+          "key": "6ae7221e-2085-46cf-9ad0-353269e95bc8",
+          "doc_count": 1608
+        },
+        {
+          "key": "a2105c9c-b869-4637-8850-eb51ea6b1066",
+          "doc_count": 1590
+        },
+        {
+          "key": "c49bc91d-0a50-497b-8b17-d77808745cf9",
+          "doc_count": 1575
+        },
+        {
+          "key": "e7496fd0-725a-42eb-bf35-af72885b6c0d",
+          "doc_count": 1570
+        },
+        {
+          "key": "fe52a17a-a7aa-4f95-a3ea-26fe640170fe",
+          "doc_count": 1555
+        },
+        {
+          "key": "204fbebc-37cc-4331-a2be-11f38949561c",
+          "doc_count": 1553
+        },
+        {
+          "key": "93e97f6c-0ab6-41a7-9b58-7e230a80ec1e",
+          "doc_count": 1511
+        },
+        {
+          "key": "36be338b-cfb2-47e4-a1fc-b3f7a1aaaf22",
+          "doc_count": 1496
+        },
+        {
+          "key": "d1f70494-b5d9-4c84-973d-e34445b7552b",
+          "doc_count": 1489
+        },
+        {
+          "key": "06c35934-1b75-4196-838d-29d509951bf9",
+          "doc_count": 1476
+        },
+        {
+          "key": "88595487-6d33-4980-ba54-bcf427c9466e",
+          "doc_count": 1458
+        },
+        {
+          "key": "fd62a976-d195-492a-b6f0-f57fef8b6acc",
+          "doc_count": 1433
+        },
+        {
+          "key": "826420a8-3d4a-4cee-901c-f0f2ee9e00b4",
+          "doc_count": 1430
+        },
+        {
+          "key": "a89f64ab-8b3b-4267-b18a-3207d25a45ad",
+          "doc_count": 1430
+        },
+        {
+          "key": "a83151ae-e1db-4166-9dde-438f6544dca9",
+          "doc_count": 1399
+        },
+        {
+          "key": "28a8561d-4699-4c90-823b-686d6207d675",
+          "doc_count": 1398
+        },
+        {
+          "key": "c8eeddef-b903-4aa3-a0fb-44344b8bf301",
+          "doc_count": 1398
+        },
+        {
+          "key": "8096525f-6f67-4bd2-a160-48ed4bea8aa7",
+          "doc_count": 1388
+        },
+        {
+          "key": "f89ada44-88df-46f0-bc61-cc46d9c84673",
+          "doc_count": 1371
+        },
+        {
+          "key": "e34cf41b-196c-4199-85d5-4d2ca5954b09",
+          "doc_count": 1343
+        },
+        {
+          "key": "d38fd1e8-bc15-46b2-92d5-5f3df98cff53",
+          "doc_count": 1336
+        },
+        {
+          "key": "1bfc0147-2df1-4488-bcf7-d140e24dda51",
+          "doc_count": 1318
+        },
+        {
+          "key": "dbb2acdc-a808-4deb-9dc2-542d70368a3f",
+          "doc_count": 1318
+        },
+        {
+          "key": "7e44229a-e8fa-4570-ada1-0cd7843a66d7",
+          "doc_count": 1315
+        },
+        {
+          "key": "6b2c3ca9-69ad-4316-a2d1-33399e9f547e",
+          "doc_count": 1293
+        },
+        {
+          "key": "b12b08da-3d05-4406-a051-0139a33ecf35",
+          "doc_count": 1289
+        },
+        {
+          "key": "67893f3c-c409-41c6-a8f2-47956739a911",
+          "doc_count": 1231
+        },
+        {
+          "key": "3fe3a250-0f48-4a9b-bb71-36d798694912",
+          "doc_count": 1222
+        },
+        {
+          "key": "6d09cfc1-a17c-4067-b1a0-557b8e5334ea",
+          "doc_count": 1218
+        },
+        {
+          "key": "c7ae0ade-c23e-4fe6-a3d4-79bd973374c2",
+          "doc_count": 1193
+        },
+        {
+          "key": "53aa69a7-bd66-468b-8ffa-ec6cb06d7d8d",
+          "doc_count": 1191
+        },
+        {
+          "key": "589ee0cf-456c-4d9c-8e7e-3adc3cec0e09",
+          "doc_count": 1171
+        },
+        {
+          "key": "bd211251-f857-4110-89df-ae59772e44c9",
+          "doc_count": 1159
+        },
+        {
+          "key": "151075fa-f464-4d76-9064-b24aa945b30f",
+          "doc_count": 1123
+        },
+        {
+          "key": "662b1aa5-9c19-4eb9-9766-1da78a117456",
+          "doc_count": 1109
+        },
+        {
+          "key": "bc93e4c6-fd85-4412-987f-52f6fa3bb67d",
+          "doc_count": 1093
+        },
+        {
+          "key": "d14d21fe-da24-47e5-81fb-4bfe962ce828",
+          "doc_count": 1070
+        },
+        {
+          "key": "5663707e-1f94-40a1-97f3-aaeff1d41d20",
+          "doc_count": 1066
+        },
+        {
+          "key": "0bffd75c-2c42-4119-bae7-1ca6d8eb4d1a",
+          "doc_count": 1049
+        },
+        {
+          "key": "5ffc8bc6-e366-4157-b1ba-00859f1048a4",
+          "doc_count": 1033
+        },
+        {
+          "key": "5f6fcfc2-598c-42e8-abb3-50ca9c2446e2",
+          "doc_count": 1024
+        },
+        {
+          "key": "74ba1d92-d9a5-486e-8e52-bb44d51e1788",
+          "doc_count": 1022
+        },
+        {
+          "key": "86b2bfc9-ca99-4250-b93a-f86f3777236d",
+          "doc_count": 1020
+        },
+        {
+          "key": "2941b767-e90b-41b9-9627-6e589e0c0c85",
+          "doc_count": 1014
+        },
+        {
+          "key": "1fc07b28-43f5-49d1-badf-63005e1c3e9a",
+          "doc_count": 1011
+        },
+        {
+          "key": "3799e4f9-f685-4796-99b5-f78524441b93",
+          "doc_count": 1007
+        },
+        {
+          "key": "de67ccab-7d04-43b9-8083-81e45f628505",
+          "doc_count": 998
+        },
+        {
+          "key": "f39780bd-7108-4685-8e6a-b340ff5a5965",
+          "doc_count": 987
+        },
+        {
+          "key": "2c84db50-bab1-40a6-a9ef-405f3ffcec7e",
+          "doc_count": 976
+        },
+        {
+          "key": "bfa3c276-a3a9-48cd-8d4a-4ac42f4fe10a",
+          "doc_count": 962
+        },
+        {
+          "key": "d5c32031-231f-4213-b0f1-2dc4bbf711a0",
+          "doc_count": 961
+        },
+        {
+          "key": "b133b7cb-c0a1-4cd7-9775-cbc78fea50fc",
+          "doc_count": 957
+        },
+        {
+          "key": "d07e7b8a-2222-477f-a7f3-f098bbfdaf54",
+          "doc_count": 952
+        },
+        {
+          "key": "d1de8464-14d4-43da-8a57-9792fc34d4bf",
+          "doc_count": 948
+        },
+        {
+          "key": "a5b1b714-7470-4635-805d-a0cdcc6a6a4b",
+          "doc_count": 930
+        },
+        {
+          "key": "2532cbd0-2752-4211-b249-4a9811a280f2",
+          "doc_count": 929
+        },
+        {
+          "key": "954ec5e0-4fcd-414d-8ad2-46b4b75cfc74",
+          "doc_count": 928
+        },
+        {
+          "key": "79aa7602-a963-44f3-82dd-e141a387adb8",
+          "doc_count": 909
+        },
+        {
+          "key": "e701ecce-f9ab-445f-afcb-24f279efbc9c",
+          "doc_count": 900
+        },
+        {
+          "key": "bfb53140-79c1-4625-81aa-3f37de7c0c2f",
+          "doc_count": 843
+        },
+        {
+          "key": "8b196eb7-1fbf-4eac-9f58-1fccae076f7f",
+          "doc_count": 831
+        },
+        {
+          "key": "b0e9fd61-1e0f-408f-b035-d7952614d7f3",
+          "doc_count": 823
+        },
+        {
+          "key": "e01f53f2-8e1b-41cb-9e5a-3dfb3ccf44d6",
+          "doc_count": 810
+        },
+        {
+          "key": "414a5bf5-061e-4e47-8410-0f76a04f7d1d",
+          "doc_count": 798
+        },
+        {
+          "key": "dcc8c1ac-38c7-4ada-a389-f4aceeacb531",
+          "doc_count": 798
+        },
+        {
+          "key": "e8c034d5-c2c7-4f23-8dc0-7f94f4116306",
+          "doc_count": 795
+        },
+        {
+          "key": "473400bf-fe83-4bd6-9f69-c4608f4cdf4f",
+          "doc_count": 786
+        },
+        {
+          "key": "5d0a9aa8-91f2-4fa4-b4df-554a4221dfcb",
+          "doc_count": 781
+        },
+        {
+          "key": "1da8098a-1e82-4b8b-bf81-d30e423cdaba",
+          "doc_count": 766
+        },
+        {
+          "key": "5486b66d-2082-433d-9223-bd789ebca29c",
+          "doc_count": 765
+        },
+        {
+          "key": "1720ead7-9d20-4179-8998-2a59b8bfa8d7",
+          "doc_count": 748
+        },
+        {
+          "key": "745caa9d-02be-4a67-a142-103282aa0bda",
+          "doc_count": 737
+        },
+        {
+          "key": "899855ee-4fd9-4e85-9033-880058303b5c",
+          "doc_count": 719
+        },
+        {
+          "key": "6f470382-cb0b-4634-a796-2248bfa97fdc",
+          "doc_count": 707
+        },
+        {
+          "key": "bf5b0620-1ff0-45af-a2eb-96f3c739edf2",
+          "doc_count": 707
+        },
+        {
+          "key": "2f740a87-8049-435d-9d06-1c393c9c11b7",
+          "doc_count": 700
+        },
+        {
+          "key": "9cd34069-24ca-4ae8-9c10-78ccfac6523d",
+          "doc_count": 690
+        },
+        {
+          "key": "5e24c385-dab9-40a3-a2dd-2cf8758821b6",
+          "doc_count": 677
+        },
+        {
+          "key": "f0bb124f-5840-41ea-98ab-b8fd8802ea5f",
+          "doc_count": 669
+        },
+        {
+          "key": "f08c31ea-0e90-4cc1-b471-dfd0584ae7cf",
+          "doc_count": 653
+        },
+        {
+          "key": "fdf98e60-9feb-4b86-a42e-ae6c7152d02c",
+          "doc_count": 648
+        },
+        {
+          "key": "4960f30c-c1c7-490e-966a-61ad02969e38",
+          "doc_count": 642
+        },
+        {
+          "key": "ac8c109d-b69c-4359-87f4-8714f8c8a65d",
+          "doc_count": 638
+        },
+        {
+          "key": "73236de8-c2cc-458c-b0c3-743c7b57db3a",
+          "doc_count": 630
+        },
+        {
+          "key": "902f9e08-9180-4f12-97b6-d8662f2b583f",
+          "doc_count": 623
+        },
+        {
+          "key": "b4154ce7-8145-4fd8-92ed-edd124d53730",
+          "doc_count": 617
+        },
+        {
+          "key": "a73b61c5-812c-453b-b12b-5c65929e947a",
+          "doc_count": 608
+        },
+        {
+          "key": "c892f8d1-108c-44f7-9458-0abb96633976",
+          "doc_count": 590
+        },
+        {
+          "key": "a4babe52-5740-44e4-9ea2-acef4797f127",
+          "doc_count": 576
+        },
+        {
+          "key": "6d99bdeb-a96f-47bf-8e28-ce1093347335",
+          "doc_count": 571
+        },
+        {
+          "key": "b6ebfa9d-fed3-4e0c-8877-47c1190f346c",
+          "doc_count": 568
+        },
+        {
+          "key": "afd773b8-280f-4a0f-98a7-7977b7e1ca24",
+          "doc_count": 562
+        },
+        {
+          "key": "964c24a3-cca4-4028-a0d8-b83513d14b7d",
+          "doc_count": 561
+        },
+        {
+          "key": "724dc40a-421c-44f8-b426-969f99fa8a1c",
+          "doc_count": 552
+        },
+        {
+          "key": "fe04dab1-5a3d-4c28-a450-012658e982d8",
+          "doc_count": 510
+        },
+        {
+          "key": "677f57a9-9a0d-4e69-8622-96aa1e6392c2",
+          "doc_count": 509
+        },
+        {
+          "key": "43c69d2a-0fd2-4d34-a1ef-50d0f9c01353",
+          "doc_count": 506
+        },
+        {
+          "key": "282fe9c2-d6cb-4325-b3b5-b70ab1d22bbb",
+          "doc_count": 504
+        },
+        {
+          "key": "69d150df-eba4-4ab3-9156-71cb0db41830",
+          "doc_count": 504
+        },
+        {
+          "key": "f5d395b8-c3c9-43df-b4ff-63d65c6a971e",
+          "doc_count": 504
+        },
+        {
+          "key": "b26cc2c9-1141-4502-805a-b9dd1d83c321",
+          "doc_count": 503
+        },
+        {
+          "key": "8bcb95b2-ab5c-4368-8ead-14588eeb9c98",
+          "doc_count": 502
+        },
+        {
+          "key": "3a0d8092-c577-4775-a586-1542574edc53",
+          "doc_count": 495
+        },
+        {
+          "key": "8dfc3d88-8f6b-4432-b69c-534717906004",
+          "doc_count": 495
+        },
+        {
+          "key": "33bac15d-b1d0-42a1-8801-86149887eeef",
+          "doc_count": 494
+        },
+        {
+          "key": "90e07356-df5d-4372-a2c4-34927db9a3ec",
+          "doc_count": 488
+        },
+        {
+          "key": "431b56fc-d016-459a-97ab-1e9c8168a7f0",
+          "doc_count": 487
+        },
+        {
+          "key": "a8cafd75-ca3b-42c6-8b8e-52aafa15753b",
+          "doc_count": 487
+        },
+        {
+          "key": "2d4658e3-0d1a-43fc-97ff-b4813dd1f86e",
+          "doc_count": 479
+        },
+        {
+          "key": "6e922c92-b37d-4c46-8982-19d945ff8fd1",
+          "doc_count": 463
+        },
+        {
+          "key": "7886c689-ed46-47e9-8dba-4c0468212c65",
+          "doc_count": 461
+        },
+        {
+          "key": "2d47501f-dbed-43ce-a9c3-9c8542648ce4",
+          "doc_count": 460
+        },
+        {
+          "key": "be72355e-a5d6-4094-8635-0127dfb510aa",
+          "doc_count": 456
+        },
+        {
+          "key": "cb2973af-0d5a-4fbf-80ab-ec96ede33ef0",
+          "doc_count": 454
+        },
+        {
+          "key": "f1960cd5-e27a-40f0-b4bd-3ca7157e4bbb",
+          "doc_count": 448
+        },
+        {
+          "key": "0f65c2e4-fc98-4a2c-bfbe-24de6ab1feb6",
+          "doc_count": 447
+        },
+        {
+          "key": "5db52f01-8d71-43e5-b835-0ff7d33d715b",
+          "doc_count": 439
+        },
+        {
+          "key": "3a5b5c9b-b241-4883-904a-b167a7edb41a",
+          "doc_count": 426
+        },
+        {
+          "key": "046a2685-be26-4d6e-80cc-d95e907922fa",
+          "doc_count": 425
+        },
+        {
+          "key": "b10b9eb2-3786-4483-8b73-3cfdf1a9eb90",
+          "doc_count": 421
+        },
+        {
+          "key": "ea9de87b-7231-4a05-809f-4b658ea4173d",
+          "doc_count": 407
+        },
+        {
+          "key": "aeed0286-ffe4-45b8-a7b9-bcee18361433",
+          "doc_count": 398
+        },
+        {
+          "key": "5af1bae4-35c0-4ab7-9d08-08bbe22ca003",
+          "doc_count": 392
+        },
+        {
+          "key": "5ab348ab-439a-4697-925c-d6abe0c09b92",
+          "doc_count": 390
+        },
+        {
+          "key": "945d6d7d-c768-4189-be9d-f693104d590c",
+          "doc_count": 381
+        },
+        {
+          "key": "d4711660-a622-4c15-adb8-608b7ac6a084",
+          "doc_count": 380
+        },
+        {
+          "key": "0fb6618f-f8d6-4361-8b2d-0923d4aa3c09",
+          "doc_count": 379
+        },
+        {
+          "key": "a50e98bd-13e9-41fe-a5cc-aee4f240628b",
+          "doc_count": 371
+        },
+        {
+          "key": "2b21081c-d5e9-49bd-b29a-0b6e4a551b78",
+          "doc_count": 370
+        },
+        {
+          "key": "7fbf76b1-6bd6-4217-a5bc-1d89e45f6a68",
+          "doc_count": 364
+        },
+        {
+          "key": "d1983d53-434a-436e-a698-3a2745eb61dc",
+          "doc_count": 359
+        },
+        {
+          "key": "fe51bced-93ce-45b2-b0c6-f7256719a07b",
+          "doc_count": 359
+        },
+        {
+          "key": "b7a5dadd-7429-489b-9b3b-72abcd9518a3",
+          "doc_count": 355
+        },
+        {
+          "key": "6226705f-4867-464d-9fab-4e81ecee731f",
+          "doc_count": 354
+        },
+        {
+          "key": "1a44dfa0-6a54-4584-8c57-d98669d7f033",
+          "doc_count": 353
+        },
+        {
+          "key": "535d4a21-8650-41d0-b92f-b6c028db13e2",
+          "doc_count": 352
+        },
+        {
+          "key": "9d35f82b-c19b-4dce-b296-808598d1fb6b",
+          "doc_count": 352
+        },
+        {
+          "key": "350ed733-b782-4195-a5dd-e61e5c82d837",
+          "doc_count": 349
+        },
+        {
+          "key": "c13a5966-99a3-4383-b9ef-259cf46800fe",
+          "doc_count": 348
+        },
+        {
+          "key": "03e04b8e-1dea-49ac-8a46-4276ddcfed21",
+          "doc_count": 345
+        },
+        {
+          "key": "feb74628-8724-466f-8c8c-b3d3b72f2417",
+          "doc_count": 341
+        },
+        {
+          "key": "080aa588-2f4c-4d65-8a55-f0b83e8aa7e6",
+          "doc_count": 330
+        },
+        {
+          "key": "a0ec3ce6-fc8a-48b7-9105-cecf27602e37",
+          "doc_count": 326
+        },
+        {
+          "key": "7915973f-a3b0-4d2c-86e7-02d40647393c",
+          "doc_count": 322
+        },
+        {
+          "key": "7e43ea77-d2e5-4bdc-a4f7-a4792866f53f",
+          "doc_count": 319
+        },
+        {
+          "key": "6f510e69-96b2-4817-bab7-3a36c8250c79",
+          "doc_count": 314
+        },
+        {
+          "key": "212dcc45-bf5b-43d8-a804-3351c04c2f7a",
+          "doc_count": 312
+        },
+        {
+          "key": "7026b70a-7245-42bd-8162-81ae9a6cfbcb",
+          "doc_count": 309
+        },
+        {
+          "key": "8ed556b0-b801-4575-ae53-db7cacbfd0c9",
+          "doc_count": 309
+        },
+        {
+          "key": "6d710d01-54f6-448b-bbf9-adee9e46fc3c",
+          "doc_count": 301
+        },
+        {
+          "key": "a69decc7-76ba-496a-a66e-f91049c02cf0",
+          "doc_count": 301
+        },
+        {
+          "key": "8e2f9392-55ac-49f3-bcc2-131a00122626",
+          "doc_count": 295
+        },
+        {
+          "key": "af4f13cd-f1e8-4e18-ac7a-b0aeee90c749",
+          "doc_count": 294
+        },
+        {
+          "key": "7f497d81-4c7e-4e06-b166-a459968b14e3",
+          "doc_count": 289
+        },
+        {
+          "key": "a0546df1-b727-402f-b9b8-570e65e58026",
+          "doc_count": 289
+        },
+        {
+          "key": "68abd0b8-cff1-4c84-a2d9-bd4ac6df4fa4",
+          "doc_count": 285
+        },
+        {
+          "key": "25972252-d6b1-4b52-b4b8-64d09d7e7da1",
+          "doc_count": 268
+        },
+        {
+          "key": "9f3bbc7b-c682-4f66-88b3-48eef3a38f38",
+          "doc_count": 268
+        },
+        {
+          "key": "40d35f62-cf89-488a-bad3-66e66d38c10c",
+          "doc_count": 260
+        },
+        {
+          "key": "37287863-bf14-438e-a194-cc2ee7ae24be",
+          "doc_count": 256
+        },
+        {
+          "key": "58afd7df-a696-4dd6-a765-540f8b31c07d",
+          "doc_count": 256
+        },
+        {
+          "key": "9d9016ef-a88f-4312-a0bf-638fc4be53ba",
+          "doc_count": 251
+        },
+        {
+          "key": "7b1f4ee4-7f50-4c82-9007-ba76528a84df",
+          "doc_count": 247
+        },
+        {
+          "key": "2cebadf7-6d52-49b2-b3a7-d4969a36aa12",
+          "doc_count": 236
+        },
+        {
+          "key": "90739622-5232-4048-8121-9af9ec69604f",
+          "doc_count": 226
+        },
+        {
+          "key": "ef967959-19e5-4e21-8821-89f822d3303b",
+          "doc_count": 225
+        },
+        {
+          "key": "23b85d9d-4669-40db-901f-aaad686fe0b8",
+          "doc_count": 220
+        },
+        {
+          "key": "f3327705-8d69-4d9c-88b7-584a08c74653",
+          "doc_count": 218
+        },
+        {
+          "key": "64b54f96-91f0-4442-b6de-173aa1a5c31b",
+          "doc_count": 215
+        },
+        {
+          "key": "560b2536-a07e-46c0-b179-6ba1ba6f5b20",
+          "doc_count": 214
+        },
+        {
+          "key": "e2fda823-8a6e-4bd8-8602-924615373938",
+          "doc_count": 213
+        },
+        {
+          "key": "23655eb9-7798-4865-9a92-1dbbc609511d",
+          "doc_count": 212
+        },
+        {
+          "key": "2fe72860-9220-4acd-894b-81b4d98a5e24",
+          "doc_count": 209
+        },
+        {
+          "key": "c22f048c-6f77-4488-a203-865537dddba9",
+          "doc_count": 203
+        },
+        {
+          "key": "f8e830e3-9b0d-4e5d-9f24-9f2ed3b465da",
+          "doc_count": 202
+        },
+        {
+          "key": "781b461a-2788-4fa6-b3df-bbed9447f5a3",
+          "doc_count": 194
+        },
+        {
+          "key": "99e84c7d-dd3c-40d9-9526-54f4342cda95",
+          "doc_count": 193
+        },
+        {
+          "key": "4c9d08ce-71c1-47b8-a572-2d40e5984c49",
+          "doc_count": 192
+        },
+        {
+          "key": "78bb515d-4508-45d6-94e2-e53638ce2fe4",
+          "doc_count": 191
+        },
+        {
+          "key": "55ddd3f9-0e9a-40e8-9e8f-d3a3ab871434",
+          "doc_count": 190
+        },
+        {
+          "key": "9e66257f-21a9-491a-ac23-06b7b62ceeb7",
+          "doc_count": 189
+        },
+        {
+          "key": "997c4dda-0465-40c0-af8d-67f8f90dea3b",
+          "doc_count": 187
+        },
+        {
+          "key": "d08a71aa-fe87-4bf5-ac68-8e7497bf585c",
+          "doc_count": 187
+        },
+        {
+          "key": "b0a3324f-849a-43bf-811a-9dd10f04806b",
+          "doc_count": 184
+        },
+        {
+          "key": "0ed0b942-198e-4500-8fe0-1d1ef0785454",
+          "doc_count": 183
+        },
+        {
+          "key": "a9b8572c-ec86-4e6b-9ed9-03d939b7f363",
+          "doc_count": 183
+        },
+        {
+          "key": "f5c38252-89f1-4753-af3a-da8818fe3a86",
+          "doc_count": 182
+        },
+        {
+          "key": "50ca2a08-0e76-4f56-9976-d344dd201a9b",
+          "doc_count": 178
+        },
+        {
+          "key": "abbf4722-c63b-492f-b183-cb45ad9f5211",
+          "doc_count": 177
+        },
+        {
+          "key": "a72205bf-d800-46a4-83a8-5fae54cdf877",
+          "doc_count": 174
+        },
+        {
+          "key": "b7704325-2dfd-4fcf-8193-01b5bdce825d",
+          "doc_count": 172
+        },
+        {
+          "key": "b1f0612a-bc21-424f-b9c1-3bba69ad4f54",
+          "doc_count": 171
+        },
+        {
+          "key": "92f0b5e8-27b5-48ae-be72-616657821f7b",
+          "doc_count": 169
+        },
+        {
+          "key": "d36887a2-9f9a-44af-887a-5bb95d09a83b",
+          "doc_count": 167
+        },
+        {
+          "key": "394dda75-c336-4ca3-acdd-1c2a317d7361",
+          "doc_count": 164
+        },
+        {
+          "key": "b6d0f953-29b4-41da-a255-2ed07c83edf1",
+          "doc_count": 164
+        },
+        {
+          "key": "0a410c4a-cd4f-4bd8-b6ba-a0c2baa37622",
+          "doc_count": 154
+        },
+        {
+          "key": "a77b7747-8a1e-40ff-8c63-fb9087cc099d",
+          "doc_count": 154
+        },
+        {
+          "key": "5a9ae910-9e4b-488b-af8e-88074fabc3a4",
+          "doc_count": 145
+        },
+        {
+          "key": "921cf6ba-3f58-41ac-90fb-33fa4ec6b282",
+          "doc_count": 144
+        },
+        {
+          "key": "ab3c6b74-477b-4f79-8711-0643851021f0",
+          "doc_count": 144
+        },
+        {
+          "key": "41800344-33b3-4201-b9d2-cabbbf564fbc",
+          "doc_count": 140
+        },
+        {
+          "key": "11f88400-8e44-4592-88e4-9d2ce4f37716",
+          "doc_count": 136
+        },
+        {
+          "key": "3a771a31-8cd0-40ac-befc-69509201b61b",
+          "doc_count": 133
+        },
+        {
+          "key": "2bfc480c-e5b3-4a9b-9587-a92c22830ace",
+          "doc_count": 132
+        },
+        {
+          "key": "9a861ebe-f8d7-4eb1-a2c8-3006f07cfec2",
+          "doc_count": 131
+        },
+        {
+          "key": "1f2933c1-3f7a-4521-9b16-2c34b369ee95",
+          "doc_count": 130
+        },
+        {
+          "key": "3ef3ced6-9fa0-4d30-98b4-2d1337d2477d",
+          "doc_count": 121
+        },
+        {
+          "key": "fb33ec4c-1bab-48f2-9faf-a5205a9a2c37",
+          "doc_count": 117
+        },
+        {
+          "key": "41b119de-f745-482d-be42-a0155bc76e5d",
+          "doc_count": 116
+        },
+        {
+          "key": "879d475f-4b76-4d18-8cf6-a7e5a6d44926",
+          "doc_count": 110
+        },
+        {
+          "key": "886f3b02-e2f2-4c49-9ace-df25bf5d091a",
+          "doc_count": 110
+        },
+        {
+          "key": "688b7731-d818-4063-b29d-666bd0024b8b",
+          "doc_count": 109
+        },
+        {
+          "key": "97c1db9d-b3c1-4c05-9b55-e99c37773a29",
+          "doc_count": 109
+        },
+        {
+          "key": "a6966178-9495-4093-9cb2-dfed4acddde6",
+          "doc_count": 105
+        },
+        {
+          "key": "94b17bab-a41a-4cb2-8ae4-209e31c5144d",
+          "doc_count": 96
+        },
+        {
+          "key": "383d5325-b1ae-4739-b5ff-8afc4e30a0db",
+          "doc_count": 92
+        },
+        {
+          "key": "3eb6d387-985a-4eed-be62-3fcfc26534cd",
+          "doc_count": 88
+        },
+        {
+          "key": "c44e18ab-837b-4a58-b8df-dc521a173029",
+          "doc_count": 88
+        },
+        {
+          "key": "53a8ce69-d9b9-4ae2-848a-dab0d4d810d1",
+          "doc_count": 86
+        },
+        {
+          "key": "67174355-6ee7-4a4c-af45-60e848973853",
+          "doc_count": 82
+        },
+        {
+          "key": "d29aa22a-03d0-4b01-b18b-fec07cea3db8",
+          "doc_count": 82
+        },
+        {
+          "key": "72f0493a-b4a7-4d0c-a3ea-dab177a95a61",
+          "doc_count": 81
+        },
+        {
+          "key": "4efa0623-a625-4949-aea4-7cb60a99b6f8",
+          "doc_count": 77
+        },
+        {
+          "key": "7ae4d15d-62e2-459b-842a-446f921b9d3f",
+          "doc_count": 76
+        },
+        {
+          "key": "b027383d-6705-4d06-8514-db6ef16efdb5",
+          "doc_count": 75
+        },
+        {
+          "key": "f0f0731a-e2c2-415e-a41c-9f514296844c",
+          "doc_count": 75
+        },
+        {
+          "key": "f5118065-6cf3-402d-a35d-8fdd2830f4da",
+          "doc_count": 73
+        },
+        {
+          "key": "6f2cd35e-9ee6-44d5-b182-cdd19d01a4c3",
+          "doc_count": 72
+        },
+        {
+          "key": "6c6f34ed-58a4-4ba2-b9c7-34524f79a349",
+          "doc_count": 71
+        },
+        {
+          "key": "ce98b978-4542-45c6-aecf-79cf3f6979ed",
+          "doc_count": 71
+        },
+        {
+          "key": "751b5d4c-aba7-4c1f-b0a1-dfe2e9346d1b",
+          "doc_count": 68
+        },
+        {
+          "key": "9ef0bd4b-c016-4791-8a3f-a99c218c1d29",
+          "doc_count": 68
+        },
+        {
+          "key": "1bc74afb-698f-43a7-90e6-352dba6c74da",
+          "doc_count": 64
+        },
+        {
+          "key": "c96ca51c-908e-41cc-ae10-ac1fb72ca3d9",
+          "doc_count": 62
+        },
+        {
+          "key": "cc05ec4b-2d82-4d89-a43c-e313c8641cf5",
+          "doc_count": 60
+        },
+        {
+          "key": "65d603ef-19be-4d6f-92dc-76c5e4220175",
+          "doc_count": 59
+        },
+        {
+          "key": "028990be-11ff-4c6b-9684-59cb1e1c3ab6",
+          "doc_count": 58
+        },
+        {
+          "key": "f4573d80-dd92-4337-9005-ba71e8a8563a",
+          "doc_count": 58
+        },
+        {
+          "key": "9c4f4765-2d02-452c-9ae9-cdd1d4846d5d",
+          "doc_count": 57
+        },
+        {
+          "key": "b1db48d5-22e7-4f5e-bce2-d267b447cdaa",
+          "doc_count": 57
+        },
+        {
+          "key": "466ee466-51d5-4bab-99e6-92e534e6877b",
+          "doc_count": 55
+        },
+        {
+          "key": "97b858df-0110-4d27-a891-75e6a0f18938",
+          "doc_count": 53
+        },
+        {
+          "key": "b80d24e8-17ff-4092-88d7-7e5ad11c117a",
+          "doc_count": 53
+        },
+        {
+          "key": "ecd540e2-b2b5-452f-b5e8-d54aac884f49",
+          "doc_count": 53
+        },
+        {
+          "key": "a1b2bdfd-00c7-4c31-8046-2c991ca777d0",
+          "doc_count": 52
+        },
+        {
+          "key": "4ecc6eb6-5f2f-4b00-8d26-a58bfa0e7f02",
+          "doc_count": 46
+        },
+        {
+          "key": "3602074e-1160-46a8-b796-349eb14b598a",
+          "doc_count": 45
+        },
+        {
+          "key": "b101e53b-8934-42ef-92db-904c226f29a8",
+          "doc_count": 45
+        },
+        {
+          "key": "4b05f088-74a4-44a5-a161-8b1484efc240",
+          "doc_count": 39
+        },
+        {
+          "key": "85ae9fb4-de87-41ce-abb3-44fda2fb24a8",
+          "doc_count": 34
+        },
+        {
+          "key": "8e58cd34-3cbb-46f7-9c25-527251881a6f",
+          "doc_count": 33
+        },
+        {
+          "key": "de41423b-7326-413a-880f-58176ef95ec7",
+          "doc_count": 29
+        },
+        {
+          "key": "c1fa848f-ec37-4cdb-930b-c38de2ae63e6",
+          "doc_count": 27
+        },
+        {
+          "key": "908ccd97-c8e1-4c7c-9871-7a80e2940032",
+          "doc_count": 26
+        },
+        {
+          "key": "b9d08bac-6b78-484b-9a96-da61552f53a5",
+          "doc_count": 26
+        },
+        {
+          "key": "384a1909-f66c-4551-9b26-ea985cd9ccd8",
+          "doc_count": 24
+        },
+        {
+          "key": "72161544-62e7-4e30-b399-ac8115c3a250",
+          "doc_count": 22
+        },
+        {
+          "key": "199dc2c5-b3fb-40e4-bbbb-0b5ef2bbf777",
+          "doc_count": 21
+        },
+        {
+          "key": "9357e02f-20fc-4bc5-9bcb-dc8abcbebf16",
+          "doc_count": 19
+        },
+        {
+          "key": "9e8c4024-45b1-4c06-854d-9f6d807dae67",
+          "doc_count": 19
+        },
+        {
+          "key": "e78939ad-42a2-4908-b914-baf5a33fabe0",
+          "doc_count": 19
+        },
+        {
+          "key": "ec6cef7d-d8aa-43b4-b352-908f172a378e",
+          "doc_count": 19
+        },
+        {
+          "key": "7c2c5cdc-80e6-49d5-8e95-08fc7da0a370",
+          "doc_count": 18
+        },
+        {
+          "key": "08fdc20d-be37-4dc4-97ef-abddffdc825a",
+          "doc_count": 17
+        },
+        {
+          "key": "53091d18-f173-4fc0-b9d9-20a1494e2466",
+          "doc_count": 16
+        },
+        {
+          "key": "ba0cbea4-9a25-49de-bfb4-02201b392f5e",
+          "doc_count": 16
+        },
+        {
+          "key": "433d3c37-8dde-42e4-a344-2cb6605c5da2",
+          "doc_count": 15
+        },
+        {
+          "key": "63ce9d6b-ec89-4e17-880d-c0a31acb4a6d",
+          "doc_count": 15
+        },
+        {
+          "key": "8b727955-5ef2-4339-b5af-e17177377470",
+          "doc_count": 15
+        },
+        {
+          "key": "a9223e1d-7a81-4311-800e-211c5a1b8205",
+          "doc_count": 15
+        },
+        {
+          "key": "5076f892-a05d-4018-9c2c-d537a22095af",
+          "doc_count": 14
+        },
+        {
+          "key": "cdb6ec43-935e-4da2-8798-71e40ca6d12a",
+          "doc_count": 14
+        },
+        {
+          "key": "b33e9dc3-8e86-40ab-a0bd-d11d817ea370",
+          "doc_count": 13
+        },
+        {
+          "key": "ecb0a329-c019-4a59-abe3-fa7e72055902",
+          "doc_count": 13
+        },
+        {
+          "key": "4c46db9d-74d7-4e45-9ed2-0da40ec6b44f",
+          "doc_count": 12
+        },
+        {
+          "key": "9835e4d7-a817-430f-9f55-5fc3325e4399",
+          "doc_count": 12
+        },
+        {
+          "key": "bb83e45d-1ed3-41ed-834a-f0f7cff4c464",
+          "doc_count": 11
+        },
+        {
+          "key": "139f2c47-4051-4c44-b95a-45fd20b1a8b9",
+          "doc_count": 9
+        },
+        {
+          "key": "7f7939c8-5276-4fbb-b12c-de89a5a8044f",
+          "doc_count": 9
+        },
+        {
+          "key": "a2bc3d61-3c37-4aca-b47d-c3413f7e3b87",
+          "doc_count": 9
+        },
+        {
+          "key": "3617a6a3-d384-48de-948d-2d1e1c54e090",
+          "doc_count": 8
+        },
+        {
+          "key": "5a660a44-afdd-45ac-8c48-1a6c570ce0b5",
+          "doc_count": 8
+        },
+        {
+          "key": "f2696243-01cd-4b91-9c13-1b30c8a85898",
+          "doc_count": 8
+        },
+        {
+          "key": "9f4ed3ee-33f7-47e9-a4a5-a1224fec2b6e",
+          "doc_count": 7
+        },
+        {
+          "key": "72059315-e131-42ba-b7c6-489415e297b9",
+          "doc_count": 6
+        },
+        {
+          "key": "25e4ea2d-74ef-4251-b461-6ceb3c812bf1",
+          "doc_count": 5
+        },
+        {
+          "key": "0e162e0a-bf3e-4710-9357-44258ca12abb",
+          "doc_count": 4
+        },
+        {
+          "key": "2cf2843f-567c-45c1-a328-cc210af76fc1",
+          "doc_count": 4
+        },
+        {
+          "key": "d4ea4495-c4b2-4d05-b524-163423f17cd7",
+          "doc_count": 4
+        },
+        {
+          "key": "2292f5d5-d39f-4944-be72-fa5dd62f581c",
+          "doc_count": 3
+        },
+        {
+          "key": "2e96b570-4567-4538-add2-bca9552f6d32",
+          "doc_count": 3
+        },
+        {
+          "key": "5626f61a-822e-4692-b432-51f53d053e4d",
+          "doc_count": 3
+        },
+        {
+          "key": "667c2736-bcd3-4a6a-abf4-db5d2dc815c4",
+          "doc_count": 3
+        },
+        {
+          "key": "b5f4526b-f4fb-4d90-8ce0-975e0cda8ff6",
+          "doc_count": 3
+        },
+        {
+          "key": "00049fe7-5ca2-4936-be50-c736221ef186",
+          "doc_count": 2
+        },
+        {
+          "key": "59428ba2-556f-4179-a9e6-3926f09e0bf3",
+          "doc_count": 2
+        },
+        {
+          "key": "5aef068f-efd3-4851-a623-f542e97350cd",
+          "doc_count": 2
+        },
+        {
+          "key": "6aad3ea3-3c10-4eb5-8c42-3e12c3429c67",
+          "doc_count": 2
+        },
+        {
+          "key": "8f886a6c-a477-42b0-8587-db4832177be9",
+          "doc_count": 2
+        },
+        {
+          "key": "a8823dd5-32d7-4465-932b-accdf76ef4ff",
+          "doc_count": 2
+        },
+        {
+          "key": "c9dad611-5e60-4456-934e-75b0e0842ddd",
+          "doc_count": 2
+        },
+        {
+          "key": "dbb14b3f-3a6b-4f3c-872d-9a5a28064a61",
+          "doc_count": 2
+        },
+        {
+          "key": "f00b6a32-5337-406b-a850-17f5d78470ad",
+          "doc_count": 2
+        },
+        {
+          "key": "02266d50-00a1-4933-bfa3-97abbdb4870a",
+          "doc_count": 1
+        },
+        {
+          "key": "4305303f-976d-4074-accc-91e205435cc8",
+          "doc_count": 1
+        },
+        {
+          "key": "4bec11d1-f8c3-43a7-9e70-ee0256fcedaf",
+          "doc_count": 1
+        },
+        {
+          "key": "518518b7-9e85-42ea-b419-2d23a3ef546a",
+          "doc_count": 1
+        },
+        {
+          "key": "5d7869be-8526-43d8-af53-f16a15ebadb5",
+          "doc_count": 1
+        },
+        {
+          "key": "61a1c0ce-8327-4e2a-9766-449751a49b7a",
+          "doc_count": 1
+        },
+        {
+          "key": "7b0809fb-fd62-4733-8f40-74ceb04cbcac",
+          "doc_count": 1
+        },
+        {
+          "key": "8445ab25-ff89-44b0-90f8-bf0790f50afc",
+          "doc_count": 1
+        },
+        {
+          "key": "85e930bf-6e90-4700-85d1-4c3330efbafb",
+          "doc_count": 1
+        },
+        {
+          "key": "8a54c5fa-2900-4859-a2d6-1b7faedafac4",
+          "doc_count": 1
+        },
+        {
+          "key": "8f3b62fb-56ec-49e8-9f8f-bb257348291f",
+          "doc_count": 1
+        },
+        {
+          "key": "9c5fea92-a28b-4b6e-94b5-9c939f7369a2",
+          "doc_count": 1
+        },
+        {
+          "key": "9ff03c57-ba5a-4127-9439-4bf3e838c4df",
+          "doc_count": 1
+        },
+        {
+          "key": "b26fa674-6300-4ea0-a8e3-fc0ce32b5226",
+          "doc_count": 1
+        },
+        {
+          "key": "b688c17c-3761-4ccd-a42f-88219f5fcff4",
+          "doc_count": 1
+        },
+        {
+          "key": "c5916431-004f-465a-a505-589e2de29c8b",
+          "doc_count": 1
+        },
+        {
+          "key": "df22987f-d20d-41db-b8eb-8b5f5fca6df0",
+          "doc_count": 1
+        },
+        {
+          "key": "e1c7bc41-50a4-4723-b8b3-f970844ffb65",
+          "doc_count": 1
+        },
+        {
+          "key": "f062cb7d-c03e-4762-b1c4-49118fee1a56",
+          "doc_count": 1
+        },
+        {
+          "key": "fc628e53-5fdf-4436-9782-bf637d812b48",
+          "doc_count": 1
+        },
+        {
+          "key": "fdf7bb59-aad2-4f10-879f-6c0e7d3baa64",
+          "doc_count": 1
+        }
+      ]
+    },
+    "max_dm": {
+      "value": 1674654616151,
+      "value_as_string": "2023-01-25T13:50:16.151Z"
+    }
+  }
+}

--- a/src/searchShim.js
+++ b/src/searchShim.js
@@ -48,18 +48,24 @@ export default async function searchShim(index, type, op, query, statsInfo) {
    * Otherwise, a 300-field search request can result in a ~11000-character
    * URL, which might not be transmittable.
    */
-  if(query._source) {
-    var source_object = false;
-    if(query._source.exclude) {
-      options.body["_sourceExclude"] = query._source.exclude;
-      source_object = true;
-    }
-    if(query._source.include) {
-      options.body["_sourceInclude"] = query._source.include;
-      source_object = true;
-    }
+  if (query._source) {
+    let source_object = {};
 
-    if(!source_object) { options.body["_source"] = query._source; }
+    // Directly assign exclude/include to the _source object if they exist
+    if (query._source.exclude || query._source.include) {
+      source_object['_source'] = {};
+      if (query._source.exclude) {
+        source_object['_source'].exclude = query._source.exclude;
+      }
+      if (query._source.include) {
+        source_object['_source'].include = query._source.include;
+      }
+      // Merge the constructed source_object with options.body
+      options.body = { ...options.body, ...source_object };
+    } else {
+      // If there's no exclude or include, directly assign _source
+      options.body["_source"] = query._source;
+    }
   }
 
   if(query.sort) {


### PR DESCRIPTION
Fixes 500 errors due to incorrect include/exclude keys. 
Generate new mocks for Travis CI. 